### PR TITLE
chore: log which otlp endpoint is configured

### DIFF
--- a/otel.ts
+++ b/otel.ts
@@ -41,6 +41,7 @@ export function startOpenTelemetry() {
   try {
     sdk?.start()
     console.log('OpenTelemetry initialized successfully')
+    console.log('OTEL_EXPORTER_OTLP_ENDPOINT:', process.env.OTEL_EXPORTER_OTLP_ENDPOINT)
   } catch (error) {
     console.error('Error initializing OpenTelemetry:', error)
     if (error instanceof Error) {


### PR DESCRIPTION
Want to confirm that the correct endpoint is being configured with the OTEL exporter. 