### PR TITLE
bug: Remove strict 6-character minimum for resource and section names

### DIFF
--- a/app/resources/schemas/metadata.schema.ts
+++ b/app/resources/schemas/metadata.schema.ts
@@ -3,11 +3,11 @@ import { z } from 'zod'
 export const nameSchema = z.object({
   name: z
     .string({ required_error: 'Name is required.' })
-    .min(6, { message: 'Name must be at least 6 characters long.' })
-    .max(30, { message: 'Name must be less than 30 characters long.' })
-    .regex(/^[a-z][a-z0-9-]*[a-z0-9]$/, {
+    .min(1, { message: 'Name is required.' })
+    .max(63, { message: 'Name must be at most 63 characters long.' })
+    .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, {
       message:
-        'Name must be kebab-case, start with a letter, and end with a letter or number',
+        'Name must use lowercase letters, numbers, and hyphens only. Must start and end with a letter or number.',
     }),
 })
 

--- a/app/resources/schemas/project.schema.ts
+++ b/app/resources/schemas/project.schema.ts
@@ -1,5 +1,18 @@
-import { metadataSchema } from './metadata.schema'
 import { z } from 'zod'
+
+// Project metadata schema (without the generic name schema)
+export const projectMetadataSchema = z.object({
+  name: z
+    .string({ required_error: 'Name is required.' })
+    .min(6, { message: 'Name must be at least 6 characters long.' })
+    .max(30, { message: 'Name must be less than 30 characters long.' })
+    .regex(/^[a-z][a-z0-9-]*[a-z0-9]$/, {
+      message:
+        'Name must be kebab-case, start with a letter, and end with a letter or number',
+    }),
+  labels: z.array(z.string()).optional(),
+  annotations: z.array(z.string()).optional(),
+})
 
 export const newProjectSchema = z
   .object({
@@ -8,6 +21,6 @@ export const newProjectSchema = z
       .max(100, { message: 'Description must be less than 100 characters long.' }),
     orgEntityId: z.string({ required_error: 'Organization ID is required.' }),
   })
-  .and(metadataSchema)
+  .and(projectMetadataSchema)
 
 export type NewProjectSchema = z.infer<typeof newProjectSchema>


### PR DESCRIPTION
This PR relaxes the minimum length validation for resource and section names in the schema files. Now, not all resource or section names require a minimum length of 6 characters.

Fixes #321 