### PR TITLE
Filter placements cities by existing locations

### DIFF
--- a/app/components/select-box/select-box.tsx
+++ b/app/components/select-box/select-box.tsx
@@ -3,6 +3,7 @@ import {
   Command,
   CommandEmpty,
   CommandGroup,
+  CommandInput,
   CommandItem,
   CommandList,
 } from '@/components/ui/command'
@@ -29,6 +30,8 @@ export const SelectBox = ({
   placeholder = 'Select a option',
   disabled = false,
   isLoading = false,
+  searchable = false,
+  itemPreview,
 }: {
   value?: string
   className?: string
@@ -39,6 +42,8 @@ export const SelectBox = ({
   placeholder?: string
   disabled?: boolean
   isLoading?: boolean
+  searchable?: boolean
+  itemPreview?: (option: SelectBoxOption) => React.ReactNode
 }) => {
   const [open, setOpen] = useState(false)
   const [initValue, setInitValue] = useState(value)
@@ -60,6 +65,10 @@ export const SelectBox = ({
     }
   }, [selectedValue])
 
+  const previewHandler = (option: SelectBoxOption): React.ReactNode => {
+    return itemPreview ? itemPreview(option) : <span>{option.label}</span>
+  }
+
   return (
     <>
       <Popover open={open} onOpenChange={setOpen}>
@@ -70,7 +79,7 @@ export const SelectBox = ({
             role="combobox"
             aria-expanded={open}
             className="relative w-full justify-between">
-            {selectedValue ? selectedValue?.label : placeholder}
+            {selectedValue ? previewHandler(selectedValue) : placeholder}
             <ChevronDown className="size-4 opacity-50" />
             {isLoading && (
               <Loader2 className="absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 animate-spin" />
@@ -82,6 +91,7 @@ export const SelectBox = ({
           align="center"
           onEscapeKeyDown={() => setOpen(false)}>
           <Command>
+            {searchable && <CommandInput placeholder="Search..." />}
             <CommandList>
               <CommandEmpty>No results found.</CommandEmpty>
               {options.length > 0 && (
@@ -97,8 +107,8 @@ export const SelectBox = ({
                           setOpen(false)
                         }}
                         disabled={option.disabled}
-                        className="cursor-pointer justify-between">
-                        <span>{option.label}</span>
+                        className="flex cursor-pointer items-center justify-between">
+                        {previewHandler(option)}
                         {isSelected && <CheckIcon className="text-primary size-4" />}
                       </CommandItem>
                     )

--- a/app/features/connect/endpoint-slice/endpoint/endpoint-field.tsx
+++ b/app/features/connect/endpoint-slice/endpoint/endpoint-field.tsx
@@ -29,7 +29,7 @@ export const EndpointField = ({
 
   return (
     <div className="relative flex w-full flex-col items-start gap-4">
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field
           isRequired
           label="Addresses"

--- a/app/features/connect/endpoint-slice/port/port-field.tsx
+++ b/app/features/connect/endpoint-slice/port/port-field.tsx
@@ -50,7 +50,7 @@ export const PortField = ({
 
   return (
     <div className="relative flex w-full flex-col items-start gap-4">
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field isRequired label="Name" errors={fields.name.errors} className="w-3/4">
           <Input
             {...getInputProps(fields.name, { type: 'text' })}

--- a/app/features/connect/gateway/listener/listener-field.tsx
+++ b/app/features/connect/gateway/listener/listener-field.tsx
@@ -71,7 +71,7 @@ export const ListenerField = ({
 
   return (
     <div className="relative flex w-full flex-col items-start gap-4">
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field isRequired label="Name" errors={fields.name.errors} className="w-full">
           <Input
             {...getInputProps(fields.name, { type: 'text' })}
@@ -85,7 +85,7 @@ export const ListenerField = ({
         </Field>
       </div>
 
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field
           isRequired
           label="Allowed Routes"

--- a/app/features/connect/http-route/rule/backend-ref/backend-ref-field.tsx
+++ b/app/features/connect/http-route/rule/backend-ref/backend-ref-field.tsx
@@ -38,7 +38,7 @@ export const BackendRefField = ({
 
   return (
     <div className="relative flex w-full flex-col items-start gap-4">
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field
           isRequired
           label="Endpoint Slice"

--- a/app/features/connect/http-route/rule/filter/url-rewrite-field.tsx
+++ b/app/features/connect/http-route/rule/filter/url-rewrite-field.tsx
@@ -70,7 +70,7 @@ export const URLRewriteField = ({
           }}
         />
       </Field>
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field isRequired label="Type" errors={pathFields?.type.errors} className="w-1/3">
           <Select
             {...getSelectProps(pathFields?.type)}

--- a/app/features/connect/http-route/rule/match/path-field.tsx
+++ b/app/features/connect/http-route/rule/match/path-field.tsx
@@ -41,7 +41,7 @@ export const PathField = ({
 
   return (
     <div className="relative flex w-full flex-col items-start gap-4">
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field isRequired label="Type" errors={fields.type.errors} className="w-1/3">
           <Select
             {...getSelectProps(fields.type)}

--- a/app/features/location/form/create-form.tsx
+++ b/app/features/location/form/create-form.tsx
@@ -14,7 +14,6 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
-import { Separator } from '@/components/ui/separator'
 import { useIsPending } from '@/hooks/useIsPending'
 import {
   ILocationControlResponse,
@@ -200,16 +199,6 @@ export const CreateLocationForm = ({
             />
           </Field>
 
-          <Field isRequired label="City" errors={fields.cityCode.errors}>
-            <SelectIATA
-              placeholder="Select a city"
-              defaultValue={fields.cityCode.value}
-              onValueChange={(value) => {
-                cityCodeControl.change(value.iata_code)
-              }}
-            />
-          </Field>
-
           <Field
             label="Labels"
             errors={fields.labels.errors}
@@ -222,20 +211,40 @@ export const CreateLocationForm = ({
             />
           </Field>
 
-          <Field isRequired label="Provider" errors={fields.provider.errors}>
-            <SelectLocationProvider
-              meta={fields.provider}
-              onChange={(value) => {
-                providerConfigControl.change(value)
-              }}
-            />
-          </Field>
+          <div className="flex w-full gap-4">
+            <Field
+              isRequired
+              label="City"
+              errors={fields.cityCode.errors}
+              className="w-1/2">
+              <SelectIATA
+                placeholder="Select a city"
+                defaultValue={fields.cityCode.value}
+                onValueChange={(value) => {
+                  cityCodeControl.change(value.value)
+                }}
+              />
+            </Field>
 
-          <Separator />
-          <h2 className="text-base font-medium">Provider Configuration</h2>
-          {fields.provider.value === LocationProvider.GCP && (
-            <GCPProvider isEdit={isEdit} meta={fields.providerConfig.getFieldset()} />
-          )}
+            <Field
+              isRequired
+              label="Provider"
+              errors={fields.provider.errors}
+              className="w-1/2">
+              <SelectLocationProvider
+                meta={fields.provider}
+                onChange={(value) => {
+                  providerConfigControl.change(value)
+                }}
+              />
+            </Field>
+          </div>
+
+          <div className="gap-2 rounded-md border p-4">
+            {fields.provider.value === LocationProvider.GCP && (
+              <GCPProvider isEdit={isEdit} meta={fields.providerConfig.getFieldset()} />
+            )}
+          </div>
         </CardContent>
         <CardFooter className="flex justify-end gap-2">
           <Button

--- a/app/features/location/form/provider/gcp-provider.tsx
+++ b/app/features/location/form/provider/gcp-provider.tsx
@@ -1,104 +1,17 @@
 import { Field } from '@/components/field/field'
-import { SelectAutocomplete } from '@/components/select-autocomplete/select-autocomplete'
-import { Option } from '@/components/select-autocomplete/select-autocomplete.types'
+import { FieldLabel } from '@/components/field/field-label'
+import { SelectBox, SelectBoxOption } from '@/components/select-box/select-box'
 import { Input } from '@/components/ui/input'
 import GCP_REGIONS from '@/constants/json/gcp-region.json'
 import { LocationProvider } from '@/resources/interfaces/location.interface'
-import { FieldMetadata, getInputProps, useInputControl } from '@conform-to/react'
+import {
+  FieldMetadata,
+  getInputProps,
+  getSelectProps,
+  useInputControl,
+} from '@conform-to/react'
 import { Slash } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
-
-const SelectRegion = ({
-  defaultValue,
-  onValueChange,
-  disabled,
-}: {
-  defaultValue?: string
-  onValueChange: (value: Option) => void
-  disabled?: boolean
-}) => {
-  const [value, setValue] = useState<string>(defaultValue ?? '')
-  const selectedValue = useMemo(() => {
-    return GCP_REGIONS.find((option) => option.name === value)
-  }, [value])
-
-  useEffect(() => {
-    setValue(defaultValue ?? '')
-  }, [defaultValue])
-
-  const ItemContent = ({ option }: { option: Option }) => {
-    return (
-      <div className="flex w-full items-center gap-0.5">
-        <span className="font-medium">{option.name}</span>
-        <Slash className="text-muted-foreground! mx-0.5 size-3!" />
-        <span className="text-muted-foreground text-sm">{option.location}</span>
-      </div>
-    )
-  }
-  return (
-    <SelectAutocomplete
-      disabled={disabled}
-      keyValue="name"
-      selectedValue={selectedValue}
-      triggerClassName="w-full h-auto min-h-10"
-      options={GCP_REGIONS}
-      placeholder="Select a region"
-      itemPreview={(option) => <ItemContent option={option} />}
-      itemContent={(option) => <ItemContent option={option} />}
-      onValueChange={(option) => {
-        // eslint-disable-next-line react/prop-types
-        setValue(option.name)
-        onValueChange(option)
-      }}
-    />
-  )
-}
-
-const SelectZone = ({
-  defaultValue,
-  onValueChange,
-  selectedRegion,
-  disabled = false,
-}: {
-  defaultValue?: string
-  onValueChange: (value: Option) => void
-  selectedRegion: string | undefined
-  disabled?: boolean
-}) => {
-  const [value, setValue] = useState<string>(defaultValue ?? '')
-
-  const zones = useMemo(() => {
-    const list = GCP_REGIONS.find((option) => option.name === selectedRegion)?.zones
-    return list?.map((zone) => ({
-      value: zone,
-      label: zone,
-    }))
-  }, [selectedRegion])
-
-  const selectedValue = useMemo(() => {
-    return zones?.find((zone) => zone.value === value)
-  }, [value])
-
-  useEffect(() => {
-    setValue(defaultValue ?? '')
-  }, [defaultValue])
-
-  return (
-    <SelectAutocomplete
-      disabled={zones?.length === 0 || !selectedRegion || disabled}
-      selectedValue={selectedValue}
-      triggerClassName="w-full h-auto min-h-10"
-      options={zones ?? []}
-      placeholder="Select a zone"
-      boxClassName="h-[150px]"
-      onValueChange={(option) => {
-        // eslint-disable-next-line react/prop-types
-        setValue(option.value ?? '')
-        onValueChange(option)
-      }}
-    />
-  )
-}
+import { useMemo } from 'react'
 
 export const GCPProvider = ({
   isEdit = false,
@@ -115,43 +28,75 @@ export const GCPProvider = ({
   const regionControl = useInputControl(meta.region)
   const zoneControl = useInputControl(meta.zone)
 
+  const zoneOptions = useMemo(() => {
+    if (!meta.region.value) return []
+
+    const list = GCP_REGIONS.find((option) => option.name === meta.region.value)?.zones
+    return list?.map((zone) => ({
+      value: zone,
+      label: zone,
+    }))
+  }, [meta.region.value])
+
   return (
-    <div className="space-y-4">
-      <Input
-        hidden
-        {...getInputProps(meta.provider, { type: 'text' })}
-        key={meta.provider.id}
-        placeholder="e.g. GCP"
-        className="hidden"
-      />
-      <Field isRequired label="Project ID" errors={meta.projectId.errors}>
+    <div className="flex flex-col gap-3">
+      <FieldLabel label="Google Cloud Platform Configuration" />
+      <div className="space-y-4">
         <Input
-          {...getInputProps(meta.projectId, { type: 'text' })}
-          key={meta.projectId.id}
-          placeholder="e.g. my-project-343j33"
-          readOnly={isEdit}
+          hidden
+          {...getInputProps(meta.provider, { type: 'text' })}
+          key={meta.provider.id}
+          placeholder="e.g. GCP"
+          className="hidden"
         />
-      </Field>
-      <Field isRequired label="Region" errors={meta.region.errors}>
-        <SelectRegion
-          defaultValue={meta.region.value}
-          onValueChange={(value) => {
-            regionControl.change(value.name)
-            zoneControl.change(undefined)
-          }}
-          disabled={isEdit}
-        />
-      </Field>
-      <Field isRequired label="Zone" errors={meta.zone.errors}>
-        <SelectZone
-          selectedRegion={meta.region.value}
-          defaultValue={meta.zone.value}
-          onValueChange={(value) => {
-            zoneControl.change(value.value ?? '')
-          }}
-          disabled={isEdit}
-        />
-      </Field>
+        <Field isRequired label="Project ID" errors={meta.projectId.errors}>
+          <Input
+            {...getInputProps(meta.projectId, { type: 'text' })}
+            key={meta.projectId.id}
+            placeholder="e.g. my-project-343j33"
+            readOnly={isEdit}
+          />
+        </Field>
+        <div className="flex w-full gap-4">
+          <Field isRequired label="Region" errors={meta.region.errors} className="w-1/2">
+            <SelectBox
+              {...getSelectProps(meta.region, { value: false })}
+              options={GCP_REGIONS.map((region) => ({
+                value: region.name,
+                label: `${region.name} - ${region.location}`,
+                ...region,
+              }))}
+              itemPreview={(option) => (
+                <div className="flex w-full items-center gap-0.5">
+                  <span className="font-medium">{option.name}</span>
+                  <Slash className="text-muted-foreground! mx-0.5 size-2!" />
+                  <span className="text-muted-foreground text-xs">{option.location}</span>
+                </div>
+              )}
+              onChange={(value: SelectBoxOption) => {
+                regionControl.change(value.value)
+                zoneControl.change(undefined)
+              }}
+              value={meta.region.value}
+              placeholder="Select a region"
+              disabled={isEdit}
+              searchable
+            />
+          </Field>
+          <Field isRequired label="Zone" errors={meta.zone.errors} className="w-1/2">
+            <SelectBox
+              {...getSelectProps(meta.zone, { value: false })}
+              options={zoneOptions ?? []}
+              onChange={(value: SelectBoxOption) => {
+                zoneControl.change(value.value)
+              }}
+              value={meta.zone.value}
+              placeholder="Select a zone"
+              disabled={isEdit}
+            />
+          </Field>
+        </div>
+      </div>
     </div>
   )
 }

--- a/app/features/location/form/select-iata.tsx
+++ b/app/features/location/form/select-iata.tsx
@@ -1,35 +1,19 @@
 import { Option } from '@/components/select-autocomplete/select-autocomplete.types'
-import { Button } from '@/components/ui/button'
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { cn } from '@/utils/misc'
-import { CheckIcon, ChevronDown } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { SelectBox } from '@/components/select-box/select-box'
+import { useMemo } from 'react'
 
-const iata = [
+const iataOptions = [
   {
-    name: 'Dallas Fort Worth Intl',
-    city: 'Dallas-Fort Worth',
-    country: 'United States',
-    iata_code: 'DFW',
+    value: 'DFW',
+    label: 'Dallas Fort Worth Intl (DFW)',
   },
   {
-    name: 'Heathrow',
-    city: 'London',
-    country: 'United Kingdom',
-    iata_code: 'LHR',
+    value: 'LHR',
+    label: 'Heathrow (LHR)',
   },
   {
-    name: 'Columbia Gorge Regional',
-    city: 'The Dalles',
-    country: 'United States',
-    iata_code: 'DLS',
+    value: 'DLS',
+    label: 'Columbia Gorge Regional (DLS)',
   },
 ]
 
@@ -40,6 +24,7 @@ export const SelectIATA = ({
   placeholder = 'Select IATA',
   name,
   id,
+  availableItems = [],
 }: {
   defaultValue?: string
   className?: string
@@ -47,114 +32,23 @@ export const SelectIATA = ({
   placeholder?: string
   name?: string
   id?: string
+  availableItems?: string[]
 }) => {
-  const [open, setOpen] = useState(false)
-
-  const iataOptions = useMemo(() => {
-    return iata.map((i) => ({
-      value: i.iata_code,
-      label: `${i.name} (${i.iata_code})`,
-      ...i,
-    }))
-  }, [])
-
-  const [value, setValue] = useState(defaultValue)
-  const selectedValue = useMemo(() => {
-    return iataOptions.find((option) => option.value === value)
-  }, [value, iataOptions])
-
-  useEffect(() => {
-    if (defaultValue) {
-      setValue(defaultValue)
-    }
-  }, [defaultValue])
-
-  useEffect(() => {
-    if (selectedValue) {
-      onValueChange(selectedValue)
-    }
-  }, [selectedValue])
+  const filteredOptions = useMemo(() => {
+    return availableItems.length > 0
+      ? iataOptions.filter((option) => availableItems.includes(option.value))
+      : iataOptions
+  }, [availableItems])
 
   return (
-    <>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            role="combobox"
-            aria-expanded={open}
-            className="w-full justify-between">
-            {selectedValue ? selectedValue?.label : placeholder}
-            <ChevronDown className="size-4 opacity-50" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent
-          className={cn('popover-content-width-full min-w-[300px] p-0', className)}
-          align="center"
-          onEscapeKeyDown={() => setOpen(false)}>
-          <Command>
-            <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-              {iataOptions.length > 0 && (
-                <CommandGroup className="max-h-[250px] overflow-y-auto">
-                  {iataOptions.map((option) => {
-                    const isSelected = selectedValue?.value === option.value
-                    return (
-                      <CommandItem
-                        value={option.value}
-                        key={option.value}
-                        onSelect={() => {
-                          setValue(option.value)
-                          setOpen(false)
-                        }}
-                        className="cursor-pointer justify-between">
-                        <span>{option.label}</span>
-                        {isSelected && <CheckIcon className="text-primary size-4" />}
-                      </CommandItem>
-                    )
-                  })}
-                </CommandGroup>
-              )}
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
-
-      {/* Hidden input for form submission */}
-      <select
-        name={name}
-        id={id}
-        value={selectedValue?.value ?? ''}
-        defaultValue={selectedValue?.value ?? ''}
-        className="absolute top-0 left-0 h-0 w-0"
-        onChange={() => undefined}>
-        <option value=""></option>
-        {iataOptions.map((option, idx) => (
-          <option key={`${option.value}-${idx}`} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </>
-  )
-
-  /* return (
-    <SelectAutocomplete
+    <SelectBox
+      value={defaultValue}
+      onChange={(value) => onValueChange(value)}
+      options={filteredOptions}
+      placeholder={placeholder}
       name={name}
       id={id}
-      isLoading={isLoading}
-      keyValue="iata_code"
-      selectedValue={selectedValue}
-      triggerClassName={cn('w-full h-auto min-h-10', className)}
-      options={iataOptions}
-      placeholder={placeholder}
-      itemPreview={(option) => <span className="font-medium">{option.iata_code}</span>}
-      itemContent={(option) => <ItemContent option={option} />}
-      onValueChange={(option) => {
-        setValue(option.iata_code)
-        onValueChange(option)
-      }}
-      boxClassName="h-[150px]"
+      className={className}
     />
-  ) */
+  )
 }

--- a/app/features/observe/export-policies/form/sink/prometheus/batch-field.tsx
+++ b/app/features/observe/export-policies/form/sink/prometheus/batch-field.tsx
@@ -36,7 +36,7 @@ export const BatchField = ({
   return (
     <div className="flex w-full flex-col gap-2">
       <FieldLabel label="Batch Configuration" />
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field
           isRequired
           label="Max Size"

--- a/app/features/observe/export-policies/form/sink/prometheus/retry-field.tsx
+++ b/app/features/observe/export-policies/form/sink/prometheus/retry-field.tsx
@@ -36,7 +36,7 @@ export const RetryField = ({
   return (
     <div className="flex w-full flex-col gap-2">
       <FieldLabel label="Retry Configuration" />
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field
           isRequired
           label="Max Attempts"

--- a/app/features/observe/export-policies/form/sink/sink-field.tsx
+++ b/app/features/observe/export-policies/form/sink/sink-field.tsx
@@ -102,7 +102,7 @@ export const SinkField = ({
         />
       </Field>
 
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field isRequired label="Type" errors={fields.type.errors} className="w-1/2">
           <Select
             {...getSelectProps(fields.type)}

--- a/app/features/observe/export-policies/form/source/source-field.tsx
+++ b/app/features/observe/export-policies/form/source/source-field.tsx
@@ -71,7 +71,7 @@ export const SourceField = ({
 
   return (
     <div className="relative flex flex-1 flex-col items-start gap-4">
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field isRequired label="Name" errors={fields.name.errors} className="w-1/2">
           <Input
             {...getInputProps(fields.name, { type: 'text' })}

--- a/app/features/secret/form/keys/key-field.tsx
+++ b/app/features/secret/form/keys/key-field.tsx
@@ -41,7 +41,7 @@ export const KeyField = ({
 
   return (
     <div className="relative flex flex-1 flex-col items-start gap-4 overflow-x-hidden p-1">
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field isRequired label="Key" errors={fields.key.errors} className="w-1/3">
           <Input
             {...getInputProps(fields.key, { type: 'text' })}

--- a/app/features/workload/form/placement/placement-field.tsx
+++ b/app/features/workload/form/placement/placement-field.tsx
@@ -10,10 +10,12 @@ export const PlacementField = ({
   isEdit = false,
   fields,
   defaultValues,
+  availableLocations = [],
 }: {
   fields: ReturnType<typeof useForm<PlacementFieldSchema>>[1]
   defaultValues?: PlacementFieldSchema
   isEdit?: boolean
+  availableLocations?: string[]
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const isHydrated = useHydrated()
@@ -68,9 +70,10 @@ export const PlacementField = ({
         />
       </Field>
 
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field isRequired label="City" errors={fields.cityCode.errors} className="w-1/2">
           <SelectIATA
+            availableItems={availableLocations}
             name={fields.cityCode.name}
             id={fields.cityCode.id}
             placeholder="Select a city"

--- a/app/features/workload/form/runtime/env-field.tsx
+++ b/app/features/workload/form/runtime/env-field.tsx
@@ -84,7 +84,7 @@ export const EnvField = ({
 
   return (
     <div className="relative flex w-full flex-col items-start gap-4">
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field isRequired label="Name" errors={fields.name.errors} className="w-2/3">
           <Input
             {...getInputProps(fields.name, { type: 'text' })}
@@ -128,7 +128,7 @@ export const EnvField = ({
         </Field>
       </div>
 
-      <div className={cn('flex w-full gap-2', { hidden: !fields.type.value })}>
+      <div className={cn('flex w-full gap-4', { hidden: !fields.type.value })}>
         <Field
           isRequired
           label="Value"

--- a/app/features/workload/form/stepper-form.tsx
+++ b/app/features/workload/form/stepper-form.tsx
@@ -361,6 +361,7 @@ export const WorkloadStepper = ({
                           ),
                           placements: () => (
                             <PlacementsForm
+                              projectId={projectId}
                               fields={
                                 fields as ReturnType<typeof useForm<PlacementsSchema>>[1]
                               }

--- a/app/features/workload/form/storage/storage-field.tsx
+++ b/app/features/workload/form/storage/storage-field.tsx
@@ -67,7 +67,7 @@ export const StorageField = ({
           }}
         />
       </Field>
-      <div className="flex w-full gap-2">
+      <div className="flex w-full gap-4">
         <Field isRequired label="Type" errors={fields.type.errors} className="w-1/2">
           <Select
             {...getSelectProps(fields.type)}

--- a/app/features/workload/form/update-form.tsx
+++ b/app/features/workload/form/update-form.tsx
@@ -296,6 +296,7 @@ export const WorkloadUpdateForm = ({
                       {section.id === 'placements' && (
                         <PlacementsForm
                           isEdit
+                          projectId={projectId}
                           fields={
                             fields as ReturnType<typeof useForm<PlacementsSchema>>[1]
                           }

--- a/app/routes/api+/locations/_index.tsx
+++ b/app/routes/api+/locations/_index.tsx
@@ -1,0 +1,23 @@
+import { authMiddleware } from '@/modules/middleware/authMiddleware'
+import { withMiddleware } from '@/modules/middleware/middleware'
+import { createLocationsControl } from '@/resources/control-plane/locations.control'
+import { CustomError } from '@/utils/errorHandle'
+import { Client } from '@hey-api/client-axios'
+import { AppLoadContext, data } from 'react-router'
+
+export const ROUTE_PATH = '/api/locations' as const
+
+export const loader = withMiddleware(async ({ request, context }) => {
+  const url = new URL(request.url)
+  const projectId = url.searchParams.get('projectId')
+
+  if (!projectId) {
+    throw new CustomError('Project ID is required', 400)
+  }
+
+  const { controlPlaneClient } = context as AppLoadContext
+  const locationsControl = createLocationsControl(controlPlaneClient as Client)
+
+  const locations = await locationsControl.list(projectId)
+  return data(locations)
+}, authMiddleware)

--- a/app/routes/api+/projects+/status.ts
+++ b/app/routes/api+/projects+/status.ts
@@ -9,9 +9,6 @@ export const ROUTE_PATH = '/api/projects/status' as const
 
 export const loader = withMiddleware(async ({ request, context }) => {
   try {
-    const { controlPlaneClient } = context as AppLoadContext
-    const projectsControl = createProjectsControl(controlPlaneClient as Client)
-
     const url = new URL(request.url)
     const projectId = url.searchParams.get('projectId')
     const orgId = url.searchParams.get('orgId')
@@ -19,6 +16,9 @@ export const loader = withMiddleware(async ({ request, context }) => {
     if (!projectId || !orgId) {
       throw new CustomError('Project ID and Organization ID are required', 400)
     }
+
+    const { controlPlaneClient } = context as AppLoadContext
+    const projectsControl = createProjectsControl(controlPlaneClient as Client)
 
     const status = await projectsControl.getStatus(orgId, projectId)
     return data(status)


### PR DESCRIPTION
Fixes #264

When creating a workload, we filter the placement cities based on the existing locations. This prevents errors when attempting to use a city that is not part of any existing location.