### PR TITLE
refactor: simplify project description & remove unused route

### DIFF
--- a/app/constants/routes.ts
+++ b/app/constants/routes.ts
@@ -20,7 +20,6 @@ export const routes = {
     projects: {
       root: '/[orgId]/projects',
       new: '/[orgId]/projects/new',
-      setup: '/[orgId]/projects/setup',
     },
   },
   account: {

--- a/app/resources/control-plane/projects.control.ts
+++ b/app/resources/control-plane/projects.control.ts
@@ -22,8 +22,9 @@ export const createProjectsControl = (client: Client) => {
     project: ComMiloapisResourcemanagerV1Alpha1Project
   ): IProjectControlResponse => {
     const metadata = {
-      name: project?.metadata?.name ?? '',
-      description: project?.metadata?.annotations?.['kubernetes.io/description'] ?? '',
+      name: project?.metadata?.name,
+      description:
+        project?.metadata?.annotations?.['kubernetes.io/description'] ?? project?.metadata?.name,
       createdAt: project?.metadata?.creationTimestamp ?? new Date(),
       organizationId: project?.spec?.ownerRef?.name ?? '',
       resourceVersion: project?.metadata?.resourceVersion ?? '',

--- a/app/routes/_private+/$orgId+/_main+/projects+/_index.tsx
+++ b/app/routes/_private+/$orgId+/_main+/projects+/_index.tsx
@@ -68,8 +68,7 @@ export default function ProjectsPage() {
             <Link
               className={cn(
                 'text-primary leading-none font-semibold',
-                isDeleted && 'pointer-events-none',
-                !row.original.description && 'italic'
+                isDeleted && 'pointer-events-none'
               )}
               to={
                 isDeleted
@@ -79,7 +78,7 @@ export default function ProjectsPage() {
                       projectId: row.original.name,
                     })
               }>
-              {row.original.description ?? 'No description'}
+              {row.original.description}
             </Link>
           );
         },
@@ -87,23 +86,6 @@ export default function ProjectsPage() {
       {
         header: 'Name',
         accessorKey: 'name',
-        cell: ({ row }) => {
-          const isDeleted = Boolean(row.original.name && row.original.name === deletedId);
-          return (
-            <Link
-              className={cn(isDeleted && 'pointer-events-none')}
-              to={
-                isDeleted
-                  ? '#'
-                  : getPathWithParams(routes.projects.detail, {
-                      orgId,
-                      projectId: row.original.name,
-                    })
-              }>
-              {row.original.name}
-            </Link>
-          );
-        },
       },
       {
         header: 'Status',

--- a/app/routes/_private+/$orgId+/_main+/projects+/new.tsx
+++ b/app/routes/_private+/$orgId+/_main+/projects+/new.tsx
@@ -50,11 +50,10 @@ export const action = withMiddleware(async ({ request, params, context }: Action
     // Invalidate the projects cache
     await cache.removeItem(`projects:${payload.orgEntityId}`);
 
-    // TODO: temporary solution for handle delay on new project
-    // https://github.com/datum-cloud/cloud-portal/issues/45
     return redirectWithToast(
-      getPathWithParams(`${routes.org.projects.setup}?projectId=${payload.name}`, {
+      getPathWithParams(routes.projects.detail, {
         orgId: params.orgId,
+        projectId: payload.name,
       }),
       {
         title: 'Project created successfully!',


### PR DESCRIPTION
- Removed the unused '/[orgId]/projects/setup' route from constants.
- Updated project description logic: fallback to project name if description annotation is missing.
- Cleaned up project list UI:
  - Removed redundant 'Name' column link logic.
  - Always show project description (no more 'No description' fallback).
- Updated project creation redirect to go directly to the project detail page, removing the temporary setup redirect.

Closes https://github.com/datum-cloud/cloud-portal/issues/420, https://github.com/datum-cloud/cloud-portal/issues/421