### PR TITLE
Add devcontainer environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 			"installZsh": true,
 			"upgradePackages": true
 		},
+		"ghcr.io/devcontainers/features/docker-in-docker": {},
 		"ghcr.io/audacioustux/devcontainers/bun": {}
 	},
 	"customizations": {


### PR DESCRIPTION
Creates a new devcontainer environment that makes it easy to create new development environments with all of the required tooling / plugins installed to make development / contributions easy.