### PR TITLE
feat: disable sidebar navigation when project is being created

### DIFF
--- a/app/components/status-badge/status-badge.tsx
+++ b/app/components/status-badge/status-badge.tsx
@@ -27,28 +27,30 @@ export const StatusBadge = ({
   readyText?: string
   tooltipText?: string | React.ReactNode
 }) => {
-  const [isReady, setIsReady] = useState<ControlPlaneStatus>(ControlPlaneStatus.Pending)
+  const [planeStatus, setPlaneStatus] = useState<ControlPlaneStatus>(
+    ControlPlaneStatus.Pending,
+  )
   const [message, setMessage] = useState<string | null>(null)
 
   useEffect(() => {
     if (status) {
-      setIsReady(status.isReady)
+      setPlaneStatus(status.status)
       setMessage(status.message)
     }
   }, [status])
 
   const Dot = () => {
-    return isReady === ControlPlaneStatus.Success ? (
+    return planeStatus === ControlPlaneStatus.Success ? (
       <CircleIcon
         className="size-3 cursor-default fill-green-500 text-green-500"
         aria-hidden="true"
       />
-    ) : isReady === ControlPlaneStatus.Error ? (
+    ) : planeStatus === ControlPlaneStatus.Error ? (
       <CircleIcon
         className="size-3 cursor-default fill-red-500 text-red-500"
         aria-hidden="true"
       />
-    ) : isReady === ControlPlaneStatus.Pending ? (
+    ) : planeStatus === ControlPlaneStatus.Pending ? (
       <Loader2 className="size-3 animate-spin cursor-default" />
     ) : null
   }
@@ -58,7 +60,7 @@ export const StatusBadge = ({
       <TooltipTrigger
         className={cn(
           'w-fit',
-          !showTooltip || isReady === ControlPlaneStatus.Success
+          !showTooltip || planeStatus === ControlPlaneStatus.Success
             ? 'pointer-events-none'
             : '',
         )}>
@@ -72,9 +74,9 @@ export const StatusBadge = ({
               badgeClassName,
             )}>
             <Dot />
-            {isReady === ControlPlaneStatus.Success
+            {planeStatus === ControlPlaneStatus.Success
               ? readyText
-              : isReady === ControlPlaneStatus.Error
+              : planeStatus === ControlPlaneStatus.Error
                 ? errorText
                 : loadingText}
           </Badge>

--- a/app/features/connect/gateway/status.tsx
+++ b/app/features/connect/gateway/status.tsx
@@ -43,7 +43,7 @@ export const GatewayStatus = ({
     // Initial load if:
     // 1. No current status exists, or
     // 2. Current status is pending
-    if (!currentStatus || currentStatus?.isReady === ControlPlaneStatus.Pending) {
+    if (!currentStatus || currentStatus?.status === ControlPlaneStatus.Pending) {
       loadStatus()
 
       // Set up polling interval
@@ -60,12 +60,11 @@ export const GatewayStatus = ({
 
   useEffect(() => {
     if (fetcher.data) {
-      const { isReady } = fetcher.data as IControlPlaneStatus
+      const { status } = fetcher.data as IControlPlaneStatus
 
       setStatus(fetcher.data)
       if (
-        (isReady === ControlPlaneStatus.Success ||
-          isReady === ControlPlaneStatus.Error) &&
+        (status === ControlPlaneStatus.Success || status === ControlPlaneStatus.Error) &&
         intervalRef.current
       ) {
         clearInterval(intervalRef.current)
@@ -80,7 +79,7 @@ export const GatewayStatus = ({
       showTooltip={showTooltip}
       badgeClassName={badgeClassName}
       tooltipText={
-        fetcher.data?.isReady === ControlPlaneStatus.Success ? 'Active' : undefined
+        fetcher.data?.status === ControlPlaneStatus.Success ? 'Active' : undefined
       }
     />
   ) : (

--- a/app/features/observe/export-policies/sinks-table.tsx
+++ b/app/features/observe/export-policies/sinks-table.tsx
@@ -73,7 +73,7 @@ export const WorkloadSinksTable = ({
               showTooltip
               badgeClassName="px-0"
               tooltipText={
-                transformedStatus?.isReady === ControlPlaneStatus.Success
+                transformedStatus?.status === ControlPlaneStatus.Success
                   ? 'Active'
                   : undefined
               }

--- a/app/features/observe/export-policies/status.tsx
+++ b/app/features/observe/export-policies/status.tsx
@@ -26,7 +26,7 @@ export const ExportPolicyStatus = ({
   const intervalRef = useRef<NodeJS.Timeout>(null)
   const [status, setStatus] = useState<IControlPlaneStatus>(
     currentStatus ?? {
-      isReady: ControlPlaneStatus.Pending,
+      status: ControlPlaneStatus.Pending,
       message: '',
     },
   )
@@ -59,8 +59,8 @@ export const ExportPolicyStatus = ({
       setStatus(currentStatus)
 
       if (
-        currentStatus?.isReady === ControlPlaneStatus.Success ||
-        currentStatus?.isReady === ControlPlaneStatus.Error
+        currentStatus?.status === ControlPlaneStatus.Success ||
+        currentStatus?.status === ControlPlaneStatus.Error
       ) {
         if (intervalRef.current) {
           clearInterval(intervalRef.current)
@@ -78,7 +78,7 @@ export const ExportPolicyStatus = ({
     // Initial load if:
     // 1. No current status exists, or
     // 2. Current status is pending
-    if (currentStatus?.isReady === ControlPlaneStatus.Pending) {
+    if (currentStatus?.status === ControlPlaneStatus.Pending) {
       loadStatus(id)
 
       // Set up polling interval
@@ -95,10 +95,9 @@ export const ExportPolicyStatus = ({
 
   useEffect(() => {
     if (fetcher.data) {
-      const { isReady } = fetcher.data as IControlPlaneStatus
+      const { status } = fetcher.data as IControlPlaneStatus
       if (
-        (isReady === ControlPlaneStatus.Success ||
-          isReady === ControlPlaneStatus.Error) &&
+        (status === ControlPlaneStatus.Success || status === ControlPlaneStatus.Error) &&
         intervalRef.current
       ) {
         clearInterval(intervalRef.current)
@@ -113,7 +112,7 @@ export const ExportPolicyStatus = ({
       showTooltip={showTooltip}
       badgeClassName={badgeClassName}
       tooltipText={
-        fetcher.data?.isReady === ControlPlaneStatus.Success ? (
+        fetcher.data?.status === ControlPlaneStatus.Success ? (
           'Active'
         ) : (
           <>

--- a/app/features/project/status.tsx
+++ b/app/features/project/status.tsx
@@ -43,7 +43,7 @@ export const ProjectStatus = ({
     // Initial load if:
     // 1. No current status exists, or
     // 2. Current status is pending
-    if (!currentStatus || currentStatus?.isReady === ControlPlaneStatus.Pending) {
+    if (!currentStatus || currentStatus?.status === ControlPlaneStatus.Pending) {
       loadStatus()
 
       // Set up polling interval
@@ -60,12 +60,11 @@ export const ProjectStatus = ({
 
   useEffect(() => {
     if (fetcher.data) {
-      const { isReady } = fetcher.data as IControlPlaneStatus
+      const { status } = fetcher.data as IControlPlaneStatus
 
       setStatus(fetcher.data)
       if (
-        (isReady === ControlPlaneStatus.Success ||
-          isReady === ControlPlaneStatus.Error) &&
+        (status === ControlPlaneStatus.Success || status === ControlPlaneStatus.Error) &&
         intervalRef.current
       ) {
         clearInterval(intervalRef.current)
@@ -80,7 +79,7 @@ export const ProjectStatus = ({
       showTooltip={showTooltip}
       badgeClassName={badgeClassName}
       tooltipText={
-        fetcher.data?.isReady === ControlPlaneStatus.Success ? 'Active' : undefined
+        fetcher.data?.status === ControlPlaneStatus.Success ? 'Active' : undefined
       }
     />
   ) : (

--- a/app/features/workload/form/placement/placement-field.tsx
+++ b/app/features/workload/form/placement/placement-field.tsx
@@ -10,7 +10,7 @@ export const PlacementField = ({
   isEdit = false,
   fields,
   defaultValue,
-  availableLocations = []
+  availableLocations = [],
 }: {
   fields: ReturnType<typeof useForm<PlacementFieldSchema>>[1]
   defaultValue?: PlacementFieldSchema

--- a/app/features/workload/status.tsx
+++ b/app/features/workload/status.tsx
@@ -56,7 +56,7 @@ export const WorkloadStatus = ({
     // Initial load if:
     // 1. No current status exists, or
     // 2. Current status is pending
-    if (!currentStatus || currentStatus?.isReady === ControlPlaneStatus.Pending) {
+    if (!currentStatus || currentStatus?.status === ControlPlaneStatus.Pending) {
       loadStatus(id, workloadType)
 
       // Set up polling interval
@@ -73,10 +73,9 @@ export const WorkloadStatus = ({
 
   useEffect(() => {
     if (fetcher.data) {
-      const { isReady } = fetcher.data as IControlPlaneStatus
+      const { status } = fetcher.data as IControlPlaneStatus
       if (
-        (isReady === ControlPlaneStatus.Success ||
-          isReady === ControlPlaneStatus.Error) &&
+        (status === ControlPlaneStatus.Success || status === ControlPlaneStatus.Error) &&
         intervalRef.current
       ) {
         clearInterval(intervalRef.current)
@@ -91,7 +90,7 @@ export const WorkloadStatus = ({
       showTooltip={showTooltip}
       badgeClassName={badgeClassName}
       tooltipText={
-        fetcher.data?.isReady === ControlPlaneStatus.Success ? 'Active' : undefined
+        fetcher.data?.status === ControlPlaneStatus.Success ? 'Active' : undefined
       }
       readyText={readyText}
     />

--- a/app/layouts/dashboard/sidebar/nav-main.tsx
+++ b/app/layouts/dashboard/sidebar/nav-main.tsx
@@ -118,7 +118,9 @@ export const NavMain = forwardRef<
             <DropdownMenuTrigger asChild>
               <SidebarMenuButton
                 tooltip={item.title}
-                isActive={isActive || hasActiveChild}>
+                isActive={isActive || hasActiveChild}
+                disabled={item.disabled}
+                className={cn(item.disabled && 'pointer-events-none opacity-50')}>
                 {item.icon && <item.icon />}
               </SidebarMenuButton>
             </DropdownMenuTrigger>
@@ -207,7 +209,9 @@ export const NavMain = forwardRef<
               <CollapsibleTrigger asChild className="w-full">
                 <SidebarMenuButton
                   tooltip={item.title}
-                  isActive={isActive || hasActiveChild}>
+                  isActive={isActive || hasActiveChild}
+                  disabled={item.disabled}
+                  className={cn(item.disabled && 'pointer-events-none opacity-50')}>
                   {item?.icon && <item.icon />}
                   <span>{item.title}</span>
                   <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
@@ -237,7 +241,10 @@ export const NavMain = forwardRef<
         className="group/collapsible">
         <SidebarMenuItem key={`collapsible-sidebar-${currentItem.title}-${currentLevel}`}>
           <CollapsibleTrigger asChild className="w-full">
-            <SidebarMenuButton tooltip={currentItem.title}>
+            <SidebarMenuButton
+              tooltip={currentItem.title}
+              disabled={currentItem.disabled}
+              className={cn(currentItem.disabled && 'pointer-events-none opacity-50')}>
               {currentItem?.icon && <currentItem.icon />}
               <span>{currentItem.title}</span>
               <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
@@ -265,8 +272,12 @@ export const NavMain = forwardRef<
             asChild
             tooltip={item.title}
             isActive={isActive && !hasActiveChild}
+            disabled={item.disabled}
             onClick={() => hasChildren && toggleItem(item.href as string)}
-            className="data-[active=true]:text-primary">
+            className={cn(
+              'data-[active=true]:text-primary',
+              item.disabled && 'pointer-events-none opacity-50',
+            )}>
             {item.type === 'externalLink' ? (
               <a
                 href={item.href || ''}

--- a/app/resources/interfaces/control-plane.interface.ts
+++ b/app/resources/interfaces/control-plane.interface.ts
@@ -5,7 +5,7 @@ export enum ControlPlaneStatus {
 }
 
 export interface IControlPlaneStatus {
-  isReady: ControlPlaneStatus
+  status: ControlPlaneStatus
   message: string
   // For Parsing any additional fields
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/routes/_private+/$orgId+/projects.$projectId+/_deploy+/workloads+/$workloadId+/overview.tsx
+++ b/app/routes/_private+/$orgId+/projects.$projectId+/_deploy+/workloads+/$workloadId+/overview.tsx
@@ -105,7 +105,7 @@ export default function WorkloadOverviewPage() {
   const isWorkloadReady: boolean = useMemo(() => {
     if (workload) {
       const status: IControlPlaneStatus = transformControlPlaneStatus(workload.status)
-      return status.isReady === ControlPlaneStatus.Success
+      return status.status === ControlPlaneStatus.Success
     }
     return false
   }, [workload])
@@ -117,7 +117,7 @@ export default function WorkloadOverviewPage() {
         (instance: IInstanceControlResponse) =>
           transformControlPlaneStatus(instance.status),
       )
-      return statuses.every((status) => status.isReady === ControlPlaneStatus.Success)
+      return statuses.every((status) => status.status === ControlPlaneStatus.Success)
     }
     return false
   }, [instances])
@@ -131,7 +131,7 @@ export default function WorkloadOverviewPage() {
       )
 
       // Check if all deployments are ready
-      return statuses?.every((status) => status.isReady === ControlPlaneStatus.Success)
+      return statuses?.every((status) => status.status === ControlPlaneStatus.Success)
     }
     return false
   }, [deployments])

--- a/app/routes/_private+/$orgId+/projects.$projectId+/_layout.tsx
+++ b/app/routes/_private+/$orgId+/projects.$projectId+/_layout.tsx
@@ -8,8 +8,10 @@ import { useApp } from '@/providers/app.provider'
 import { createProjectsControl } from '@/resources/control-plane/projects.control'
 import { OrganizationModel } from '@/resources/gql/models/organization.model'
 import { createOrganizationGql } from '@/resources/gql/organization.gql'
+import { ControlPlaneStatus } from '@/resources/interfaces/control-plane.interface'
 import { IProjectControlResponse } from '@/resources/interfaces/project.interface'
 import { CustomError } from '@/utils/errorHandle'
+import { transformControlPlaneStatus } from '@/utils/misc'
 import { getPathWithParams } from '@/utils/path'
 import { redirectWithToast } from '@/utils/toast'
 import { Client } from '@hey-api/client-axios'
@@ -23,7 +25,7 @@ import {
   ShieldCheckIcon,
   TerminalIcon,
 } from 'lucide-react'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { AppLoadContext, Outlet, redirect, useLoaderData } from 'react-router'
 
 export const loader = withMiddleware(async ({ params, context }) => {
@@ -76,8 +78,15 @@ export default function ProjectLayout() {
   const project: IProjectControlResponse = useLoaderData<typeof loader>()
   const { orgId } = useApp()
 
+  useEffect(() => {
+    console.log(project)
+  }, [project])
+
   const navItems: NavItem[] = useMemo(() => {
+    const currentStatus = transformControlPlaneStatus(project.status)
+    const isReady = currentStatus.status === ControlPlaneStatus.Success
     const projectId = project.name
+
     return [
       {
         title: 'Dashboard',
@@ -93,12 +102,14 @@ export default function ProjectLayout() {
         href: getPathWithParams(routes.projects.locations.root, { orgId, projectId }),
         type: 'link',
         icon: MapIcon,
+        disabled: !isReady,
       },
       {
         title: 'Config',
         href: getPathWithParams(routes.projects.config.root, { orgId, projectId }),
         type: 'collapsible',
         icon: BoltIcon,
+        disabled: !isReady,
         children: [
           {
             title: 'Config Maps',
@@ -126,6 +137,7 @@ export default function ProjectLayout() {
         }),
         type: 'collapsible',
         icon: GlobeIcon,
+        disabled: !isReady,
         children: [
           {
             title: 'Networks',
@@ -174,6 +186,7 @@ export default function ProjectLayout() {
         }),
         type: 'collapsible',
         icon: TerminalIcon,
+        disabled: !isReady,
         children: [
           {
             title: 'Workloads',
@@ -198,6 +211,7 @@ export default function ProjectLayout() {
         href: getPathWithParams(routes.projects.observe.root, { orgId, projectId }),
         type: 'collapsible',
         icon: AreaChartIcon,
+        disabled: !isReady,
         children: [
           {
             title: 'Metrics',
@@ -229,6 +243,7 @@ export default function ProjectLayout() {
         href: getPathWithParams(routes.projects.iam, { orgId, projectId }),
         type: 'collapsible',
         icon: ShieldCheckIcon,
+        disabled: !isReady,
         children: [
           {
             title: 'IAM Policies',

--- a/app/routes/_private+/$orgId+/projects.$projectId+/dashboard.tsx
+++ b/app/routes/_private+/$orgId+/projects.$projectId+/dashboard.tsx
@@ -41,7 +41,7 @@ export default function ProjectDashboardPage() {
     }
 
     // Only start new interval if status is Pending
-    if (status?.isReady === ControlPlaneStatus.Pending) {
+    if (status?.status === ControlPlaneStatus.Pending) {
       intervalId.current = setInterval(revalidate, REVALIDATE_INTERVAL)
     }
 
@@ -72,7 +72,7 @@ export default function ProjectDashboardPage() {
             </div>
             <p className="text-muted-foreground text-xl">{project.name}</p>
           </div>
-          {status?.isReady === ControlPlaneStatus.Pending && (
+          {status?.status === ControlPlaneStatus.Pending && (
             <SectionDescription>
               {status.message}
               <span className="ml-1 inline-flex after:animate-[ellipsis_1s_steps(4,end)_infinite] after:content-['.']"></span>
@@ -80,7 +80,7 @@ export default function ProjectDashboardPage() {
           )}
         </div>
 
-        {status?.isReady === ControlPlaneStatus.Success ? (
+        {status?.status === ControlPlaneStatus.Success ? (
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -199,7 +199,7 @@ export function transformControlPlaneStatus(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   status: any,
 ): IControlPlaneStatus {
-  if (!status) return { isReady: ControlPlaneStatus.Pending, message: '' }
+  if (!status) return { status: ControlPlaneStatus.Pending, message: '' }
 
   const { conditions, ...rest } = status
   if (status && (conditions ?? []).length > 0) {
@@ -209,7 +209,7 @@ export function transformControlPlaneStatus(
     //   : false
     const isFailed = false
     return {
-      isReady:
+      status:
         condition?.status === 'True'
           ? ControlPlaneStatus.Success
           : isFailed
@@ -221,7 +221,7 @@ export function transformControlPlaneStatus(
   }
 
   return {
-    isReady: ControlPlaneStatus.Pending,
+    status: ControlPlaneStatus.Pending,
     message: 'Resource is being provisioned...',
   }
 }


### PR DESCRIPTION
This PR implements the following changes:

- Renamed isReady to status in IControlPlaneStatus interface for better semantics
- Added disabled state to sidebar navigation items when project is not ready
- Updated all components to use the new status property
- Improved UX by preventing access to project features during creation

This change ensures that users cannot access project features while the project is still being created, providing better UX and preventing potential errors.