### PR TITLE
fix GitHub Actions for release event

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,35 +11,12 @@ on:
 jobs:
   check-files:
     runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.filter.outputs.run_ci }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: filter
-        run: |
-          git fetch --no-tags --depth=1 origin ${{ github.event.before }}
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
-
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-
-          # Filter out only Markdown files and infra directory changes
-          NON_IGNORED_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '\.md$|^docs/' || true)
-
-          if [[ -n "$NON_IGNORED_CHANGES" ]]; then
-            echo "run_ci=true" >> $GITHUB_ENV
-            echo "run_ci=true" >> $GITHUB_OUTPUT
-          else
-            echo "run_ci=false" >> $GITHUB_ENV
-            echo "run_ci=false" >> $GITHUB_OUTPUT
-          fi
   code-quality:
     runs-on: ubuntu-latest
     needs: check-files
-    if: needs.check-files.outputs.should_run == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,31 +12,9 @@ on:
 jobs:
   check-files:
     runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.filter.outputs.run_ci }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: filter
-        run: |
-          git fetch --no-tags --depth=1 origin ${{ github.event.before }}
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
-
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-
-          # Filter out only Markdown files and infra directory changes
-          NON_IGNORED_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '\.md$|^docs/' || true)
-
-          if [[ -n "$NON_IGNORED_CHANGES" ]]; then
-            echo "run_ci=true" >> $GITHUB_ENV
-            echo "run_ci=true" >> $GITHUB_OUTPUT
-          else
-            echo "run_ci=false" >> $GITHUB_ENV
-            echo "run_ci=false" >> $GITHUB_OUTPUT
-          fi
   build-and-push:
     permissions:
       contents: read
@@ -45,7 +23,6 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: check-files
-    if: needs.check-files.outputs.should_run == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,36 +12,13 @@ on:
 jobs:
   check-files:
     runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.filter.outputs.run_ci }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: filter
-        run: |
-          git fetch --no-tags --depth=1 origin ${{ github.event.before }}
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
-
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-
-          # Filter out only Markdown files and infra directory changes
-          NON_IGNORED_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '\.md$|^docs/' || true)
-
-          if [[ -n "$NON_IGNORED_CHANGES" ]]; then
-            echo "run_ci=true" >> $GITHUB_ENV
-            echo "run_ci=true" >> $GITHUB_OUTPUT
-          else
-            echo "run_ci=false" >> $GITHUB_ENV
-            echo "run_ci=false" >> $GITHUB_OUTPUT
-          fi
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest
     needs: check-files
-    if: needs.check-files.outputs.should_run == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request removes the docs validation filter to simplify these actions. I encountered an issue when trying to [release a new portal](https://github.com/datum-cloud/cloud-portal/actions/runs/13490860629) version - the build-and-push step didn't run due to how the filter works. However, fixing it would make that script too complex, and I believe we might run into similar issue again soon. 

if we run into github actions quoting issues for updating docs, we can investigate a better alternative.