### PR TITLE
feat: add project display name update functionality

### DIFF
--- a/app/components/input-with-copy/input-with-copy.tsx
+++ b/app/components/input-with-copy/input-with-copy.tsx
@@ -38,6 +38,7 @@ export const InputWithCopy = ({
       containerClassName={cn('focus-within:ring-0', className)}
       trailing={
         <Button
+          type="button"
           variant="outline"
           size="sm"
           className={cn('h-7 w-fit gap-1 px-2 text-xs', buttonClassName)}

--- a/app/components/metadata/metadata-form.tsx
+++ b/app/components/metadata/metadata-form.tsx
@@ -9,11 +9,11 @@ import { useHydrated } from 'remix-utils/use-hydrated'
 
 export const MetadataForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   isEdit = false,
 }: {
   fields: ReturnType<typeof useForm<MetadataSchema>>[1]
-  defaultValues?: MetadataSchema
+  defaultValue?: MetadataSchema
   isEdit?: boolean
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -23,12 +23,12 @@ export const MetadataForm = ({
   const annotationsControl = useInputControl(fields.annotations)
 
   useEffect(() => {
-    if (defaultValues) {
-      nameControl.change(defaultValues.name)
-      labelsControl.change(defaultValues.labels)
-      annotationsControl.change(defaultValues.annotations)
+    if (defaultValue) {
+      nameControl.change(defaultValue.name)
+      labelsControl.change(defaultValue.labels)
+      annotationsControl.change(defaultValue.annotations)
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   // Focus the input when the form is hydrated
   useEffect(() => {

--- a/app/features/connect/endpoint-slice/endpoint/endpoint-field.tsx
+++ b/app/features/connect/endpoint-slice/endpoint/endpoint-field.tsx
@@ -11,21 +11,21 @@ import { useEffect } from 'react'
 
 export const EndpointField = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<EndpointSliceEndpointSchema>>[1]
-  defaultValues?: EndpointSliceEndpointSchema
+  defaultValue?: EndpointSliceEndpointSchema
 }) => {
   const addressesControl = useInputControl(fields.addresses)
   const conditionsControl = useInputControl(fields.conditions)
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.conditions && !fields.conditions.value) {
-        conditionsControl.change(defaultValues?.conditions)
+    if (defaultValue) {
+      if (defaultValue.conditions && !fields.conditions.value) {
+        conditionsControl.change(defaultValue?.conditions)
       }
     }
-  }, [defaultValues, conditionsControl, fields.conditions.value])
+  }, [defaultValue, conditionsControl, fields.conditions.value])
 
   return (
     <div className="relative flex w-full flex-col items-start gap-4">

--- a/app/features/connect/endpoint-slice/endpoint/endpoints-form.tsx
+++ b/app/features/connect/endpoint-slice/endpoint/endpoints-form.tsx
@@ -10,34 +10,34 @@ import { useForm, useFormMetadata } from '@conform-to/react'
 import { PlusIcon, TrashIcon } from 'lucide-react'
 import { useEffect } from 'react'
 
-const defaultValue: EndpointSliceEndpointSchema = {
+const defaultEndpointValue: EndpointSliceEndpointSchema = {
   addresses: [],
   conditions: ['ready', 'reachable', 'terminating'],
 }
 
 export const EndpointsForm = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<EndpointSliceSchema>>[1]
-  defaultValues?: EndpointSliceEndpointSchema[]
+  defaultValue?: EndpointSliceEndpointSchema[]
 }) => {
   const form = useFormMetadata('endpoint-slice-form')
   const endpointList = fields.endpoints.getFieldList()
 
   useEffect(() => {
-    if (defaultValues && defaultValues.length > 0) {
+    if (defaultValue && defaultValue.length > 0) {
       form.update({
         name: fields.endpoints.name,
-        value: defaultValues,
+        value: defaultValue,
       })
     } else if (endpointList.length === 0) {
       form.insert({
         name: fields.endpoints.name,
-        defaultValue: defaultValue,
+        defaultValue: defaultEndpointValue,
       })
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   return (
     <div className="flex flex-col gap-3">
@@ -56,7 +56,7 @@ export const EndpointsForm = ({
                     typeof useForm<EndpointSliceEndpointSchema>
                   >[1]
                 }
-                defaultValues={defaultValues?.[index]}
+                defaultValue={defaultValue?.[index]}
               />
 
               {endpointList.length > 1 && (
@@ -81,7 +81,7 @@ export const EndpointsForm = ({
         onClick={() =>
           form.insert({
             name: fields.endpoints.name,
-            defaultValue: defaultValue,
+            defaultValue: defaultEndpointValue,
           })
         }>
         <PlusIcon className="size-4" />

--- a/app/features/connect/endpoint-slice/form.tsx
+++ b/app/features/connect/endpoint-slice/form.tsx
@@ -134,7 +134,7 @@ export const EndpointSliceForm = ({
           <CardContent className="space-y-4">
             <MetadataForm
               fields={fields as unknown as ReturnType<typeof useForm<MetadataSchema>>[1]}
-              defaultValues={formattedValues as MetadataSchema}
+              defaultValue={formattedValues as MetadataSchema}
               isEdit={isEdit}
             />
             <Field
@@ -148,13 +148,13 @@ export const EndpointSliceForm = ({
               fields={
                 fields as unknown as ReturnType<typeof useForm<EndpointSliceSchema>>[1]
               }
-              defaultValues={formattedValues?.endpoints}
+              defaultValue={formattedValues?.endpoints}
             />
             <PortsForm
               fields={
                 fields as unknown as ReturnType<typeof useForm<EndpointSliceSchema>>[1]
               }
-              defaultValues={formattedValues?.ports}
+              defaultValue={formattedValues?.ports}
             />
           </CardContent>
           <CardFooter className="flex justify-between gap-2">

--- a/app/features/connect/endpoint-slice/port/port-field.tsx
+++ b/app/features/connect/endpoint-slice/port/port-field.tsx
@@ -22,26 +22,26 @@ import { useEffect } from 'react'
 
 export const PortField = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<EndpointSlicePortSchema>>[1]
-  defaultValues?: EndpointSlicePortSchema
+  defaultValue?: EndpointSlicePortSchema
 }) => {
   const nameControl = useInputControl(fields.name)
   const appProtocolControl = useInputControl(fields.appProtocol)
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.name && fields.name.value === '') {
-        nameControl.change(defaultValues?.name)
+    if (defaultValue) {
+      if (defaultValue.name && fields.name.value === '') {
+        nameControl.change(defaultValue?.name)
       }
 
-      if (defaultValues.appProtocol && !fields.appProtocol.value) {
-        appProtocolControl.change(defaultValues?.appProtocol)
+      if (defaultValue.appProtocol && !fields.appProtocol.value) {
+        appProtocolControl.change(defaultValue?.appProtocol)
       }
     }
   }, [
-    defaultValues,
+    defaultValue,
     nameControl,
     fields.name.value,
     appProtocolControl,
@@ -72,7 +72,7 @@ export const PortField = ({
             {...getSelectProps(fields.appProtocol)}
             key={fields.appProtocol.id}
             value={appProtocolControl.value}
-            defaultValue={defaultValues?.appProtocol}
+            defaultValue={defaultValue?.appProtocol}
             onValueChange={(value) => {
               appProtocolControl.change(value)
             }}>

--- a/app/features/connect/endpoint-slice/port/ports-form.tsx
+++ b/app/features/connect/endpoint-slice/port/ports-form.tsx
@@ -11,34 +11,34 @@ import { useForm, useFormMetadata } from '@conform-to/react'
 import { PlusIcon, TrashIcon } from 'lucide-react'
 import { useEffect } from 'react'
 
-const defaultValue: EndpointSlicePortSchema = {
+const defaultPortValue: EndpointSlicePortSchema = {
   name: '',
   appProtocol: EndpointSlicePortProtocol.HTTPS,
 }
 
 export const PortsForm = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<EndpointSliceSchema>>[1]
-  defaultValues?: EndpointSlicePortSchema[]
+  defaultValue?: EndpointSlicePortSchema[]
 }) => {
   const form = useFormMetadata('endpoint-slice-form')
   const portList = fields.ports.getFieldList()
 
   useEffect(() => {
-    if (defaultValues && defaultValues.length > 0) {
+    if (defaultValue && defaultValue.length > 0) {
       form.update({
         name: fields.ports.name,
-        value: defaultValues,
+        value: defaultValue,
       })
     } else if (portList.length === 0) {
       form.insert({
         name: fields.ports.name,
-        defaultValue: defaultValue,
+        defaultValue: defaultPortValue,
       })
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   return (
     <div className="flex flex-col gap-3">
@@ -57,7 +57,7 @@ export const PortsForm = ({
                     typeof useForm<EndpointSlicePortSchema>
                   >[1]
                 }
-                defaultValues={defaultValues?.[index]}
+                defaultValue={defaultValue?.[index]}
               />
               {portList.length > 1 && (
                 <Button
@@ -82,7 +82,7 @@ export const PortsForm = ({
         onClick={() =>
           form.insert({
             name: fields.ports.name,
-            defaultValue: defaultValue,
+            defaultValue: defaultPortValue,
           })
         }>
         <PlusIcon className="size-4" />

--- a/app/features/connect/gateway/form.tsx
+++ b/app/features/connect/gateway/form.tsx
@@ -172,14 +172,14 @@ export const GatewayForm = ({
           <CardContent className="space-y-4">
             <MetadataForm
               fields={fields as unknown as ReturnType<typeof useForm<MetadataSchema>>[1]}
-              defaultValues={formattedValues as MetadataSchema}
+              defaultValue={formattedValues as MetadataSchema}
               isEdit={isEdit}
             />
             <ListenersForm
               fields={
                 fields as unknown as ReturnType<typeof useForm<GatewayListenerSchema>>[1]
               }
-              defaultValues={{ listeners: formattedValues?.listeners ?? [] }}
+              defaultValue={{ listeners: formattedValues?.listeners ?? [] }}
             />
           </CardContent>
           <CardFooter className="flex justify-between gap-2">

--- a/app/features/connect/gateway/listener/listener-field.tsx
+++ b/app/features/connect/gateway/listener/listener-field.tsx
@@ -27,10 +27,10 @@ import { useEffect } from 'react'
 
 export const ListenerField = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<GatewayListenerFieldSchema>>[1]
-  defaultValues?: GatewayListenerFieldSchema
+  defaultValue?: GatewayListenerFieldSchema
 }) => {
   const nameControl = useInputControl(fields.name)
   const protocolControl = useInputControl(fields.protocol)
@@ -40,25 +40,25 @@ export const ListenerField = ({
   const tlsFieldset = fields.tlsConfiguration.getFieldset()
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.name && fields.name.value === '') {
-        nameControl.change(defaultValues?.name)
+    if (defaultValue) {
+      if (defaultValue.name && fields.name.value === '') {
+        nameControl.change(defaultValue?.name)
       }
 
-      if (defaultValues.protocol && !fields.protocol.value) {
-        protocolControl.change(defaultValues?.protocol)
+      if (defaultValue.protocol && !fields.protocol.value) {
+        protocolControl.change(defaultValue?.protocol)
       }
 
-      if (defaultValues.allowedRoutes && !fields.allowedRoutes.value) {
-        allowedRoutesControl.change(defaultValues?.allowedRoutes)
+      if (defaultValue.allowedRoutes && !fields.allowedRoutes.value) {
+        allowedRoutesControl.change(defaultValue?.allowedRoutes)
       }
 
-      /* if (defaultValues.matchLabels && !fields.matchLabels.value) {
-        matchLabelsControl.change(defaultValues?.matchLabels)
+      /* if (defaultValue.matchLabels && !fields.matchLabels.value) {
+        matchLabelsControl.change(defaultValue?.matchLabels)
       } */
     }
   }, [
-    defaultValues,
+    defaultValue,
     nameControl,
     fields.name.value,
     protocolControl,
@@ -95,7 +95,7 @@ export const ListenerField = ({
             {...getSelectProps(fields.allowedRoutes)}
             key={fields.allowedRoutes.id}
             value={fields.allowedRoutes.value}
-            defaultValue={defaultValues?.allowedRoutes}
+            defaultValue={defaultValue?.allowedRoutes}
             onValueChange={(value) => {
               allowedRoutesControl.change(value)
 
@@ -124,7 +124,7 @@ export const ListenerField = ({
             {...getSelectProps(fields.protocol)}
             key={fields.protocol.id}
             value={protocolControl.value}
-            defaultValue={defaultValues?.protocol}
+            defaultValue={defaultValue?.protocol}
             onValueChange={(value) => {
               protocolControl.change(value)
             }}>
@@ -162,7 +162,7 @@ export const ListenerField = ({
               fields={
                 tlsFieldset as unknown as ReturnType<typeof useForm<GatewayTlsSchema>>[1]
               }
-              defaultValues={defaultValues?.tlsConfiguration}
+              defaultValue={defaultValue?.tlsConfiguration}
             />
           </div>
         )}

--- a/app/features/connect/gateway/listener/listeners-form.tsx
+++ b/app/features/connect/gateway/listener/listeners-form.tsx
@@ -15,7 +15,8 @@ import { useForm, useFormMetadata } from '@conform-to/react'
 import { PlusIcon, TrashIcon } from 'lucide-react'
 import { useEffect, useMemo } from 'react'
 
-const defaultValue = {
+const defaultListenerValue: GatewayListenerFieldSchema = {
+  name: '',
   protocol: GatewayProtocol.HTTP,
   allowedRoutes: GatewayAllowedRoutes.SAME,
   tlsConfiguration: {
@@ -25,19 +26,19 @@ const defaultValue = {
 
 export const ListenersForm = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<GatewayListenerSchema>>[1]
-  defaultValues?: GatewayListenerSchema
+  defaultValue?: GatewayListenerSchema
 }) => {
   const form = useFormMetadata('gateway-form')
   const listenerList = fields.listeners.getFieldList()
 
   const values = useMemo(() => {
-    return defaultValues?.listeners
-      ? defaultValues.listeners
-      : ((defaultValues ?? []) as GatewayListenerFieldSchema[])
-  }, [defaultValues])
+    return defaultValue?.listeners
+      ? defaultValue.listeners
+      : ((defaultValue ?? []) as GatewayListenerFieldSchema[])
+  }, [defaultValue])
 
   useEffect(() => {
     if (values && values.length > 0) {
@@ -48,7 +49,7 @@ export const ListenersForm = ({
     } else if (listenerList.length === 0) {
       form.insert({
         name: fields.listeners.name,
-        defaultValue: defaultValue,
+        defaultValue: defaultListenerValue,
       })
     }
   }, [values])
@@ -70,7 +71,7 @@ export const ListenersForm = ({
                     typeof useForm<GatewayListenerFieldSchema>
                   >[1]
                 }
-                defaultValues={values?.[index]}
+                defaultValue={values?.[index]}
               />
 
               {listenerList.length > 1 && (
@@ -95,7 +96,7 @@ export const ListenersForm = ({
         onClick={() =>
           form.insert({
             name: fields.listeners.name,
-            defaultValue: defaultValue,
+            defaultValue: defaultListenerValue,
           })
         }>
         <PlusIcon className="size-4" />

--- a/app/features/connect/gateway/listener/tls-configuration.tsx
+++ b/app/features/connect/gateway/listener/tls-configuration.tsx
@@ -13,25 +13,25 @@ import { useEffect } from 'react'
 
 export const TlsConfiguration = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<GatewayTlsSchema>>[1]
-  defaultValues?: GatewayTlsSchema
+  defaultValue?: GatewayTlsSchema
 }) => {
   const modeControl = useInputControl(fields.mode)
 
   useEffect(() => {
-    if (defaultValues && !fields.mode.value) {
-      modeControl.change(defaultValues?.mode)
+    if (defaultValue && !fields.mode.value) {
+      modeControl.change(defaultValue?.mode)
     }
-  }, [defaultValues, modeControl, fields.mode.value])
+  }, [defaultValue, modeControl, fields.mode.value])
 
   return (
     <Field isRequired label="TLS Mode" errors={fields.mode.errors}>
       <Select
         {...getSelectProps(fields.mode)}
         key={fields.mode.id}
-        defaultValue={defaultValues?.mode}
+        defaultValue={defaultValue?.mode}
         value={fields.mode.value}
         onValueChange={(value) => {
           modeControl.change(value)

--- a/app/features/connect/http-route/form.tsx
+++ b/app/features/connect/http-route/form.tsx
@@ -150,7 +150,7 @@ export const HttpRouteForm = ({
           <CardContent className="space-y-4">
             <MetadataForm
               fields={fields as unknown as ReturnType<typeof useForm<MetadataSchema>>[1]}
-              defaultValues={formattedValues as MetadataSchema}
+              defaultValue={formattedValues as MetadataSchema}
               isEdit={isEdit}
             />
 
@@ -165,7 +165,7 @@ export const HttpRouteForm = ({
 
             <RulesForm
               fields={fields as unknown as ReturnType<typeof useForm<HttpRouteSchema>>[1]}
-              defaultValues={formattedValues?.rules}
+              defaultValue={formattedValues?.rules}
               projectId={projectId}
             />
           </CardContent>

--- a/app/features/connect/http-route/rule/backend-ref/backend-ref-field.tsx
+++ b/app/features/connect/http-route/rule/backend-ref/backend-ref-field.tsx
@@ -12,12 +12,12 @@ import { useEffect } from 'react'
 
 export const BackendRefField = ({
   fields,
-  defaultValues,
+  defaultValue,
   projectId,
   selectedEndpointSlice,
 }: {
   fields: ReturnType<typeof useForm<HttpRouteBackendRefSchema>>[1]
-  defaultValues?: HttpRouteBackendRefSchema
+  defaultValue?: HttpRouteBackendRefSchema
   projectId?: string
   selectedEndpointSlice?: string[]
 }) => {
@@ -25,16 +25,16 @@ export const BackendRefField = ({
   const portControl = useInputControl(fields.port)
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.name && fields.name.value === '') {
-        nameControl.change(defaultValues?.name)
+    if (defaultValue) {
+      if (defaultValue.name && fields.name.value === '') {
+        nameControl.change(defaultValue?.name)
       }
 
-      if (defaultValues.port && fields.port.value === '') {
-        portControl.change(defaultValues?.port.toString())
+      if (defaultValue.port && fields.port.value === '') {
+        portControl.change(defaultValue?.port.toString())
       }
     }
-  }, [defaultValues, nameControl, fields.name.value, portControl, fields.port.value])
+  }, [defaultValue, nameControl, fields.name.value, portControl, fields.port.value])
 
   return (
     <div className="relative flex w-full flex-col items-start gap-4">

--- a/app/features/connect/http-route/rule/backend-ref/backend-refs-form.tsx
+++ b/app/features/connect/http-route/rule/backend-ref/backend-refs-form.tsx
@@ -17,12 +17,12 @@ export const BackendRefDefaultValues: HttpRouteBackendRefSchema = {
 
 export const BackendRefsForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   projectId,
   selectedEndpointSlice,
 }: {
   fields: ReturnType<typeof useForm<HttpRouteRuleSchema>>[1]
-  defaultValues?: HttpRouteBackendRefSchema[]
+  defaultValue?: HttpRouteBackendRefSchema[]
   projectId?: string
   selectedEndpointSlice?: string[]
 }) => {
@@ -30,13 +30,13 @@ export const BackendRefsForm = ({
   const backendRefList = fields.backendRefs.getFieldList()
 
   useEffect(() => {
-    if (defaultValues) {
+    if (defaultValue) {
       form.update({
         name: fields.backendRefs.name,
-        value: defaultValues,
+        value: defaultValue,
       })
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   return (
     <div className="flex flex-col gap-3">
@@ -56,7 +56,7 @@ export const BackendRefsForm = ({
                     typeof useForm<HttpRouteBackendRefSchema>
                   >[1]
                 }
-                defaultValues={defaultValues?.[index]}
+                defaultValue={defaultValue?.[index]}
                 projectId={projectId}
               />
               {backendRefList.length > 1 && (

--- a/app/features/connect/http-route/rule/filter/filter-field.tsx
+++ b/app/features/connect/http-route/rule/filter/filter-field.tsx
@@ -17,18 +17,18 @@ import { useEffect } from 'react'
 
 export const FilterField = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<HttpRouteFilterSchema>>[1]
-  defaultValues?: HttpRouteFilterSchema
+  defaultValue?: HttpRouteFilterSchema
 }) => {
   const typeControl = useInputControl(fields.type)
 
   useEffect(() => {
-    if (defaultValues && !fields.type.value) {
-      typeControl.change(defaultValues.type)
+    if (defaultValue && !fields.type.value) {
+      typeControl.change(defaultValue.type)
     }
-  }, [defaultValues, fields.type.value, typeControl])
+  }, [defaultValue, fields.type.value, typeControl])
 
   return (
     <div className="relative flex w-full flex-col items-start gap-4">
@@ -37,7 +37,7 @@ export const FilterField = ({
           {...getSelectProps(fields.type)}
           key={fields.type.id}
           value={typeControl.value}
-          defaultValue={defaultValues?.type}
+          defaultValue={defaultValue?.type}
           onValueChange={(value) => {
             typeControl.change(value)
           }}>
@@ -61,7 +61,7 @@ export const FilterField = ({
               typeof useForm<HttpURLRewriteSchema>
             >[1]
           }
-          defaultValues={defaultValues?.urlRewrite}
+          defaultValue={defaultValue?.urlRewrite}
         />
       )}
     </div>

--- a/app/features/connect/http-route/rule/filter/filters-form.tsx
+++ b/app/features/connect/http-route/rule/filter/filters-form.tsx
@@ -27,22 +27,22 @@ export const FilterDefaultValues: HttpRouteFilterSchema = {
 
 export const FiltersForm = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<HttpRouteRuleSchema>>[1]
-  defaultValues?: HttpRouteFilterSchema[]
+  defaultValue?: HttpRouteFilterSchema[]
 }) => {
   const form = useFormMetadata('http-route-form')
   const filterList = fields.filters.getFieldList()
 
   useEffect(() => {
-    if (defaultValues) {
+    if (defaultValue) {
       form.update({
         name: fields.filters.name,
-        value: defaultValues,
+        value: defaultValue,
       })
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   return (
     <div className="flex flex-col gap-3">
@@ -61,7 +61,7 @@ export const FiltersForm = ({
                     typeof useForm<HttpRouteFilterSchema>
                   >[1]
                 }
-                defaultValues={defaultValues?.[index]}
+                defaultValue={defaultValue?.[index]}
               />
               {filterList.length > 1 && (
                 <Button

--- a/app/features/connect/http-route/rule/filter/url-rewrite-field.tsx
+++ b/app/features/connect/http-route/rule/filter/url-rewrite-field.tsx
@@ -19,10 +19,10 @@ import { useEffect } from 'react'
 
 export const URLRewriteField = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<HttpURLRewriteSchema>>[1]
-  defaultValues?: HttpURLRewriteSchema
+  defaultValue?: HttpURLRewriteSchema
 }) => {
   const hostnameControl = useInputControl(fields.hostname)
 
@@ -31,21 +31,21 @@ export const URLRewriteField = ({
   const valueControl = useInputControl(pathFields?.value)
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.hostname && fields.hostname.value === '') {
-        hostnameControl.change(defaultValues?.hostname)
+    if (defaultValue) {
+      if (defaultValue.hostname && fields.hostname.value === '') {
+        hostnameControl.change(defaultValue?.hostname)
       }
 
-      if (defaultValues.path?.type && !pathFields?.type.value) {
-        typeControl.change(defaultValues?.path?.type)
+      if (defaultValue.path?.type && !pathFields?.type.value) {
+        typeControl.change(defaultValue?.path?.type)
       }
 
-      if (defaultValues.path?.value && pathFields?.value.value === '') {
-        valueControl.change(defaultValues?.path?.value)
+      if (defaultValue.path?.value && pathFields?.value.value === '') {
+        valueControl.change(defaultValue?.path?.value)
       }
     }
   }, [
-    defaultValues,
+    defaultValue,
     fields.hostname.value,
     typeControl,
     pathFields?.type.value,
@@ -76,7 +76,7 @@ export const URLRewriteField = ({
             {...getSelectProps(pathFields?.type)}
             key={pathFields?.type.id}
             value={typeControl.value}
-            defaultValue={defaultValues?.path?.type}
+            defaultValue={defaultValue?.path?.type}
             onValueChange={(value) => {
               typeControl.change(value)
             }}>

--- a/app/features/connect/http-route/rule/match/matches-form.tsx
+++ b/app/features/connect/http-route/rule/match/matches-form.tsx
@@ -21,22 +21,22 @@ export const MatchDefaultValues: HttpRouteMatchSchema = {
 
 export const MatchesForm = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<HttpRouteRuleSchema>>[1]
-  defaultValues?: HttpRouteMatchSchema[]
+  defaultValue?: HttpRouteMatchSchema[]
 }) => {
   const form = useFormMetadata('http-route-form')
   const matchList = fields.matches.getFieldList()
 
   useEffect(() => {
-    if (defaultValues) {
+    if (defaultValue) {
       form.update({
         name: fields.matches.name,
-        value: defaultValues as HttpRouteMatchSchema[],
+        value: defaultValue as HttpRouteMatchSchema[],
       })
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   return (
     <div className="flex w-full flex-col gap-2">
@@ -54,7 +54,7 @@ export const MatchesForm = ({
                     typeof useForm<HttpPathMatchSchema>
                   >[1]
                 }
-                defaultValues={defaultValues?.[index]?.path}
+                defaultValue={defaultValue?.[index]?.path}
               />
 
               {matchList.length > 1 && (

--- a/app/features/connect/http-route/rule/match/path-field.tsx
+++ b/app/features/connect/http-route/rule/match/path-field.tsx
@@ -19,25 +19,25 @@ import { useEffect } from 'react'
 
 export const PathField = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<HttpPathMatchSchema>>[1]
-  defaultValues?: HttpPathMatchSchema
+  defaultValue?: HttpPathMatchSchema
 }) => {
   const typeControl = useInputControl(fields.type)
   const valueControl = useInputControl(fields.value)
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.type && !fields.type.value) {
-        typeControl.change(defaultValues?.type)
+    if (defaultValue) {
+      if (defaultValue.type && !fields.type.value) {
+        typeControl.change(defaultValue?.type)
       }
 
-      if (defaultValues.value && fields.value.value === '') {
-        valueControl.change(defaultValues?.value)
+      if (defaultValue.value && fields.value.value === '') {
+        valueControl.change(defaultValue?.value)
       }
     }
-  }, [defaultValues, typeControl, fields.type.value, valueControl, fields.value.value])
+  }, [defaultValue, typeControl, fields.type.value, valueControl, fields.value.value])
 
   return (
     <div className="relative flex w-full flex-col items-start gap-4">
@@ -47,7 +47,7 @@ export const PathField = ({
             {...getSelectProps(fields.type)}
             key={fields.type.id}
             value={typeControl.value}
-            defaultValue={defaultValues?.type}
+            defaultValue={defaultValue?.type}
             onValueChange={(value) => {
               typeControl.change(value)
             }}>

--- a/app/features/connect/http-route/rule/rules-form.tsx
+++ b/app/features/connect/http-route/rule/rules-form.tsx
@@ -13,7 +13,7 @@ import { useForm, useFormMetadata } from '@conform-to/react'
 import { PlusIcon, TrashIcon } from 'lucide-react'
 import { useEffect } from 'react'
 
-const defaultValue: HttpRouteRuleSchema = {
+const defaultRuleValue: HttpRouteRuleSchema = {
   matches: [MatchDefaultValues],
   backendRefs: [BackendRefDefaultValues],
   filters: [FilterDefaultValues],
@@ -21,29 +21,29 @@ const defaultValue: HttpRouteRuleSchema = {
 
 export const RulesForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   projectId,
 }: {
   fields: ReturnType<typeof useForm<HttpRouteSchema>>[1]
-  defaultValues?: HttpRouteRuleSchema[]
+  defaultValue?: HttpRouteRuleSchema[]
   projectId?: string
 }) => {
   const form = useFormMetadata('http-route-form')
   const ruleList = fields.rules.getFieldList()
 
   useEffect(() => {
-    if (defaultValues && defaultValues.length > 0) {
+    if (defaultValue && defaultValue.length > 0) {
       form.update({
         name: fields.rules.name,
-        value: defaultValues,
+        value: defaultValue,
       })
     } else if (ruleList.length === 0) {
       form.insert({
         name: fields.rules.name,
-        defaultValue: defaultValue,
+        defaultValue: defaultRuleValue,
       })
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   // Enable this when you don't want to implement same endpoint slice for all backend refs
   /* const selectedEndpointSlice = useMemo(() => {
@@ -79,7 +79,7 @@ export const RulesForm = ({
                       typeof useForm<HttpRouteRuleSchema>
                     >[1]
                   }
-                  defaultValues={defaultValues?.[index]?.matches}
+                  defaultValue={defaultValue?.[index]?.matches}
                 />
 
                 <Separator />
@@ -92,7 +92,7 @@ export const RulesForm = ({
                       typeof useForm<HttpRouteRuleSchema>
                     >[1]
                   }
-                  defaultValues={defaultValues?.[index]?.backendRefs}
+                  defaultValue={defaultValue?.[index]?.backendRefs}
                   projectId={projectId}
                 />
 
@@ -105,7 +105,7 @@ export const RulesForm = ({
                       typeof useForm<HttpRouteRuleSchema>
                     >[1]
                   }
-                  defaultValues={defaultValues?.[index]?.filters}
+                  defaultValue={defaultValue?.[index]?.filters}
                 />
               </div>
 
@@ -116,7 +116,7 @@ export const RulesForm = ({
                   size="sm"
                   className={cn('text-destructive relative top-2 w-fit')}
                   onClick={() => {
-                    defaultValues?.splice(index, 1)
+                    defaultValue?.splice(index, 1)
                     form.remove({ name: fields.rules.name, index })
                   }}>
                   <TrashIcon className="size-4" />
@@ -134,7 +134,7 @@ export const RulesForm = ({
         onClick={() =>
           form.insert({
             name: fields.rules.name,
-            defaultValue: defaultValue,
+            defaultValue: defaultRuleValue,
           })
         }>
         <PlusIcon className="size-4" />

--- a/app/features/observe/export-policies/form/sink/prometheus/auth-field.tsx
+++ b/app/features/observe/export-policies/form/sink/prometheus/auth-field.tsx
@@ -19,11 +19,11 @@ import { useEffect, useState } from 'react'
 
 export const AuthField = ({
   fields,
-  defaultValues,
+  defaultValue,
   projectId,
 }: {
   fields: ReturnType<typeof useForm<ExportPolicySinkAuthenticationSchema>>[1]
-  defaultValues?: ExportPolicySinkAuthenticationSchema
+  defaultValue?: ExportPolicySinkAuthenticationSchema
   projectId?: string
 }) => {
   const authTypeControl = useInputControl(fields.authType)
@@ -32,18 +32,18 @@ export const AuthField = ({
   const [isAuthenticationEnabled, setIsAuthenticationEnabled] = useState<boolean>(false)
 
   useEffect(() => {
-    if (defaultValues) {
-      setIsAuthenticationEnabled(!!defaultValues.authType)
+    if (defaultValue) {
+      setIsAuthenticationEnabled(!!defaultValue.authType)
 
-      if (defaultValues.authType && !fields.authType.value) {
-        authTypeControl.change(defaultValues.authType)
+      if (defaultValue.authType && !fields.authType.value) {
+        authTypeControl.change(defaultValue.authType)
       }
 
-      if (defaultValues.secretName && !fields.secretName.value) {
-        secretNameControl.change(defaultValues.secretName)
+      if (defaultValue.secretName && !fields.secretName.value) {
+        secretNameControl.change(defaultValue.secretName)
       }
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   return (
     <div className="flex w-full flex-col gap-2">
@@ -57,9 +57,9 @@ export const AuthField = ({
 
             if (value) {
               authTypeControl.change(
-                defaultValues?.authType ?? ExportPolicyAuthenticationType.BASIC_AUTH,
+                defaultValue?.authType ?? ExportPolicyAuthenticationType.BASIC_AUTH,
               )
-              secretNameControl.change(defaultValues?.secretName ?? undefined)
+              secretNameControl.change(defaultValue?.secretName ?? undefined)
             } else {
               authTypeControl.change(undefined)
               secretNameControl.change(undefined)

--- a/app/features/observe/export-policies/form/sink/prometheus/batch-field.tsx
+++ b/app/features/observe/export-policies/form/sink/prometheus/batch-field.tsx
@@ -8,25 +8,25 @@ import { useEffect } from 'react'
 
 export const BatchField = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<ExportPolicySinkPrometheusFieldSchema['batch']>>[1]
-  defaultValues?: ExportPolicySinkPrometheusFieldSchema['batch']
+  defaultValue?: ExportPolicySinkPrometheusFieldSchema['batch']
 }) => {
   const maxSizeControl = useInputControl(fields.maxSize)
   const timeoutControl = useInputControl(fields.timeout)
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.maxSize && !fields.maxSize.value) {
-        maxSizeControl.change(String(defaultValues.maxSize))
+    if (defaultValue) {
+      if (defaultValue.maxSize && !fields.maxSize.value) {
+        maxSizeControl.change(String(defaultValue.maxSize))
       }
-      if (defaultValues.timeout && !fields.timeout.value) {
-        timeoutControl.change(String(defaultValues.timeout))
+      if (defaultValue.timeout && !fields.timeout.value) {
+        timeoutControl.change(String(defaultValue.timeout))
       }
     }
   }, [
-    defaultValues,
+    defaultValue,
     maxSizeControl,
     fields.maxSize.value,
     timeoutControl,

--- a/app/features/observe/export-policies/form/sink/prometheus/prometheus-field.tsx
+++ b/app/features/observe/export-policies/form/sink/prometheus/prometheus-field.tsx
@@ -14,22 +14,22 @@ import { useEffect } from 'react'
 
 export const PrometheusField = ({
   fields,
-  defaultValues,
+  defaultValue,
   projectId,
 }: {
   fields: ReturnType<typeof useForm<ExportPolicySinkPrometheusFieldSchema>>[1]
-  defaultValues?: ExportPolicySinkPrometheusFieldSchema
+  defaultValue?: ExportPolicySinkPrometheusFieldSchema
   projectId?: string
 }) => {
   const endpointUrlControl = useInputControl(fields.endpoint)
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.endpoint && !fields.endpoint.value) {
-        endpointUrlControl.change(defaultValues.endpoint)
+    if (defaultValue) {
+      if (defaultValue.endpoint && !fields.endpoint.value) {
+        endpointUrlControl.change(defaultValue.endpoint)
       }
     }
-  }, [defaultValues, endpointUrlControl, fields.endpoint.value])
+  }, [defaultValue, endpointUrlControl, fields.endpoint.value])
 
   return (
     <div className="flex w-full flex-col gap-2">
@@ -60,8 +60,8 @@ export const PrometheusField = ({
               typeof useForm<ExportPolicySinkPrometheusFieldSchema['batch']>
             >[1]
           }
-          defaultValues={
-            defaultValues?.batch as ExportPolicySinkPrometheusFieldSchema['batch']
+          defaultValue={
+            defaultValue?.batch as ExportPolicySinkPrometheusFieldSchema['batch']
           }
         />
 
@@ -73,8 +73,8 @@ export const PrometheusField = ({
               typeof useForm<ExportPolicySinkPrometheusFieldSchema['retry']>
             >[1]
           }
-          defaultValues={
-            defaultValues?.retry as ExportPolicySinkPrometheusFieldSchema['retry']
+          defaultValue={
+            defaultValue?.retry as ExportPolicySinkPrometheusFieldSchema['retry']
           }
         />
 
@@ -87,8 +87,8 @@ export const PrometheusField = ({
               typeof useForm<ExportPolicySinkAuthenticationSchema>
             >[1]
           }
-          defaultValues={
-            defaultValues?.authentication as ExportPolicySinkAuthenticationSchema
+          defaultValue={
+            defaultValue?.authentication as ExportPolicySinkAuthenticationSchema
           }
         />
       </div>

--- a/app/features/observe/export-policies/form/sink/prometheus/retry-field.tsx
+++ b/app/features/observe/export-policies/form/sink/prometheus/retry-field.tsx
@@ -8,25 +8,25 @@ import { useEffect } from 'react'
 
 export const RetryField = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<ExportPolicySinkPrometheusFieldSchema['retry']>>[1]
-  defaultValues?: ExportPolicySinkPrometheusFieldSchema['retry']
+  defaultValue?: ExportPolicySinkPrometheusFieldSchema['retry']
 }) => {
   const backoffDurationControl = useInputControl(fields.backoffDuration)
   const maxAttemptsControl = useInputControl(fields.maxAttempts)
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.backoffDuration && !fields.backoffDuration.value) {
-        backoffDurationControl.change(String(defaultValues.backoffDuration))
+    if (defaultValue) {
+      if (defaultValue.backoffDuration && !fields.backoffDuration.value) {
+        backoffDurationControl.change(String(defaultValue.backoffDuration))
       }
-      if (defaultValues.maxAttempts && !fields.maxAttempts.value) {
-        maxAttemptsControl.change(String(defaultValues.maxAttempts))
+      if (defaultValue.maxAttempts && !fields.maxAttempts.value) {
+        maxAttemptsControl.change(String(defaultValue.maxAttempts))
       }
     }
   }, [
-    defaultValues,
+    defaultValue,
     backoffDurationControl,
     fields.backoffDuration.value,
     maxAttemptsControl,

--- a/app/features/observe/export-policies/form/sink/sink-field.tsx
+++ b/app/features/observe/export-policies/form/sink/sink-field.tsx
@@ -28,13 +28,13 @@ import { useHydrated } from 'remix-utils/use-hydrated'
 export const SinkField = ({
   fields,
   isEdit = false,
-  defaultValues,
+  defaultValue,
   sourceList = [],
   projectId,
 }: {
   fields: ReturnType<typeof useForm<ExportPolicySinkFieldSchema>>[1]
   isEdit?: boolean
-  defaultValues?: ExportPolicySinkFieldSchema
+  defaultValue?: ExportPolicySinkFieldSchema
   sourceList: string[]
   projectId?: string
 }) => {
@@ -49,24 +49,24 @@ export const SinkField = ({
   const [selectedSources, setSelectedSources] = useState<string[]>([])
 
   useEffect(() => {
-    if (defaultValues) {
-      // Only set values if they exist in defaultValues and current fields are empty
-      if (defaultValues.name && fields.name.value === '') {
-        nameControl.change(defaultValues?.name)
+    if (defaultValue) {
+      // Only set values if they exist in defaultValue and current fields are empty
+      if (defaultValue.name && fields.name.value === '') {
+        nameControl.change(defaultValue?.name)
       }
 
-      if (defaultValues.type && !fields.type.value) {
-        typeControl.change(defaultValues?.type)
+      if (defaultValue.type && !fields.type.value) {
+        typeControl.change(defaultValue?.type)
       }
     }
-  }, [defaultValues, nameControl, fields.name.value, typeControl, fields.type.value])
+  }, [defaultValue, nameControl, fields.name.value, typeControl, fields.type.value])
 
   useEffect(() => {
-    if (defaultValues?.sources && !fields.sources.value) {
-      setSelectedSources(defaultValues?.sources)
-      sourcesControl.change(defaultValues?.sources)
+    if (defaultValue?.sources && !fields.sources.value) {
+      setSelectedSources(defaultValue?.sources)
+      sourcesControl.change(defaultValue?.sources)
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   // Focus the input when the form is hydrated
   useEffect(() => {
@@ -108,7 +108,7 @@ export const SinkField = ({
             {...getSelectProps(fields.type)}
             key={fields.type.id}
             value={typeControl.value}
-            defaultValue={defaultValues?.type}
+            defaultValue={defaultValue?.type}
             onValueChange={typeControl.change}>
             <SelectTrigger disabled>
               <SelectValue placeholder="Select a sink type" />
@@ -155,8 +155,8 @@ export const SinkField = ({
               typeof useForm<ExportPolicySinkPrometheusFieldSchema>
             >[1]
           }
-          defaultValues={
-            defaultValues?.prometheusRemoteWrite as ExportPolicySinkPrometheusFieldSchema
+          defaultValue={
+            defaultValue?.prometheusRemoteWrite as ExportPolicySinkPrometheusFieldSchema
           }
         />
       )}

--- a/app/features/observe/export-policies/form/sink/sinks-form.tsx
+++ b/app/features/observe/export-policies/form/sink/sinks-form.tsx
@@ -14,13 +14,13 @@ import { useMemo, useEffect } from 'react'
 
 export const SinksForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   isEdit = false,
   sourceList,
   projectId,
 }: {
   fields: ReturnType<typeof useForm<UpdateExportPolicySchema>>[1]
-  defaultValues?: ExportPolicySinksSchema
+  defaultValue?: ExportPolicySinksSchema
   isEdit?: boolean
   sourceList?: ExportPolicySourceFieldSchema[]
   projectId?: string
@@ -30,10 +30,10 @@ export const SinksForm = ({
   const sourceFieldList = fields.sources.getFieldList()
 
   const values = useMemo(() => {
-    return defaultValues?.sinks
-      ? defaultValues.sinks
-      : ((defaultValues ?? []) as ExportPolicySinkFieldSchema[])
-  }, [defaultValues])
+    return defaultValue?.sinks
+      ? defaultValue.sinks
+      : ((defaultValue ?? []) as ExportPolicySinkFieldSchema[])
+  }, [defaultValue])
 
   useEffect(() => {
     form.update({
@@ -71,7 +71,7 @@ export const SinksForm = ({
                     typeof useForm<ExportPolicySinkFieldSchema>
                   >[1]
                 }
-                defaultValues={values?.[index] as ExportPolicySinkFieldSchema}
+                defaultValue={values?.[index] as ExportPolicySinkFieldSchema}
                 sourceList={
                   typeof sourceList !== 'undefined'
                     ? sourceList.map((source) => source.name)

--- a/app/features/observe/export-policies/form/source/source-field.tsx
+++ b/app/features/observe/export-policies/form/source/source-field.tsx
@@ -22,12 +22,12 @@ import { useHydrated } from 'remix-utils/use-hydrated'
 
 export const SourceField = ({
   fields,
-  defaultValues,
+  defaultValue,
   isEdit = false,
   isMultiple = false,
 }: {
   fields: ReturnType<typeof useForm<ExportPolicySourceFieldSchema>>[1]
-  defaultValues?: ExportPolicySourceFieldSchema
+  defaultValue?: ExportPolicySourceFieldSchema
   isEdit?: boolean
   isMultiple?: boolean
 }) => {
@@ -39,22 +39,22 @@ export const SourceField = ({
   const metricQueryControl = useInputControl(fields.metricQuery)
 
   useEffect(() => {
-    if (defaultValues) {
-      // Only set values if they exist in defaultValues and current fields are empty
-      if (defaultValues.name && fields.name.value === '') {
-        nameControl.change(defaultValues?.name)
+    if (defaultValue) {
+      // Only set values if they exist in defaultValue and current fields are empty
+      if (defaultValue.name && fields.name.value === '') {
+        nameControl.change(defaultValue?.name)
       }
 
-      if (defaultValues.type && !fields.type.value) {
-        typeControl.change(defaultValues?.type)
+      if (defaultValue.type && !fields.type.value) {
+        typeControl.change(defaultValue?.type)
       }
 
-      if (defaultValues.metricQuery && fields.metricQuery.value === '') {
-        metricQueryControl.change(defaultValues?.metricQuery)
+      if (defaultValue.metricQuery && fields.metricQuery.value === '') {
+        metricQueryControl.change(defaultValue?.metricQuery)
       }
     }
   }, [
-    defaultValues,
+    defaultValue,
     nameControl,
     fields.name.value,
     typeControl,
@@ -90,7 +90,7 @@ export const SourceField = ({
             {...getSelectProps(fields.type)}
             key={fields.type.id}
             value={typeControl.value}
-            defaultValue={defaultValues?.type}
+            defaultValue={defaultValue?.type}
             onValueChange={typeControl.change}>
             <SelectTrigger disabled>
               <SelectValue placeholder="Select a source type" />

--- a/app/features/observe/export-policies/form/source/sources-form.tsx
+++ b/app/features/observe/export-policies/form/source/sources-form.tsx
@@ -13,20 +13,20 @@ import { useMemo, useEffect } from 'react'
 
 export const SourcesForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   isEdit = false,
 }: {
   fields: ReturnType<typeof useForm<UpdateExportPolicySchema>>[1]
-  defaultValues?: ExportPolicySourcesSchema
+  defaultValue?: ExportPolicySourcesSchema
   isEdit?: boolean
 }) => {
   const form = useFormMetadata('export-policy-form')
   const fieldList = fields.sources.getFieldList()
   const values = useMemo(() => {
-    return defaultValues?.sources
-      ? defaultValues.sources
-      : ((defaultValues ?? []) as ExportPolicySourceFieldSchema[])
-  }, [defaultValues])
+    return defaultValue?.sources
+      ? defaultValue.sources
+      : ((defaultValue ?? []) as ExportPolicySourceFieldSchema[])
+  }, [defaultValue])
 
   useEffect(() => {
     if (values) {
@@ -54,7 +54,7 @@ export const SourcesForm = ({
                     typeof useForm<ExportPolicySourceFieldSchema>
                   >[1]
                 }
-                defaultValues={values?.[index] as ExportPolicySourceFieldSchema}
+                defaultValue={values?.[index] as ExportPolicySourceFieldSchema}
               />
 
               {fieldList.length > 1 && (

--- a/app/features/observe/export-policies/form/stepper-form.tsx
+++ b/app/features/observe/export-policies/form/stepper-form.tsx
@@ -239,7 +239,7 @@ export const ExportPolicyStepperForm = ({
                           metadata: () => (
                             <MetadataForm
                               isEdit={isEdit}
-                              defaultValues={
+                              defaultValue={
                                 stepper.getMetadata('metadata') as MetadataSchema
                               }
                               fields={
@@ -257,7 +257,7 @@ export const ExportPolicyStepperForm = ({
                                   typeof useForm<UpdateExportPolicySchema>
                                 >[1]
                               }
-                              defaultValues={
+                              defaultValue={
                                 stepper.getMetadata(
                                   'sources',
                                 ) as ExportPolicySourcesSchema
@@ -273,7 +273,7 @@ export const ExportPolicyStepperForm = ({
                                   typeof useForm<UpdateExportPolicySchema>
                                 >[1]
                               }
-                              defaultValues={
+                              defaultValue={
                                 stepper.getMetadata('sinks') as ExportPolicySinksSchema
                               }
                               sourceList={

--- a/app/features/observe/export-policies/form/update-form.tsx
+++ b/app/features/observe/export-policies/form/update-form.tsx
@@ -261,7 +261,7 @@ export const ExportPolicyUpdateForm = ({
                       {section.id === 'metadata' && (
                         <MetadataForm
                           isEdit
-                          defaultValues={formattedValues?.metadata}
+                          defaultValue={formattedValues?.metadata}
                           fields={
                             fields as unknown as ReturnType<
                               typeof useForm<MetadataSchema>
@@ -278,7 +278,7 @@ export const ExportPolicyUpdateForm = ({
                               typeof useForm<UpdateExportPolicySchema>
                             >[1]
                           }
-                          defaultValues={{ sources: formattedValues?.sources ?? [] }}
+                          defaultValue={{ sources: formattedValues?.sources ?? [] }}
                         />
                       )}
 
@@ -291,7 +291,7 @@ export const ExportPolicyUpdateForm = ({
                               typeof useForm<UpdateExportPolicySchema>
                             >[1]
                           }
-                          defaultValues={{ sinks: formattedValues?.sinks ?? [] }}
+                          defaultValue={{ sinks: formattedValues?.sinks ?? [] }}
                         />
                       )}
                     </div>

--- a/app/features/project/create-form.tsx
+++ b/app/features/project/create-form.tsx
@@ -101,7 +101,7 @@ export const CreateProjectForm = () => {
           </Field>
           <Field
             isRequired
-            label="Description"
+            label="Display Name"
             description="Enter a short, human-friendly name. Can be changed later."
             errors={description.errors}>
             <Input

--- a/app/features/project/update-form.tsx
+++ b/app/features/project/update-form.tsx
@@ -1,0 +1,136 @@
+import { Field } from '@/components/field/field'
+import { InputWithCopy } from '@/components/input-with-copy/input-with-copy'
+import { SelectLabels } from '@/components/select-labels/select-labels'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { useIsPending } from '@/hooks/useIsPending'
+import { IProjectControlResponse } from '@/resources/interfaces/project.interface'
+import { updateProjectSchema } from '@/resources/schemas/project.schema'
+import { convertObjectToLabels } from '@/utils/misc'
+import { getFormProps, getInputProps, useForm, useInputControl } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
+import { useEffect, useRef } from 'react'
+import { Form } from 'react-router'
+import { AuthenticityTokenInput } from 'remix-utils/csrf/react'
+import { useHydrated } from 'remix-utils/use-hydrated'
+
+export const UpdateProjectForm = ({
+  defaultValue,
+}: {
+  defaultValue: IProjectControlResponse
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const isHydrated = useHydrated()
+  const isPending = useIsPending()
+
+  const [form, fields] = useForm({
+    constraint: getZodConstraint(updateProjectSchema),
+    shouldValidate: 'onInput',
+    shouldRevalidate: 'onInput',
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: updateProjectSchema })
+    },
+  })
+
+  const displayNameControl = useInputControl(fields.description)
+  const labelsControl = useInputControl(fields.labels)
+
+  useEffect(() => {
+    if (defaultValue) {
+      form.update({
+        value: {
+          description: defaultValue.description,
+          labels: convertObjectToLabels(defaultValue.labels ?? {}),
+        },
+      })
+    }
+  }, [defaultValue])
+
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    isHydrated && inputRef.current?.focus()
+  }, [isHydrated])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Project Settings</CardTitle>
+      </CardHeader>
+
+      <Form
+        method="POST"
+        autoComplete="off"
+        {...getFormProps(form)}
+        className="flex flex-col gap-6">
+        <AuthenticityTokenInput />
+
+        {defaultValue && (
+          <>
+            <input
+              type="hidden"
+              name="resourceVersion"
+              value={defaultValue?.resourceVersion}
+            />
+            <input
+              type="hidden"
+              name="orgEntityId"
+              value={defaultValue?.organizationId}
+            />
+          </>
+        )}
+
+        <CardContent className="space-y-4">
+          <Field
+            label="Immutable Name"
+            tooltipInfo="Used to identify your project in the dashboard, Datum CLI, and in the URL of your deployments">
+            <InputWithCopy value={defaultValue.name ?? ''} className="bg-muted h-9" />
+          </Field>
+
+          <Field
+            isRequired
+            label="Display Name"
+            description="Enter a short, human-friendly name. Can be changed later."
+            errors={fields.description.errors}>
+            <Input
+              placeholder="e.g. My Project"
+              ref={inputRef}
+              onInput={(e: React.FormEvent<HTMLInputElement>) => {
+                const value = (e.target as HTMLInputElement).value
+                displayNameControl.change(value)
+              }}
+              {...getInputProps(fields.description, { type: 'text' })}
+            />
+          </Field>
+
+          <Field
+            label="Labels"
+            errors={fields.labels.errors}
+            description="Add labels to help identify, organize, and filter your projects.">
+            <SelectLabels
+              defaultValue={fields.labels.value as string[]}
+              onChange={(value) => {
+                labelsControl.change(value)
+              }}
+            />
+          </Field>
+        </CardContent>
+        <CardFooter className="flex justify-end gap-2">
+          <Button
+            variant="default"
+            type="submit"
+            disabled={isPending}
+            isLoading={isPending}>
+            {isPending ? 'Updating' : 'Update'}
+          </Button>
+        </CardFooter>
+      </Form>
+    </Card>
+  )
+}

--- a/app/features/secret/form/keys/key-field.tsx
+++ b/app/features/secret/form/keys/key-field.tsx
@@ -13,10 +13,10 @@ import { useEffect, useRef } from 'react'
 
 export const KeyField = ({
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<SecretEnvSchema>>[1]
-  defaultValues?: SecretEnvSchema
+  defaultValue?: SecretEnvSchema
 }) => {
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
 
@@ -28,16 +28,16 @@ export const KeyField = ({
   })
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.key && !fields.key.value) {
-        keyControl.change(defaultValues?.key)
+    if (defaultValue) {
+      if (defaultValue.key && !fields.key.value) {
+        keyControl.change(defaultValue?.key)
       }
 
-      if (defaultValues.value && !fields.value.value) {
-        valueControl.change(defaultValues?.value)
+      if (defaultValue.value && !fields.value.value) {
+        valueControl.change(defaultValue?.value)
       }
     }
-  }, [defaultValues, keyControl, fields.key.value, valueControl, fields.value.value])
+  }, [defaultValue, keyControl, fields.key.value, valueControl, fields.value.value])
 
   return (
     <div className="relative flex flex-1 flex-col items-start gap-4 overflow-x-hidden p-1">

--- a/app/features/secret/form/keys/keys-form-dialog.tsx
+++ b/app/features/secret/form/keys/keys-form-dialog.tsx
@@ -138,7 +138,7 @@ export const KeysFormDialog = ({
             className="flex flex-col gap-6">
             <KeysForm
               mode="dialog"
-              defaultValues={defaultValue}
+              defaultValue={defaultValue}
               form={form as FormMetadata<SecretVariablesSchema>}
               fields={
                 fields as unknown as ReturnType<typeof useForm<SecretVariablesSchema>>[1]

--- a/app/features/secret/form/keys/keys-form.tsx
+++ b/app/features/secret/form/keys/keys-form.tsx
@@ -10,21 +10,21 @@ import { useEffect, useMemo } from 'react'
 export const KeysForm = ({
   form,
   fields,
-  defaultValues,
+  defaultValue,
   mode = 'inline',
 }: {
   form: FormMetadata<SecretVariablesSchema>
   fields: ReturnType<typeof useForm<SecretVariablesSchema>>[1]
-  defaultValues?: SecretVariablesSchema
+  defaultValue?: SecretVariablesSchema
   mode?: 'inline' | 'dialog'
 }) => {
   const variableList = fields.variables.getFieldList()
 
   const variableValue = useMemo(() => {
-    return defaultValues?.variables
-      ? defaultValues.variables
-      : ((defaultValues ?? []) as SecretEnvSchema[])
-  }, [defaultValues])
+    return defaultValue?.variables
+      ? defaultValue.variables
+      : ((defaultValue ?? []) as SecretEnvSchema[])
+  }, [defaultValue])
 
   useEffect(() => {
     if (variableValue && variableValue.length > 0) {
@@ -68,7 +68,7 @@ export const KeysForm = ({
                     typeof useForm<SecretEnvSchema>
                   >[1]
                 }
-                defaultValues={variableValue?.[index]}
+                defaultValue={variableValue?.[index]}
               />
 
               {variableList.length > 1 && (

--- a/app/features/workload/form/network/network-field.tsx
+++ b/app/features/workload/form/network/network-field.tsx
@@ -9,13 +9,13 @@ import { useEffect, useState } from 'react'
 export const NetworkFieldForm = ({
   projectId,
   fields,
-  defaultValues,
+  defaultValue,
   networkOptions = [],
   exceptItems,
 }: {
   projectId?: string
   fields: ReturnType<typeof useForm<NetworkFieldSchema>>[1]
-  defaultValues?: NetworkFieldSchema
+  defaultValue?: NetworkFieldSchema
   networkOptions?: Option[]
   exceptItems: string[]
 }) => {
@@ -40,18 +40,18 @@ export const NetworkFieldForm = ({
   }
 
   useEffect(() => {
-    if (defaultValues) {
-      // Only set values if they exist in defaultValues and current fields are empty
-      if (defaultValues.name && fields.name.value === '') {
-        networkNameControl.change(defaultValues?.name ?? '')
+    if (defaultValue) {
+      // Only set values if they exist in defaultValue and current fields are empty
+      if (defaultValue.name && fields.name.value === '') {
+        networkNameControl.change(defaultValue?.name ?? '')
       }
 
-      if (defaultValues.ipFamilies && !fields.ipFamilies.value) {
-        ipFamiliesControl.change(defaultValues.ipFamilies ?? [])
+      if (defaultValue.ipFamilies && !fields.ipFamilies.value) {
+        ipFamiliesControl.change(defaultValue.ipFamilies ?? [])
       }
     }
   }, [
-    defaultValues,
+    defaultValue,
     networkNameControl,
     ipFamiliesControl,
     fields.name.value,

--- a/app/features/workload/form/network/networks-form.tsx
+++ b/app/features/workload/form/network/networks-form.tsx
@@ -18,11 +18,11 @@ import { useEffect, useMemo, useState } from 'react'
 export const NetworksForm = ({
   projectId,
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   projectId?: string
   fields: ReturnType<typeof useForm<UpdateWorkloadSchema>>[1]
-  defaultValues?: NetworksSchema
+  defaultValue?: NetworksSchema
 }) => {
   const form = useFormMetadata('workload-form')
   const networks = fields.networks.getFieldList()
@@ -41,10 +41,10 @@ export const NetworksForm = ({
   }, [networks])
 
   const values = useMemo(() => {
-    return defaultValues?.networks
-      ? defaultValues.networks
-      : ((defaultValues ?? []) as NetworkFieldSchema[])
-  }, [defaultValues])
+    return defaultValue?.networks
+      ? defaultValue.networks
+      : ((defaultValue ?? []) as NetworkFieldSchema[])
+  }, [defaultValue])
 
   useEffect(() => {
     if (values && networkOptions.length > 0) {
@@ -100,7 +100,7 @@ export const NetworksForm = ({
                   typeof useForm<NetworkFieldSchema>
                 >[1]
               }
-              defaultValues={values?.[index] as NetworkFieldSchema}
+              defaultValue={values?.[index] as NetworkFieldSchema}
             />
             {networks.length > 1 && (
               <Button

--- a/app/features/workload/form/placement/placement-field.tsx
+++ b/app/features/workload/form/placement/placement-field.tsx
@@ -9,10 +9,10 @@ import { useHydrated } from 'remix-utils/use-hydrated'
 export const PlacementField = ({
   isEdit = false,
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   fields: ReturnType<typeof useForm<PlacementFieldSchema>>[1]
-  defaultValues?: PlacementFieldSchema
+  defaultValue?: PlacementFieldSchema
   isEdit?: boolean
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -23,22 +23,22 @@ export const PlacementField = ({
   const minimumReplicasControl = useInputControl(fields.minimumReplicas)
 
   useEffect(() => {
-    if (defaultValues) {
-      // Only set values if they exist in defaultValues and current fields are empty
-      if (defaultValues.name && fields.name.value === '') {
-        nameControl.change(defaultValues?.name)
+    if (defaultValue) {
+      // Only set values if they exist in defaultValue and current fields are empty
+      if (defaultValue.name && fields.name.value === '') {
+        nameControl.change(defaultValue?.name)
       }
 
-      if (defaultValues.cityCode && fields.cityCode.value === '') {
-        cityCodeControl.change(defaultValues?.cityCode)
+      if (defaultValue.cityCode && fields.cityCode.value === '') {
+        cityCodeControl.change(defaultValue?.cityCode)
       }
 
-      if (defaultValues.minimumReplicas && !fields.minimumReplicas.value) {
-        minimumReplicasControl.change(defaultValues?.minimumReplicas.toString() ?? '1')
+      if (defaultValue.minimumReplicas && !fields.minimumReplicas.value) {
+        minimumReplicasControl.change(defaultValue?.minimumReplicas.toString() ?? '1')
       }
     }
   }, [
-    defaultValues,
+    defaultValue,
     nameControl,
     cityCodeControl,
     minimumReplicasControl,

--- a/app/features/workload/form/placement/placements-form.tsx
+++ b/app/features/workload/form/placement/placements-form.tsx
@@ -14,21 +14,21 @@ import { useEffect, useMemo } from 'react'
 
 export const PlacementsForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   isEdit = false,
 }: {
   fields: ReturnType<typeof useForm<PlacementsSchema>>[1]
-  defaultValues?: PlacementsSchema
+  defaultValue?: PlacementsSchema
   isEdit?: boolean
 }) => {
   const form = useFormMetadata('workload-form')
   const placements = fields.placements.getFieldList()
 
   const values = useMemo(() => {
-    return defaultValues?.placements
-      ? defaultValues.placements
-      : ((defaultValues ?? []) as PlacementFieldSchema[])
-  }, [defaultValues])
+    return defaultValue?.placements
+      ? defaultValue.placements
+      : ((defaultValue ?? []) as PlacementFieldSchema[])
+  }, [defaultValue])
 
   useEffect(() => {
     if (values) {
@@ -55,7 +55,7 @@ export const PlacementsForm = ({
                     typeof useForm<PlacementFieldSchema>
                   >[1]
                 }
-                defaultValues={values?.[index] as PlacementFieldSchema}
+                defaultValue={values?.[index] as PlacementFieldSchema}
               />
 
               {placements.length > 1 && (

--- a/app/features/workload/form/runtime/container-field.tsx
+++ b/app/features/workload/form/runtime/container-field.tsx
@@ -14,12 +14,12 @@ import { useHydrated } from 'remix-utils/use-hydrated'
 
 export const ContainerField = ({
   isEdit,
-  defaultValues,
+  defaultValue,
   projectId,
   fields,
 }: {
   isEdit: boolean
-  defaultValues?: RuntimeContainerSchema
+  defaultValue?: RuntimeContainerSchema
   projectId?: string
   fields: ReturnType<typeof useForm<RuntimeContainerSchema>>[1]
 }) => {
@@ -30,17 +30,17 @@ export const ContainerField = ({
   const nameControl = useInputControl(fields.name)
 
   useEffect(() => {
-    if (defaultValues) {
-      // Only set values if they exist in defaultValues and current fields are empty
-      if (defaultValues.name && fields.name.value === '') {
-        nameControl.change(defaultValues?.name)
+    if (defaultValue) {
+      // Only set values if they exist in defaultValue and current fields are empty
+      if (defaultValue.name && fields.name.value === '') {
+        nameControl.change(defaultValue?.name)
       }
 
-      if (defaultValues.image && fields.image.value === '') {
-        imageControl.change(defaultValues?.image)
+      if (defaultValue.image && fields.image.value === '') {
+        imageControl.change(defaultValue?.image)
       }
     }
-  }, [defaultValues, imageControl, nameControl, fields.name.value, fields.image.value])
+  }, [defaultValue, imageControl, nameControl, fields.name.value, fields.image.value])
 
   // Focus the input when the form is hydrated
   useEffect(() => {
@@ -85,7 +85,7 @@ export const ContainerField = ({
               typeof useForm<{ ports: RuntimePortSchema[] }>
             >[1]
           }
-          defaultValues={defaultValues?.ports}
+          defaultValue={defaultValue?.ports}
           isEdit={isEdit}
         />
       </div>
@@ -98,7 +98,7 @@ export const ContainerField = ({
               typeof useForm<{ envs: RuntimeEnvSchema[] }>
             >[1]
           }
-          defaultValues={defaultValues?.envs}
+          defaultValue={defaultValue?.envs}
           isEdit={isEdit}
           projectId={projectId}
         />

--- a/app/features/workload/form/runtime/container-form.tsx
+++ b/app/features/workload/form/runtime/container-form.tsx
@@ -12,25 +12,25 @@ import { useEffect } from 'react'
 export const ContainerForm = ({
   isEdit,
   fields,
-  defaultValues,
+  defaultValue,
   projectId,
 }: {
   isEdit: boolean
   fields: ReturnType<typeof useForm<RuntimeSchema>>[1]
-  defaultValues?: RuntimeContainerSchema[]
+  defaultValue?: RuntimeContainerSchema[]
   projectId?: string
 }) => {
   const form = useFormMetadata('workload-form')
   const containers = fields.containers.getFieldList()
 
   useEffect(() => {
-    if (defaultValues) {
+    if (defaultValue) {
       form.update({
         name: fields.containers.name,
-        value: defaultValues as RuntimeContainerSchema[],
+        value: defaultValue as RuntimeContainerSchema[],
       })
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   return (
     <div className="flex w-full flex-col gap-2">
@@ -43,7 +43,7 @@ export const ContainerForm = ({
               key={container.key}>
               <ContainerField
                 isEdit={isEdit}
-                defaultValues={defaultValues?.[index]}
+                defaultValue={defaultValue?.[index]}
                 projectId={projectId}
                 fields={
                   containerFields as unknown as ReturnType<

--- a/app/features/workload/form/runtime/env-field.tsx
+++ b/app/features/workload/form/runtime/env-field.tsx
@@ -24,12 +24,12 @@ import { useHydrated } from 'remix-utils/use-hydrated'
 
 export const EnvField = ({
   isEdit,
-  defaultValues,
+  defaultValue,
   projectId,
   fields,
 }: {
   isEdit?: boolean
-  defaultValues?: RuntimeEnvSchema
+  defaultValue?: RuntimeEnvSchema
   projectId?: string
   fields: ReturnType<typeof useForm<RuntimeEnvSchema>>[1]
 }) => {
@@ -48,26 +48,26 @@ export const EnvField = ({
   const keyControl = useInputControl(fields.key)
 
   useEffect(() => {
-    if (defaultValues) {
-      // Only set values if they exist in defaultValues and current fields are empty
-      if (defaultValues.name && fields.name.value === '') {
-        nameControl.change(defaultValues?.name)
+    if (defaultValue) {
+      // Only set values if they exist in defaultValue and current fields are empty
+      if (defaultValue.name && fields.name.value === '') {
+        nameControl.change(defaultValue?.name)
       }
 
-      if (defaultValues.type && !fields.type.value) {
-        typeControl.change(defaultValues?.type)
+      if (defaultValue.type && !fields.type.value) {
+        typeControl.change(defaultValue?.type)
 
         if (
-          defaultValues.type === ContainerEnvType.TEXT &&
-          defaultValues.value &&
+          defaultValue.type === ContainerEnvType.TEXT &&
+          defaultValue.value &&
           fields.value.value === ''
         ) {
-          valueControl.change(defaultValues?.value)
+          valueControl.change(defaultValue?.value)
         }
       }
     }
   }, [
-    defaultValues,
+    defaultValue,
     typeControl,
     nameControl,
     valueControl,
@@ -202,7 +202,7 @@ export const EnvField = ({
             {...getSelectProps(fields.key, { value: false })}
             key={fields.key.id}
             value={keyControl.value}
-            defaultValue={defaultValues?.key}
+            defaultValue={defaultValue?.key}
             onValueChange={(value) => {
               keyControl.change(value)
             }}>

--- a/app/features/workload/form/runtime/envs-form.tsx
+++ b/app/features/workload/form/runtime/envs-form.tsx
@@ -8,12 +8,12 @@ import { useEffect } from 'react'
 
 export const EnvsForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   isEdit = false,
   projectId,
 }: {
   fields: ReturnType<typeof useForm<{ envs: RuntimeEnvSchema[] }>>[1]
-  defaultValues?: RuntimeEnvSchema[]
+  defaultValue?: RuntimeEnvSchema[]
   isEdit?: boolean
   projectId?: string
 }) => {
@@ -21,13 +21,13 @@ export const EnvsForm = ({
   const envs = fields.envs?.getFieldList()
 
   useEffect(() => {
-    if (defaultValues) {
+    if (defaultValue) {
       form.update({
         name: fields.envs.name,
-        value: defaultValues as RuntimeEnvSchema[],
+        value: defaultValue as RuntimeEnvSchema[],
       })
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   return (
     <div className="flex w-full flex-col gap-2">
@@ -41,7 +41,7 @@ export const EnvsForm = ({
                 key={env.key}>
                 <EnvField
                   isEdit={isEdit}
-                  defaultValues={defaultValues?.[index]}
+                  defaultValue={defaultValue?.[index]}
                   projectId={projectId}
                   fields={envFields as ReturnType<typeof useForm<RuntimeEnvSchema>>[1]}
                 />

--- a/app/features/workload/form/runtime/port-field.tsx
+++ b/app/features/workload/form/runtime/port-field.tsx
@@ -20,11 +20,11 @@ import { useHydrated } from 'remix-utils/use-hydrated'
 
 export const PortField = ({
   isEdit,
-  defaultValues,
+  defaultValue,
   fields,
 }: {
   isEdit?: boolean
-  defaultValues?: RuntimePortSchema
+  defaultValue?: RuntimePortSchema
   fields: ReturnType<typeof useForm<RuntimePortSchema>>[1]
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -35,22 +35,22 @@ export const PortField = ({
   const protocolControl = useInputControl(fields.protocol)
 
   useEffect(() => {
-    if (defaultValues) {
-      // Only set values if they exist in defaultValues and current fields are empty
-      if (defaultValues.name && fields.name.value === '') {
-        nameControl.change(defaultValues?.name)
+    if (defaultValue) {
+      // Only set values if they exist in defaultValue and current fields are empty
+      if (defaultValue.name && fields.name.value === '') {
+        nameControl.change(defaultValue?.name)
       }
 
-      if (defaultValues.port && fields.port.value === '') {
-        portControl.change(defaultValues?.port.toString())
+      if (defaultValue.port && fields.port.value === '') {
+        portControl.change(defaultValue?.port.toString())
       }
 
-      if (defaultValues.protocol && !fields.protocol.value) {
-        protocolControl.change(defaultValues?.protocol)
+      if (defaultValue.protocol && !fields.protocol.value) {
+        protocolControl.change(defaultValue?.protocol)
       }
     }
   }, [
-    defaultValues,
+    defaultValue,
     portControl,
     protocolControl,
     nameControl,
@@ -105,7 +105,7 @@ export const PortField = ({
           {...getSelectProps(fields.protocol)}
           key={fields.protocol.id}
           value={protocolControl.value}
-          defaultValue={defaultValues?.protocol}
+          defaultValue={defaultValue?.protocol}
           onValueChange={protocolControl.change}>
           <SelectTrigger>
             <SelectValue placeholder="Select a protocol" />

--- a/app/features/workload/form/runtime/ports-form.tsx
+++ b/app/features/workload/form/runtime/ports-form.tsx
@@ -9,24 +9,24 @@ import { useEffect } from 'react'
 
 export const PortsForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   isEdit = false,
 }: {
   fields: ReturnType<typeof useForm<{ ports: RuntimePortSchema[] }>>[1]
-  defaultValues?: RuntimePortSchema[]
+  defaultValue?: RuntimePortSchema[]
   isEdit?: boolean
 }) => {
   const form = useFormMetadata('workload-form')
   const ports = fields.ports?.getFieldList()
 
   useEffect(() => {
-    if (defaultValues) {
+    if (defaultValue) {
       form.update({
         name: fields.ports.name,
-        value: defaultValues as RuntimePortSchema[],
+        value: defaultValue as RuntimePortSchema[],
       })
     }
-  }, [defaultValues])
+  }, [defaultValue])
 
   return (
     <div className="flex w-full flex-col gap-2">
@@ -40,7 +40,7 @@ export const PortsForm = ({
                 key={port.key}>
                 <PortField
                   isEdit={isEdit}
-                  defaultValues={defaultValues?.[index]}
+                  defaultValue={defaultValue?.[index]}
                   fields={portFields as ReturnType<typeof useForm<RuntimePortSchema>>[1]}
                 />
                 {ports.length > 0 && (

--- a/app/features/workload/form/runtime/runtime-form.tsx
+++ b/app/features/workload/form/runtime/runtime-form.tsx
@@ -29,12 +29,12 @@ import { useEffect, useMemo } from 'react'
 
 export const RuntimeForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   isEdit = false,
   projectId,
 }: {
   fields: ReturnType<typeof useForm<RuntimeSchema>>[1]
-  defaultValues?: RuntimeSchema
+  defaultValue?: RuntimeSchema
   isEdit?: boolean
   projectId?: string
 }) => {
@@ -43,17 +43,17 @@ export const RuntimeForm = ({
   const runtimeTypeControl = useInputControl(fields.runtimeType)
 
   useEffect(() => {
-    if (!defaultValues) return
+    if (!defaultValue) return
 
-    if (defaultValues.instanceType && !fields.instanceType.value) {
-      instanceTypeControl.change(defaultValues.instanceType)
+    if (defaultValue.instanceType && !fields.instanceType.value) {
+      instanceTypeControl.change(defaultValue.instanceType)
     }
 
-    if (defaultValues.runtimeType && !fields.runtimeType.value) {
-      runtimeTypeControl.change(defaultValues.runtimeType)
+    if (defaultValue.runtimeType && !fields.runtimeType.value) {
+      runtimeTypeControl.change(defaultValue.runtimeType)
     }
   }, [
-    defaultValues,
+    defaultValue,
     instanceTypeControl,
     runtimeTypeControl,
     fields.instanceType.value,
@@ -65,7 +65,7 @@ export const RuntimeForm = ({
 
     if (
       value === RuntimeType.CONTAINER &&
-      (defaultValues?.containers ?? []).length === 0
+      (defaultValue?.containers ?? []).length === 0
     ) {
       form.update({
         name: fields.containers.name,
@@ -86,7 +86,7 @@ export const RuntimeForm = ({
           onValueChange={instanceTypeControl.change}
           key={fields.instanceType.id}
           value={instanceTypeControl.value}
-          defaultValue={defaultValues?.instanceType}>
+          defaultValue={defaultValue?.instanceType}>
           <SelectTrigger disabled>
             <SelectValue placeholder="Select a instance type" />
           </SelectTrigger>
@@ -119,7 +119,7 @@ export const RuntimeForm = ({
           onValueChange={handleRuntimeTypeChange}
           key={fields.runtimeType.id}
           value={runtimeTypeControl.value?.toString()}
-          defaultValue={defaultValues?.runtimeType}>
+          defaultValue={defaultValue?.runtimeType}>
           <SelectTrigger>
             <SelectValue placeholder="Select a type" />
           </SelectTrigger>
@@ -140,7 +140,7 @@ export const RuntimeForm = ({
               typeof useForm<RuntimeVMSchema>
             >[1]
           }
-          defaultValues={defaultValues?.virtualMachine as RuntimeVMSchema}
+          defaultValue={defaultValue?.virtualMachine as RuntimeVMSchema}
         />
       ) : fields.runtimeType.value === RuntimeType.CONTAINER ? (
         <div className="flex w-full flex-col gap-2">
@@ -149,7 +149,7 @@ export const RuntimeForm = ({
             projectId={projectId}
             isEdit={isEdit}
             fields={fields as unknown as ReturnType<typeof useForm<RuntimeSchema>>[1]}
-            defaultValues={defaultValues?.containers as RuntimeContainerSchema[]}
+            defaultValue={defaultValue?.containers as RuntimeContainerSchema[]}
           />
         </div>
       ) : null}

--- a/app/features/workload/form/runtime/virtual-machine-form.tsx
+++ b/app/features/workload/form/runtime/virtual-machine-form.tsx
@@ -21,11 +21,11 @@ import { useHydrated } from 'remix-utils/use-hydrated'
 
 export const VirtualMachineForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   isEdit = false,
 }: {
   fields: ReturnType<typeof useForm<RuntimeVMSchema>>[1]
-  defaultValues?: RuntimeVMSchema
+  defaultValue?: RuntimeVMSchema
   isEdit?: boolean
 }) => {
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -34,17 +34,17 @@ export const VirtualMachineForm = ({
   const sshKeyControl = useInputControl(fields.sshKey)
 
   useEffect(() => {
-    if (defaultValues) {
-      if (defaultValues.sshKey && !fields.sshKey.value) {
-        sshKeyControl.change(defaultValues.sshKey)
+    if (defaultValue) {
+      if (defaultValue.sshKey && !fields.sshKey.value) {
+        sshKeyControl.change(defaultValue.sshKey)
       }
 
-      if (defaultValues.bootImage && !fields.bootImage.value) {
-        bootImageControl.change(defaultValues.bootImage)
+      if (defaultValue.bootImage && !fields.bootImage.value) {
+        bootImageControl.change(defaultValue.bootImage)
       }
     }
   }, [
-    defaultValues,
+    defaultValue,
     bootImageControl,
     sshKeyControl,
     fields.bootImage.value,
@@ -69,7 +69,7 @@ export const VirtualMachineForm = ({
           onValueChange={(value) => bootImageControl.change(value?.toString())}
           key={fields.bootImage.id}
           value={fields.bootImage.value?.toString()}
-          defaultValue={defaultValues?.bootImage}>
+          defaultValue={defaultValue?.bootImage}>
           <SelectTrigger disabled>
             <SelectValue placeholder="Select a boot image" />
           </SelectTrigger>
@@ -119,7 +119,7 @@ export const VirtualMachineForm = ({
               typeof useForm<{ ports: RuntimePortSchema[] }>
             >[1]
           }
-          defaultValues={defaultValues?.ports}
+          defaultValue={defaultValue?.ports}
           isEdit={isEdit}
         />
       </div>

--- a/app/features/workload/form/stepper-form.tsx
+++ b/app/features/workload/form/stepper-form.tsx
@@ -306,7 +306,7 @@ export const WorkloadStepper = ({
                           metadata: () => (
                             <MetadataForm
                               isEdit={isEdit}
-                              defaultValues={
+                              defaultValue={
                                 stepper.getMetadata('metadata') as MetadataSchema
                               }
                               fields={
@@ -319,7 +319,7 @@ export const WorkloadStepper = ({
                           runtime: () => (
                             <RuntimeForm
                               projectId={projectId}
-                              defaultValues={
+                              defaultValue={
                                 stepper.getMetadata('runtime') as RuntimeSchema
                               }
                               fields={
@@ -332,7 +332,7 @@ export const WorkloadStepper = ({
                           networks: () => (
                             <NetworksForm
                               projectId={projectId}
-                              defaultValues={
+                              defaultValue={
                                 stepper.getMetadata('networks') as NetworksSchema
                               }
                               fields={
@@ -344,7 +344,7 @@ export const WorkloadStepper = ({
                           ),
                           storages: () => (
                             <StoragesForm
-                              defaultValues={
+                              defaultValue={
                                 stepper.getMetadata('storages') as StoragesSchema
                               }
                               fields={
@@ -364,7 +364,7 @@ export const WorkloadStepper = ({
                               fields={
                                 fields as ReturnType<typeof useForm<PlacementsSchema>>[1]
                               }
-                              defaultValues={
+                              defaultValue={
                                 stepper.getMetadata('placements') as PlacementsSchema
                               }
                             />

--- a/app/features/workload/form/storage/boot-field.tsx
+++ b/app/features/workload/form/storage/boot-field.tsx
@@ -10,9 +10,9 @@ import {
 import { BOOT_IMAGES } from '@/constants/bootImages'
 
 export const BootField = ({
-  defaultValues,
+  defaultValue,
 }: {
-  defaultValues?: { name: string; bootImage: string }
+  defaultValue?: { name: string; bootImage: string }
 }) => {
   return (
     <div className="relative flex w-full items-start gap-4">
@@ -21,11 +21,11 @@ export const BootField = ({
           type="text"
           readOnly
           placeholder="e.g. my-storage-us-3sd122"
-          value={defaultValues?.name}
+          value={defaultValue?.name}
         />
       </Field>
       <Field isRequired label="Boot Image" className="w-1/2">
-        <Select value={defaultValues?.bootImage}>
+        <Select value={defaultValue?.bootImage}>
           <SelectTrigger disabled>
             <SelectValue placeholder="Select a boot image" />
           </SelectTrigger>

--- a/app/features/workload/form/storage/storage-field.tsx
+++ b/app/features/workload/form/storage/storage-field.tsx
@@ -22,11 +22,11 @@ import { useHydrated } from 'remix-utils/use-hydrated'
 export const StorageField = ({
   isEdit = false,
   fields,
-  defaultValues,
+  defaultValue,
 }: {
   isEdit?: boolean
   fields: ReturnType<typeof useForm<StorageFieldSchema>>[1]
-  defaultValues?: StorageFieldSchema
+  defaultValue?: StorageFieldSchema
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const isHydrated = useHydrated()
@@ -35,17 +35,17 @@ export const StorageField = ({
   const nameControl = useInputControl(fields.name)
 
   useEffect(() => {
-    if (defaultValues) {
-      // Only set values if they exist in defaultValues and current fields are empty
-      if (defaultValues.name && fields.name.value === '') {
-        nameControl.change(defaultValues?.name)
+    if (defaultValue) {
+      // Only set values if they exist in defaultValue and current fields are empty
+      if (defaultValue.name && fields.name.value === '') {
+        nameControl.change(defaultValue?.name)
       }
 
-      if (defaultValues.type && !fields.type.value) {
-        typeControl.change(defaultValues?.type)
+      if (defaultValue.type && !fields.type.value) {
+        typeControl.change(defaultValue?.type)
       }
     }
-  }, [defaultValues, typeControl, nameControl, fields.name.value, fields.type.value])
+  }, [defaultValue, typeControl, nameControl, fields.name.value, fields.type.value])
 
   // Focus the input when the form is hydrated
   useEffect(() => {
@@ -73,7 +73,7 @@ export const StorageField = ({
             {...getSelectProps(fields.type)}
             key={fields.type.id}
             value={typeControl.value}
-            defaultValue={defaultValues?.type}
+            defaultValue={defaultValue?.type}
             onValueChange={typeControl.change}>
             <SelectTrigger disabled>
               <SelectValue placeholder="Select a storage type" />

--- a/app/features/workload/form/storage/storages-form.tsx
+++ b/app/features/workload/form/storage/storages-form.tsx
@@ -18,12 +18,12 @@ import { useEffect, useMemo } from 'react'
 
 export const StoragesForm = ({
   fields,
-  defaultValues,
+  defaultValue,
   isEdit = false,
   vmBootImage,
 }: {
   fields: ReturnType<typeof useForm<UpdateWorkloadSchema>>[1]
-  defaultValues?: StoragesSchema
+  defaultValue?: StoragesSchema
   isEdit?: boolean
   vmBootImage?: string
 }) => {
@@ -32,10 +32,10 @@ export const StoragesForm = ({
   const virtualMachineFieldSet = fields.virtualMachine.getFieldset()
 
   const values = useMemo(() => {
-    return defaultValues?.storages
-      ? defaultValues.storages
-      : ((defaultValues ?? []) as StorageFieldSchema[])
-  }, [defaultValues])
+    return defaultValue?.storages
+      ? defaultValue.storages
+      : ((defaultValue ?? []) as StorageFieldSchema[])
+  }, [defaultValue])
 
   const bootImage = useMemo(() => {
     if (vmBootImage) {
@@ -56,7 +56,7 @@ export const StoragesForm = ({
       <div className="space-y-4">
         {bootImage !== undefined && (
           <div className="relative flex items-center gap-2 rounded-md border p-4">
-            <BootField defaultValues={{ name: 'boot', bootImage: bootImage ?? '' }} />
+            <BootField defaultValue={{ name: 'boot', bootImage: bootImage ?? '' }} />
           </div>
         )}
         {storages.map((storage, index) => {
@@ -72,7 +72,7 @@ export const StoragesForm = ({
                     typeof useForm<StorageFieldSchema>
                   >[1]
                 }
-                defaultValues={values?.[index] as StorageFieldSchema}
+                defaultValue={values?.[index] as StorageFieldSchema}
               />
 
               {storages.length > 0 && (

--- a/app/features/workload/form/update-form.tsx
+++ b/app/features/workload/form/update-form.tsx
@@ -247,7 +247,7 @@ export const WorkloadUpdateForm = ({
                       {section.id === 'metadata' && (
                         <MetadataForm
                           isEdit
-                          defaultValues={formattedValues?.metadata}
+                          defaultValue={formattedValues?.metadata}
                           fields={
                             fields as unknown as ReturnType<
                               typeof useForm<MetadataSchema>
@@ -260,7 +260,7 @@ export const WorkloadUpdateForm = ({
                         <RuntimeForm
                           isEdit
                           projectId={projectId}
-                          defaultValues={formattedValues?.runtime}
+                          defaultValue={formattedValues?.runtime}
                           fields={
                             fields as unknown as ReturnType<
                               typeof useForm<RuntimeSchema>
@@ -272,7 +272,7 @@ export const WorkloadUpdateForm = ({
                       {section.id === 'networks' && (
                         <NetworksForm
                           projectId={projectId}
-                          defaultValues={{ networks: formattedValues?.networks ?? [] }}
+                          defaultValue={{ networks: formattedValues?.networks ?? [] }}
                           fields={
                             fields as unknown as ReturnType<
                               typeof useForm<UpdateWorkloadSchema>
@@ -284,7 +284,7 @@ export const WorkloadUpdateForm = ({
                       {section.id === 'storages' && (
                         <StoragesForm
                           isEdit
-                          defaultValues={{ storages: formattedValues?.storages ?? [] }}
+                          defaultValue={{ storages: formattedValues?.storages ?? [] }}
                           fields={
                             fields as unknown as ReturnType<
                               typeof useForm<UpdateWorkloadSchema>
@@ -299,7 +299,7 @@ export const WorkloadUpdateForm = ({
                           fields={
                             fields as ReturnType<typeof useForm<PlacementsSchema>>[1]
                           }
-                          defaultValues={{
+                          defaultValue={{
                             placements: formattedValues?.placements ?? [],
                           }}
                         />

--- a/app/resources/interfaces/endpoint-slice.interface.ts
+++ b/app/resources/interfaces/endpoint-slice.interface.ts
@@ -1,3 +1,4 @@
+import { ILabel } from './label.interface'
 import { IoK8sApiDiscoveryV1EndpointSlice } from '@/modules/control-plane/discovery/types.gen'
 
 export interface IEndpointSliceControlResponseLite {
@@ -14,8 +15,8 @@ export interface IEndpointSliceControlResponse {
   createdAt?: Date
   resourceVersion?: string
   namespace?: string
-  labels?: Record<string, string>
-  annotations?: Record<string, string>
+  labels?: ILabel
+  annotations?: ILabel
   endpoints?: {
     addresses: string[]
     conditions: Array<EndpointSliceCondition>

--- a/app/resources/interfaces/export-policy.interface.ts
+++ b/app/resources/interfaces/export-policy.interface.ts
@@ -1,3 +1,4 @@
+import { ILabel } from './label.interface'
 import { ComDatumapisTelemetryV1Alpha1ExportPolicy } from '@/modules/control-plane/telemetry'
 
 export interface IExportPolicyControlResponse {
@@ -9,8 +10,8 @@ export interface IExportPolicyControlResponse {
   sinks?: ComDatumapisTelemetryV1Alpha1ExportPolicy['spec']['sinks']
   status?: ComDatumapisTelemetryV1Alpha1ExportPolicy['status']
   createdAt?: Date
-  labels?: Record<string, string>
-  annotations?: Record<string, string>
+  labels?: ILabel
+  annotations?: ILabel
 }
 
 export enum ExportPolicySourceType {

--- a/app/resources/interfaces/gateway.interface.ts
+++ b/app/resources/interfaces/gateway.interface.ts
@@ -1,3 +1,4 @@
+import { ILabel } from './label.interface'
 import { IoK8sNetworkingGatewayV1Gateway } from '@/modules/control-plane/gateway/types.gen'
 
 export interface IGatewayControlResponse {
@@ -10,8 +11,8 @@ export interface IGatewayControlResponse {
   status?: IoK8sNetworkingGatewayV1Gateway['status']
   addresses?: IoK8sNetworkingGatewayV1Gateway['spec']['addresses']
   createdAt?: Date
-  labels?: Record<string, string>
-  annotations?: Record<string, string>
+  labels?: ILabel
+  annotations?: ILabel
 }
 
 export interface IGatewayControlResponseLite {

--- a/app/resources/interfaces/http-route.interface.ts
+++ b/app/resources/interfaces/http-route.interface.ts
@@ -1,4 +1,5 @@
 import { HttpRouteRuleSchema, HttpRouteSchema } from '../schemas/http-route.schema'
+import { ILabel } from './label.interface'
 
 export interface IHttpRouteControlResponseLite {
   uid?: string
@@ -17,8 +18,8 @@ export interface IHttpRouteControlResponse {
   resourceVersion?: string
   namespace?: string
   name?: string
-  labels?: Record<string, string>
-  annotations?: Record<string, string>
+  labels?: ILabel
+  annotations?: ILabel
   createdAt?: Date
 
   // Spec Section

--- a/app/resources/interfaces/secret.interface.ts
+++ b/app/resources/interfaces/secret.interface.ts
@@ -1,3 +1,5 @@
+import { ILabel } from './label.interface'
+
 export interface ISecretControlResponse {
   name?: string
   namespace?: string
@@ -6,8 +8,8 @@ export interface ISecretControlResponse {
   resourceVersion?: string
   data?: string[]
   type?: SecretType
-  labels?: Record<string, string>
-  annotations?: Record<string, string>
+  labels?: ILabel
+  annotations?: ILabel
 }
 
 export enum SecretType {

--- a/app/resources/interfaces/workload.interface.ts
+++ b/app/resources/interfaces/workload.interface.ts
@@ -1,3 +1,4 @@
+import { ILabel } from './label.interface'
 import {
   ComDatumapisComputeV1AlphaInstance,
   ComDatumapisComputeV1AlphaWorkload,
@@ -12,8 +13,8 @@ export interface IWorkloadControlResponse {
   resourceVersion?: string
   spec?: ComDatumapisComputeV1AlphaWorkload['spec']
   status?: ComDatumapisComputeV1AlphaWorkload['status']
-  labels?: Record<string, string>
-  annotations?: Record<string, string>
+  labels?: ILabel
+  annotations?: ILabel
 }
 
 export interface IWorkloadDeploymentControlResponse {

--- a/app/resources/schemas/project.schema.ts
+++ b/app/resources/schemas/project.schema.ts
@@ -23,4 +23,14 @@ export const newProjectSchema = z
   })
   .and(projectMetadataSchema)
 
+export const updateProjectSchema = z.object({
+  description: z
+    .string({ required_error: 'Description is required.' })
+    .max(100, { message: 'Description must be less than 100 characters long.' }),
+  labels: z.array(z.string()).optional(),
+  resourceVersion: z.string().optional(),
+  orgEntityId: z.string().optional(),
+})
+
 export type NewProjectSchema = z.infer<typeof newProjectSchema>
+export type UpdateProjectSchema = z.infer<typeof updateProjectSchema>

--- a/app/routes/_private+/$orgId+/projects.$projectId+/_config+/config-maps+/$configId.edit.tsx
+++ b/app/routes/_private+/$orgId+/projects.$projectId+/_config+/config-maps+/$configId.edit.tsx
@@ -86,8 +86,8 @@ export const action = withMiddleware(
           projectId,
         }),
         {
-          title: 'Config map updated',
-          description: 'Config map updated successfully',
+          title: 'Config map updated successfully',
+          description: 'You have successfully updated a config map.',
           type: 'success',
         },
       )

--- a/app/routes/_private+/$orgId+/projects.$projectId+/_deploy+/workloads+/$workloadId+/edit.tsx
+++ b/app/routes/_private+/$orgId+/projects.$projectId+/_deploy+/workloads+/$workloadId+/edit.tsx
@@ -87,8 +87,8 @@ export const action = async ({ request, params, context }: ActionFunctionArgs) =
         projectId,
       }),
       {
-        title: 'Workload updated',
-        description: 'Workload updated successfully',
+        title: 'Workload updated successfully',
+        description: 'You have successfully updated a workload.',
         type: 'success',
       },
     )

--- a/app/routes/_private+/$orgId+/projects.$projectId+/_observe+/export-policies+/$exportPolicyId+/edit.tsx
+++ b/app/routes/_private+/$orgId+/projects.$projectId+/_observe+/export-policies+/$exportPolicyId+/edit.tsx
@@ -87,8 +87,8 @@ export const action = async ({ request, params, context }: ActionFunctionArgs) =
         projectId,
       }),
       {
-        title: 'Export policy updated',
-        description: 'Export policy updated successfully',
+        title: 'Export policy updated successfully',
+        description: 'You have successfully updated an export policy.',
         type: 'success',
       },
     )

--- a/app/routes/_private+/$orgId+/projects.$projectId+/locations+/$locationId.edit.tsx
+++ b/app/routes/_private+/$orgId+/projects.$projectId+/locations+/$locationId.edit.tsx
@@ -78,8 +78,8 @@ export const action = withMiddleware(
           projectId,
         }),
         {
-          title: 'Location updated',
-          description: 'Location updated successfully',
+          title: 'Location updated successfully',
+          description: 'You have successfully updated a location.',
           type: 'success',
         },
       )

--- a/app/routes/_private+/account+/api-keys+/new.tsx
+++ b/app/routes/_private+/account+/api-keys+/new.tsx
@@ -1,3 +1,4 @@
+import { routes } from '@/constants/routes'
 import { ApiKeyForm } from '@/features/api-key/form'
 import { commitSession, getSession } from '@/modules/auth/authSession.server'
 import { GraphqlClient } from '@/modules/graphql/graphql'
@@ -7,6 +8,7 @@ import { createUserGql } from '@/resources/gql/user.gql'
 import { NewApiKeySchema, newApiKeySchema } from '@/resources/schemas/api-key.schema'
 import { validateCSRF } from '@/utils/csrf'
 import { mergeMeta, metaObject } from '@/utils/meta'
+import { getPathWithParams } from '@/utils/path'
 import { dataWithToast, redirectWithToast } from '@/utils/toast'
 import { parseWithZod } from '@conform-to/zod'
 import { addDays } from 'date-fns'
@@ -51,10 +53,10 @@ export const action = withMiddleware(async ({ request, context }: ActionFunction
     session.set('apiKey', apiKey.token)
 
     return redirectWithToast(
-      '/account/api-keys',
+      getPathWithParams(routes.account.apiKeys.root),
       {
-        title: 'API Key Created',
-        description: 'API Key created successfully',
+        title: 'API Key created successfully',
+        description: 'You have successfully created an API key.',
         type: 'success',
       },
       {

--- a/app/routes/api+/connect+/networks+/actions.ts
+++ b/app/routes/api+/connect+/networks+/actions.ts
@@ -70,7 +70,7 @@ export const action = withMiddleware(async ({ request, context }: ActionFunction
           { success: true, data: res },
           {
             title: 'Network created successfully',
-            description: 'The network has been created successfully',
+            description: 'You have successfully created a network.',
             type: 'success',
           },
         )
@@ -112,7 +112,7 @@ export const action = withMiddleware(async ({ request, context }: ActionFunction
           { success: true, data: res },
           {
             title: 'Network updated successfully',
-            description: 'The network has been updated successfully',
+            description: 'You have successfully updated a network.',
             type: 'success',
           },
         )

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -151,8 +151,13 @@ export function convertLabelsToObject(
  * @param labels - Object containing label key-value pairs
  * @returns Array of strings in the format "key:value"
  */
-export function convertObjectToLabels(labels: ILabel): string[] {
-  return Object.entries(labels).map(([key, value]) => `${key}:${value}`)
+export function convertObjectToLabels(
+  labels: ILabel,
+  skipPrefixes: string[] = ['resourcemanager'],
+): string[] {
+  return Object.entries(labels)
+    .filter(([key]) => !skipPrefixes.some((prefix) => key.startsWith(prefix)))
+    .map(([key, value]) => `${key}:${value}`)
 }
 
 /**


### PR DESCRIPTION
## Description
This PR adds the ability to update a project's display name from the project settings page. The changes improve the UX by making it clear that the 'Description' field is actually used as the project's display name.

### Changes
- Changed 'Description' field label to 'Display Name' for better clarity
- Added update functionality in project settings page
- Implemented API endpoint for updating project metadata
- Added form validation for display name updates
- Improved success messages across project operations

### Testing Instructions
1. Navigate to any project's settings page
2. Verify that the form shows 'Display Name' instead of 'Description'
3. Try updating the display name:
   - Enter a new display name
   - Submit the form
   - Verify that the success message appears
   - Verify that the new display name is reflected throughout the UI

### Issue
Fix #189 