### PR TITLE
feat: add kustomize deployment manifests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
       "upgradePackages": true
     },
     "ghcr.io/devcontainers/features/docker-in-docker": {},
-    "ghcr.io/audacioustux/devcontainers/bun": {}
+    "ghcr.io/audacioustux/devcontainers/bun": {},
+    "ghcr.io/audacioustux/devcontainers/kustomize": {},
   },
   "customizations": {
     "vscode": {
@@ -22,7 +23,8 @@
         "task.vscode-task",
         "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
         "streetsidesoftware.code-spell-checker",
-        "github.vscode-github-actions"
+        "github.vscode-github-actions",
+        "ms-kubernetes-tools.vscode-kubernetes-tools"
       ],
       "settings": {
         "remote.portsAttributes": {

--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloud-portal
+    app.kubernetes.io/name: cloud-portal
+    app.kubernetes.io/version: 1.0.0
+  name: cloud-portal
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: frontend
+      app.kubernetes.io/instance: cloud-portal
+      app.kubernetes.io/name: cloud-portal
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/instance: cloud-portal
+        app.kubernetes.io/name: cloud-portal
+    spec:
+      containers:
+        - name: cloud-portal
+          image: ghcr.io/datum-cloud/cloud-portal:latest
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 3000
+            name: http
+            protocol: TCP
+          env:
+            - name: API_URL
+              value: https://api.datum.net
+            - name: APP_URL
+              value: https://cloud.datum.net
+          envFrom:
+           - secretRef:
+               name: cloud-portal
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              path: /
+              port: 3000
+              scheme: HTTP
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              path: /
+              port: 3000
+              scheme: HTTP
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/config/base/http-route.yaml
+++ b/config/base/http-route.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: cloud-portal
+spec:
+  parentRefs:
+    # This should be overridden at the environment level if needed to configure
+    # which gateway should be used to expose the portal outside of the cluster.
+    - name: external
+      namespace: gateway-system
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: cloud-portal
+          kind: Service
+          group: ""
+          port: 3000

--- a/config/base/service.yaml
+++ b/config/base/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: cloud-portal
+    app.kubernetes.io/name: cloud-portal
+    app.kubernetes.io/version: 1.0.0
+  name: cloud-portal
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/instance: cloud-portal
+    app.kubernetes.io/name: cloud-portal
+  sessionAffinity: None
+  type: ClusterIP

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+  - base/deployment.yaml
+  - base/service.yaml
+  - base/http-route.yaml
+secretGenerator:
+  # By default we load the secrets from the filesystem. This is expected to be
+  # overridden in a real environment to inject the actual secrets.
+  - name: cloud-portal
+    envs:
+      - .env


### PR DESCRIPTION
Introduces a new [kustomize](https://kustomize.io) program that can be used to deploy the cloud portal to a kubernetes environment. This will be used by our fluxcd pipeline to deploy the cloud portal to our environments.

I'll update the deployment docs in the repo once we've formally adopted fluxcd & kustomize for managing the deployment.