### PR TITLE
fix: allow empty .env file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 ./node_modules/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN bun run build
 # Remove development dependencies
 RUN bun install --production --frozen-lockfile
 
+# Add empty .env file so it can be parsed correctly.
+RUN touch .env
+
 # Final stage for app image
 FROM base
 

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -27,17 +27,20 @@ declare global {
 
 export function initEnvs() {
   const result = dotenv.config()
-  const parsed = schema.safeParse(result.parsed)
+  if (result.error !== undefined) {
+    throw new Error("Could not get configuration file: " + result.error.message);
+  }
 
+  for (const key in result.parsed) {
+    if (Object.prototype.hasOwnProperty.call(result.parsed, key)) {
+      process.env[key] = result.parsed[key]
+    }
+  }
+
+  const parsed = schema.safeParse(process.env)
   if (parsed.success === false) {
     console.error('Invalid environment variables:', parsed.error.flatten().fieldErrors)
     throw new Error('Invalid environment variables.')
-  } else {
-    for (const key in result.parsed) {
-      if (Object.prototype.hasOwnProperty.call(result.parsed, key)) {
-        process.env[key] = result.parsed[key]
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Adjusts the environment variable validation to allow the `.env` file to be empty so env variables can be loaded from the environment instead of a file on disk. This is required to deploy the application in a kubernetes environment. This also adds an empty `.env` file to the resulting image so it won't error that the file can't be found.