### PR TITLE
feat: manage env variables for workload sandbox

### DIFF
--- a/app/components/select-configmap/select-configmap.tsx
+++ b/app/components/select-configmap/select-configmap.tsx
@@ -1,0 +1,158 @@
+import { Option } from '@/components/select-autocomplete/select-autocomplete.types'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { IConfigMapControlResponse } from '@/resources/interfaces/config-map.interface'
+import { ROUTE_PATH as CONFIGS_LIST_ROUTE_PATH } from '@/routes/api+/config+/config-maps+/list'
+import { cn } from '@/utils/misc'
+import { CheckIcon, ChevronDown, Loader2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { useFetcher } from 'react-router'
+
+export const SelectConfigMap = ({
+  projectId,
+  defaultValue,
+  className,
+  onValueChange,
+  defaultOptions,
+  exceptItems,
+  name,
+  id,
+}: {
+  projectId?: string
+  defaultValue?: string
+  className?: string
+  onValueChange: (value?: Option) => void
+  defaultOptions?: Option[]
+  exceptItems?: string[]
+  name?: string
+  id?: string
+}) => {
+  const fetcher = useFetcher({ key: 'select-configmap' })
+
+  const [open, setOpen] = useState(false)
+
+  const [value, setValue] = useState(defaultValue)
+  const [options, setOptions] = useState<Option[]>(defaultOptions ?? [])
+
+  const selectedValue = useMemo(() => {
+    if (!value) return undefined
+    return options.find((option) => option.value === value)
+  }, [value, options])
+
+  const fetchOptions = async () => {
+    fetcher.load(`${CONFIGS_LIST_ROUTE_PATH}?projectId=${projectId}`)
+  }
+
+  useEffect(() => {
+    if (typeof defaultOptions === 'undefined') {
+      fetchOptions()
+    } else {
+      setOptions(defaultOptions)
+    }
+  }, [projectId, defaultOptions])
+
+  useEffect(() => {
+    if (defaultValue) {
+      setValue(defaultValue)
+    }
+  }, [defaultValue])
+
+  useEffect(() => {
+    if (fetcher.data && fetcher.state === 'idle') {
+      const opt = (fetcher.data ?? []).map((configMap: IConfigMapControlResponse) => ({
+        value: configMap.name,
+        label: configMap.name,
+        ...configMap,
+      }))
+
+      setOptions(opt)
+    }
+  }, [fetcher.data, fetcher.state])
+
+  useEffect(() => {
+    if (selectedValue) {
+      onValueChange(selectedValue)
+    }
+  }, [selectedValue])
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-full justify-between">
+            {selectedValue ? selectedValue?.label : 'Select a Config Map'}
+            <ChevronDown className="size-4 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className={cn('popover-content-width-full min-w-[300px] p-0', className)}
+          align="center"
+          onEscapeKeyDown={() => setOpen(false)}>
+          <Command>
+            <CommandList>
+              <CommandEmpty>No results found.</CommandEmpty>
+              {fetcher.state === 'loading' && (
+                <CommandItem disabled>
+                  <Loader2 className="size-4 animate-spin" />
+                  <span>Loading config maps...</span>
+                </CommandItem>
+              )}
+              {options.length > 0 && (
+                <CommandGroup className="max-h-[250px] overflow-y-auto">
+                  {options.map((option) => {
+                    const isSelected = selectedValue?.value === option.value
+                    const isDisabled =
+                      option.value !== value && exceptItems?.includes(option.value)
+                    return (
+                      <CommandItem
+                        value={option.value}
+                        key={option.value}
+                        onSelect={() => {
+                          setValue(option.value)
+                          setOpen(false)
+                        }}
+                        disabled={isDisabled}
+                        className="cursor-pointer justify-between">
+                        <span>{option.label}</span>
+                        {isSelected && <CheckIcon className="text-primary size-4" />}
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+              )}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {/* Hidden input for form submission */}
+      <select
+        aria-hidden={true}
+        multiple={false}
+        name={name}
+        id={id}
+        value={selectedValue?.value ?? ''}
+        defaultValue={undefined}
+        className="absolute top-0 left-0 h-0 w-0"
+        onChange={() => undefined}>
+        <option value=""></option>
+        {options.map((option, idx) => (
+          <option key={`${option.value}-${idx}`} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </>
+  )
+}

--- a/app/constants/options.ts
+++ b/app/constants/options.ts
@@ -8,7 +8,11 @@ import {
   LocationProvider,
 } from '@/resources/interfaces/location.interface'
 import { SecretType } from '@/resources/interfaces/secret.interface'
-import { RuntimeType, StorageType } from '@/resources/interfaces/workload.interface'
+import {
+  ContainerEnvType,
+  RuntimeType,
+  StorageType,
+} from '@/resources/interfaces/workload.interface'
 
 export const LOCATION_PROVIDERS = {
   [LocationProvider.GCP]: {
@@ -53,6 +57,21 @@ export const STORAGE_TYPES = {
   [StorageType.BOOT]: {
     label: 'Boot volume',
     description: 'A boot volume is a volume that is used to store the boot image.',
+  },
+}
+
+export const ENV_TYPES = {
+  [ContainerEnvType.TEXT]: {
+    label: 'Text',
+    description: 'A text is a value that is used to store a text.',
+  },
+  [ContainerEnvType.SECRET]: {
+    label: 'Secret',
+    description: 'A secret is a value that is used to store a secret.',
+  },
+  [ContainerEnvType.CONFIG_MAP]: {
+    label: 'Config Map',
+    description: 'A config map is a value that is used to store a config map.',
   },
 }
 

--- a/app/features/workload/form/runtime/container-field.tsx
+++ b/app/features/workload/form/runtime/container-field.tsx
@@ -1,8 +1,11 @@
+import { EnvsForm } from './envs-form'
 import { PortsForm } from './ports-form'
 import { Field } from '@/components/field/field'
+import { FieldLabel } from '@/components/field/field-label'
 import { Input } from '@/components/ui/input'
 import {
   RuntimeContainerSchema,
+  RuntimeEnvSchema,
   RuntimePortSchema,
 } from '@/resources/schemas/workload.schema'
 import { getInputProps, useForm, useInputControl } from '@conform-to/react'
@@ -12,10 +15,12 @@ import { useHydrated } from 'remix-utils/use-hydrated'
 export const ContainerField = ({
   isEdit,
   defaultValues,
+  projectId,
   fields,
 }: {
   isEdit: boolean
   defaultValues?: RuntimeContainerSchema
+  projectId?: string
   fields: ReturnType<typeof useForm<RuntimeContainerSchema>>[1]
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -44,8 +49,8 @@ export const ContainerField = ({
   }, [isHydrated])
 
   return (
-    <div className="flex w-full flex-col gap-2">
-      <div className="relative flex w-full items-start gap-4">
+    <div className="flex w-full flex-col gap-4">
+      <div className="relative flex w-full items-start gap-2">
         <Field isRequired label="Name" errors={fields.name.errors} className="w-full">
           <Input
             {...getInputProps(fields.name, { type: 'text' })}
@@ -73,7 +78,7 @@ export const ContainerField = ({
       </div>
 
       <div className="flex w-full flex-col gap-2">
-        <h3 className="text-sm font-medium">Ports</h3>
+        <FieldLabel label="Ports" />
         <PortsForm
           fields={
             fields as unknown as ReturnType<
@@ -82,6 +87,20 @@ export const ContainerField = ({
           }
           defaultValues={defaultValues?.ports}
           isEdit={isEdit}
+        />
+      </div>
+
+      <div className="flex w-full flex-col gap-2">
+        <FieldLabel label="Environment Variables" />
+        <EnvsForm
+          fields={
+            fields as unknown as ReturnType<
+              typeof useForm<{ envs: RuntimeEnvSchema[] }>
+            >[1]
+          }
+          defaultValues={defaultValues?.envs}
+          isEdit={isEdit}
+          projectId={projectId}
         />
       </div>
     </div>

--- a/app/features/workload/form/runtime/container-form.tsx
+++ b/app/features/workload/form/runtime/container-form.tsx
@@ -13,10 +13,12 @@ export const ContainerForm = ({
   isEdit,
   fields,
   defaultValues,
+  projectId,
 }: {
   isEdit: boolean
   fields: ReturnType<typeof useForm<RuntimeSchema>>[1]
   defaultValues?: RuntimeContainerSchema[]
+  projectId?: string
 }) => {
   const form = useFormMetadata('workload-form')
   const containers = fields.containers.getFieldList()
@@ -42,6 +44,7 @@ export const ContainerForm = ({
               <ContainerField
                 isEdit={isEdit}
                 defaultValues={defaultValues?.[index]}
+                projectId={projectId}
                 fields={
                   containerFields as unknown as ReturnType<
                     typeof useForm<RuntimeContainerSchema>

--- a/app/features/workload/form/runtime/env-field.tsx
+++ b/app/features/workload/form/runtime/env-field.tsx
@@ -1,0 +1,224 @@
+import { Field } from '@/components/field/field'
+import { SelectConfigMap } from '@/components/select-configmap/select-configmap'
+import { SelectSecret } from '@/components/select-secret/select-secret'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { ENV_TYPES } from '@/constants/options'
+import { ContainerEnvType } from '@/resources/interfaces/workload.interface'
+import { RuntimeEnvSchema } from '@/resources/schemas/workload.schema'
+import { cn } from '@/utils/misc'
+import {
+  getInputProps,
+  getSelectProps,
+  useForm,
+  useInputControl,
+} from '@conform-to/react'
+import { useEffect, useRef, useState } from 'react'
+import { useHydrated } from 'remix-utils/use-hydrated'
+
+export const EnvField = ({
+  isEdit,
+  defaultValues,
+  projectId,
+  fields,
+}: {
+  isEdit?: boolean
+  defaultValues?: RuntimeEnvSchema
+  projectId?: string
+  fields: ReturnType<typeof useForm<RuntimeEnvSchema>>[1]
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const isHydrated = useHydrated()
+
+  const nameControl = useInputControl(fields.name)
+  const typeControl = useInputControl(fields.type)
+
+  // For text
+  const valueControl = useInputControl(fields.value)
+
+  // For secret and config map
+  const [keyOptions, setKeyOptions] = useState<string[]>([])
+  const refNameControl = useInputControl(fields.refName)
+  const keyControl = useInputControl(fields.key)
+
+  useEffect(() => {
+    if (defaultValues) {
+      // Only set values if they exist in defaultValues and current fields are empty
+      if (defaultValues.name && fields.name.value === '') {
+        nameControl.change(defaultValues?.name)
+      }
+
+      if (defaultValues.type && !fields.type.value) {
+        typeControl.change(defaultValues?.type)
+
+        if (
+          defaultValues.type === ContainerEnvType.TEXT &&
+          defaultValues.value &&
+          fields.value.value === ''
+        ) {
+          valueControl.change(defaultValues?.value)
+        }
+      }
+    }
+  }, [
+    defaultValues,
+    typeControl,
+    nameControl,
+    valueControl,
+    fields.name.value,
+    fields.type.value,
+    fields.value.value,
+  ])
+
+  useEffect(() => {
+    // Focus the input when the form is hydrated
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    isHydrated && inputRef.current?.focus()
+  }, [isHydrated])
+
+  return (
+    <div className="relative flex w-full flex-col items-start gap-4">
+      <div className="flex w-full gap-2">
+        <Field isRequired label="Name" errors={fields.name.errors} className="w-2/3">
+          <Input
+            {...getInputProps(fields.name, { type: 'text' })}
+            ref={isEdit ? undefined : inputRef}
+            key={fields.name.id}
+            placeholder="e.g. ENV_VAR_NAME"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              const value = (e.target as HTMLInputElement).value
+              nameControl.change(value)
+            }}
+          />
+        </Field>
+        <Field
+          isRequired
+          label="Value Source"
+          errors={fields.type.errors}
+          className="w-1/3">
+          <Select
+            {...getSelectProps(fields.type, { value: false })}
+            key={fields.type.id}
+            value={typeControl.value}
+            defaultValue={undefined}
+            onValueChange={(value) => {
+              typeControl.change(value)
+
+              valueControl.change(undefined)
+              refNameControl.change(undefined)
+              keyControl.change(undefined)
+            }}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select a Source" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.keys(ENV_TYPES).map((type) => (
+                <SelectItem key={type} value={type}>
+                  {ENV_TYPES[type as keyof typeof ENV_TYPES].label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+      </div>
+
+      <div className={cn('flex w-full gap-2', { hidden: !fields.type.value })}>
+        <Field
+          isRequired
+          label="Value"
+          errors={fields.value.errors}
+          className={cn('w-1/2', {
+            hidden: fields.type.value !== ContainerEnvType.TEXT,
+          })}>
+          <Input
+            {...getInputProps(fields.value, { type: 'text' })}
+            key={fields.value.id}
+            placeholder="e.g. my-value"
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              const value = (e.target as HTMLInputElement).value
+              valueControl.change(value)
+            }}
+          />
+        </Field>
+
+        <Field
+          isRequired
+          label={fields.type.value === ContainerEnvType.SECRET ? 'Secret' : 'Config Map'}
+          errors={fields.refName.errors}
+          className={cn('w-1/2', {
+            hidden: fields.type.value === ContainerEnvType.TEXT,
+          })}>
+          {fields.type.value === ContainerEnvType.SECRET ? (
+            <SelectSecret
+              {...getSelectProps(fields.refName, { value: false })}
+              name={fields.refName.name}
+              id={fields.refName.id}
+              key={fields.refName.id}
+              defaultValue={refNameControl.value}
+              projectId={projectId}
+              onValueChange={(value) => {
+                if (value?.value !== refNameControl.value) {
+                  keyControl.change(undefined)
+                }
+
+                refNameControl.change(value?.value)
+                setKeyOptions(value?.data ?? [])
+              }}
+            />
+          ) : (
+            <SelectConfigMap
+              {...getSelectProps(fields.refName, { value: false })}
+              name={fields.refName.name}
+              id={fields.refName.id}
+              key={fields.refName.id}
+              defaultValue={refNameControl.value}
+              projectId={projectId}
+              onValueChange={(value) => {
+                if (value?.value !== refNameControl.value) {
+                  keyControl.change(undefined)
+                }
+
+                refNameControl.change(value?.value)
+                setKeyOptions(Object.keys(value?.data ?? {}))
+              }}
+            />
+          )}
+        </Field>
+
+        <Field
+          isRequired
+          label="Key"
+          errors={fields.key.errors}
+          className={cn('w-1/2', {
+            hidden: fields.type.value === ContainerEnvType.TEXT,
+          })}>
+          <Select
+            {...getSelectProps(fields.key, { value: false })}
+            key={fields.key.id}
+            value={keyControl.value}
+            defaultValue={defaultValues?.key}
+            onValueChange={(value) => {
+              keyControl.change(value)
+            }}>
+            <SelectTrigger disabled={!keyOptions.length}>
+              <SelectValue placeholder="Select a Key" />
+            </SelectTrigger>
+            <SelectContent>
+              {keyOptions.map((key) => (
+                <SelectItem key={key} value={key}>
+                  {key}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+      </div>
+    </div>
+  )
+}

--- a/app/features/workload/form/runtime/envs-form.tsx
+++ b/app/features/workload/form/runtime/envs-form.tsx
@@ -1,0 +1,87 @@
+import { EnvField } from './env-field'
+import { Button } from '@/components/ui/button'
+import { RuntimeEnvSchema } from '@/resources/schemas/workload.schema'
+import { cn } from '@/utils/misc'
+import { useForm, useFormMetadata } from '@conform-to/react'
+import { PlusIcon, TrashIcon } from 'lucide-react'
+import { useEffect } from 'react'
+
+export const EnvsForm = ({
+  fields,
+  defaultValues,
+  isEdit = false,
+  projectId,
+}: {
+  fields: ReturnType<typeof useForm<{ envs: RuntimeEnvSchema[] }>>[1]
+  defaultValues?: RuntimeEnvSchema[]
+  isEdit?: boolean
+  projectId?: string
+}) => {
+  const form = useFormMetadata('workload-form')
+  const envs = fields.envs?.getFieldList()
+
+  useEffect(() => {
+    if (defaultValues) {
+      form.update({
+        name: fields.envs.name,
+        value: defaultValues as RuntimeEnvSchema[],
+      })
+    }
+  }, [defaultValues])
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      {envs?.length > 0 && (
+        <div className="space-y-4">
+          {envs?.map((env, index) => {
+            const envFields = env.getFieldset()
+            return (
+              <div
+                className="relative flex items-center gap-2 rounded-md border p-4"
+                key={env.key}>
+                <EnvField
+                  isEdit={isEdit}
+                  defaultValues={defaultValues?.[index]}
+                  projectId={projectId}
+                  fields={envFields as ReturnType<typeof useForm<RuntimeEnvSchema>>[1]}
+                />
+                {envs.length > 0 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className={cn(
+                      'text-destructive relative w-fit',
+                      (envFields.name.errors ?? []).length > 0 ||
+                        (envFields.type.errors ?? []).length > 0 ||
+                        (envFields.value.errors ?? []).length > 0 ||
+                        (envFields.key.errors ?? []).length > 0
+                        ? '-top-1'
+                        : 'top-2.5',
+                    )}
+                    onClick={() => form.remove({ name: fields.envs.name, index })}>
+                    <TrashIcon className="size-4" />
+                  </Button>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-fit"
+        onClick={() =>
+          form.insert({
+            name: fields.envs.name,
+            defaultValue: { name: '', type: undefined, value: '', key: undefined },
+          })
+        }>
+        <PlusIcon className="size-4" />
+        Add Environment Variable
+      </Button>
+    </div>
+  )
+}

--- a/app/features/workload/form/runtime/runtime-form.tsx
+++ b/app/features/workload/form/runtime/runtime-form.tsx
@@ -1,6 +1,7 @@
 import { ContainerForm } from './container-form'
 import { VirtualMachineForm } from './virtual-machine-form'
 import { Field } from '@/components/field/field'
+import { FieldLabel } from '@/components/field/field-label'
 import { List, ListItem } from '@/components/list/list'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -30,10 +31,12 @@ export const RuntimeForm = ({
   fields,
   defaultValues,
   isEdit = false,
+  projectId,
 }: {
   fields: ReturnType<typeof useForm<RuntimeSchema>>[1]
   defaultValues?: RuntimeSchema
   isEdit?: boolean
+  projectId?: string
 }) => {
   const form = useFormMetadata('workload-form')
   const instanceTypeControl = useInputControl(fields.instanceType)
@@ -117,7 +120,7 @@ export const RuntimeForm = ({
           key={fields.runtimeType.id}
           value={runtimeTypeControl.value?.toString()}
           defaultValue={defaultValues?.runtimeType}>
-          <SelectTrigger disabled>
+          <SelectTrigger>
             <SelectValue placeholder="Select a type" />
           </SelectTrigger>
           <SelectContent>
@@ -141,8 +144,9 @@ export const RuntimeForm = ({
         />
       ) : fields.runtimeType.value === RuntimeType.CONTAINER ? (
         <div className="flex w-full flex-col gap-2">
-          <h3 className="text-sm font-medium">Containers</h3>
+          <FieldLabel label="Containers" />
           <ContainerForm
+            projectId={projectId}
             isEdit={isEdit}
             fields={fields as unknown as ReturnType<typeof useForm<RuntimeSchema>>[1]}
             defaultValues={defaultValues?.containers as RuntimeContainerSchema[]}

--- a/app/features/workload/form/stepper-form.tsx
+++ b/app/features/workload/form/stepper-form.tsx
@@ -318,6 +318,7 @@ export const WorkloadStepper = ({
                           ),
                           runtime: () => (
                             <RuntimeForm
+                              projectId={projectId}
                               defaultValues={
                                 stepper.getMetadata('runtime') as RuntimeSchema
                               }

--- a/app/features/workload/form/update-form.tsx
+++ b/app/features/workload/form/update-form.tsx
@@ -259,6 +259,7 @@ export const WorkloadUpdateForm = ({
                       {section.id === 'runtime' && (
                         <RuntimeForm
                           isEdit
+                          projectId={projectId}
                           defaultValues={formattedValues?.runtime}
                           fields={
                             fields as unknown as ReturnType<

--- a/app/resources/interfaces/workload.interface.ts
+++ b/app/resources/interfaces/workload.interface.ts
@@ -62,3 +62,9 @@ export enum PortProtocol {
   UDP = 'UDP',
   SCTP = 'SCTP',
 }
+
+export enum ContainerEnvType {
+  TEXT = 'text',
+  SECRET = 'secret',
+  CONFIG_MAP = 'config-map',
+}

--- a/app/routes/api+/config+/config-maps+/list.ts
+++ b/app/routes/api+/config+/config-maps+/list.ts
@@ -1,0 +1,43 @@
+import { authMiddleware } from '@/modules/middleware/authMiddleware'
+import { withMiddleware } from '@/modules/middleware/middleware'
+import { createConfigMapsControl } from '@/resources/control-plane/config-maps.control'
+import { CustomError } from '@/utils/errorHandle'
+import { Client } from '@hey-api/client-axios'
+import { AppLoadContext, data } from 'react-router'
+
+export const ROUTE_PATH = '/api/config/config-maps/list' as const
+
+export const loader = withMiddleware(async ({ request, context }) => {
+  const { controlPlaneClient, cache } = context as AppLoadContext
+  const configMapsControl = createConfigMapsControl(controlPlaneClient as Client)
+
+  const url = new URL(request.url)
+  const projectId = url.searchParams.get('projectId')
+  const noCache = false
+
+  if (!projectId) {
+    throw new CustomError('Project ID is required', 400)
+  }
+
+  const key = `config-maps:${projectId}`
+
+  // Try to get cached config maps if caching is enabled
+  const [isCached, cachedConfigMaps] = await Promise.all([
+    !noCache && cache.hasItem(key),
+    !noCache && cache.getItem(key),
+  ])
+
+  // Return cached config maps if available and caching is enabled
+  if (isCached && cachedConfigMaps) {
+    return data(cachedConfigMaps)
+  }
+
+  // Fetch fresh config maps from control plane
+  const configMaps = await configMapsControl.list(projectId)
+
+  // Cache the fresh config maps if caching is enabled
+  await cache.setItem(key, configMaps).catch((error) => {
+    console.error('Failed to cache config maps:', error)
+  })
+  return data(configMaps)
+}, authMiddleware)


### PR DESCRIPTION
This PR introduces the ability to manage environment variables for workload sandboxes. The following changes were made:

- Added new components and logic to support selecting ConfigMaps and managing environment variables for workloads.
- Updated schemas, interfaces, and helpers to support the new environment variable management features.
- Minor updates to existing workload form components to integrate the new env management logic.

Fixes #213 