### PR TITLE
Add CHANGELOG.md to store release history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Change Log
+
+<!-- CHANGELOG:INSERT_HERE -->
+
+## [v0.1.16] 2025-04-23
+
+### Changes
+
+**Features and Improvements**
+
+- :eyes: Added the ability to view secrets.
+- :key: Users can now manage secrets within the Cloud Portal.
+- :chart_with_upwards_trend: Implemented Fathom analytics to better understand user behavior.
+- :bulb: Improved field documentation with helpful tooltips, providing more context within the UI.
+- :rocket: OpenTelemetry integration is complete, including:
+  - Addition of OpenTelemetry for enhanced tracing.
+  - Express traces are now included.
+  - Moving to Otel GRPC for improved communication.
+  - Ensuring the correct OpenTelemetry endpoint is logged for verification.
+- :art: Optimized login images for faster loading.
+
+**Bug Fixes**
+
+- :lock: Fixed a bug in CSRF handling and improved the display of error messages.
+- :whale: Resolved issues with ELKJS during Docker builds.
+- :x: Reverted the Pyroscope integration due to incompatibility with the Bun runtime. We'll explore alternative solutions in the future.
+- :recycle: Addressed an issue where the workload Reactflow was returning null
+- :warning: The portal will now show users when a workload is being deleted.
+
+**Chores**
+
+- :arrows_counterclockwise: Changed the export policy form to "stepper" mode and added a view for export policies.
+- :arrow_up: Updated the prom/prometheus Docker tag to v3.3.0.


### PR DESCRIPTION
This PR adds a CHANGELOG.md file to formalize how we track and preserve release details over time.

Why
* We already have automation in place that generates release notes and posts them to Slack.
* This changelog provides a persistent, version-controlled history of those releases, ensuring important changes aren’t lost or siloed in ephemeral channels.
* A <!-- CHANGELOG:INSERT_HERE --> marker is included to enable automated prepending of new releases via workflows (e.g., n8n), keeping the latest changes always at the top.

Benefits
* Central source of truth for feature additions, fixes, and improvements.
* Complements existing Slack notifications with long-term visibility.
* Enables traceability, easier onboarding, and changelog-based automation (e.g., release pages, docs updates).
