### PR TITLE
feat: Add activity logs to account and organization settings

### DIFF
--- a/app/components/data-table/data-table.tsx
+++ b/app/components/data-table/data-table.tsx
@@ -125,7 +125,11 @@ export const DataTable = <TData, TValue>({
       columnVisibility={{}}
       enableColumnOrdering={false}
       isLoading={undefined}>
-      <div className={cn('flex h-full w-full flex-col gap-4', className)}>
+      <div
+        className={cn(
+          'mx-auto flex h-full w-full max-w-(--breakpoint-xl) flex-col gap-4',
+          className
+        )}>
         {isLoading ? (
           <DataTableLoadingContent title={loadingText} />
         ) : data?.length > 0 ? (

--- a/app/constants/routes.ts
+++ b/app/constants/routes.ts
@@ -11,10 +11,8 @@ export const routes = {
     root: '/[orgId]/dashboard',
     docs: '/[orgId]/docs',
     settings: {
-      root: '/[orgId]/settings',
-      general: '/[orgId]/settings/general',
-      members: '/[orgId]/settings/members',
-      billing: '/[orgId]/settings/billing',
+      root: '/[orgId]/preferences',
+      activity: '/[orgId]/activity',
     },
     projects: {
       root: '/[orgId]/projects',
@@ -32,7 +30,8 @@ export const routes = {
       root: '/account/api-keys',
       new: '/account/api-keys/new',
     },
-    settings: '/account/settings',
+    preferences: '/account/preferences',
+    activity: '/account/activity',
   },
   projects: {
     detail: '/[orgId]/projects/[projectId]',

--- a/app/features/activity-log/list.tsx
+++ b/app/features/activity-log/list.tsx
@@ -4,36 +4,52 @@ import type { ActivityLogEntry, QueryParams } from '@/modules/loki/types';
 import { ROUTE_PATH as ACTIVITY_LOGS_ROUTE_PATH } from '@/routes/api+/activity-logs';
 import { ColumnDef } from '@tanstack/react-table';
 import { useMemo, useEffect, useState } from 'react';
-import { useFetcher, useParams } from 'react-router';
+import { useFetcher } from 'react-router';
 import { toast } from 'sonner';
 
-export const ActivityLogList = () => {
+export const ActivityLogList = ({
+  params,
+  title,
+  className,
+}: {
+  params?: QueryParams;
+  title?: string;
+  className?: string;
+}) => {
   const fetcher = useFetcher<{
     success: boolean;
     message?: string;
     data: { logs: ActivityLogEntry[] };
   }>({ key: 'activity-logs' });
-  const params = useParams();
-
   const [logs, setLogs] = useState<ActivityLogEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Fetch activity logs on component mount
-  useEffect(() => {
-    if (params.projectId) {
-      const queryParams: QueryParams = {
-        project: params.projectId,
-        start: '7d',
-        limit: '1000',
-        // Only Write operations
-        actions: 'create,update,patch,delete,deletecollection',
-      };
+  // Memoize the query parameters to prevent infinite re-renders
+  const queryParams = useMemo(
+    () => ({
+      start: '7d',
+      limit: '1000',
+      // Only Write operations
+      actions: 'create,update,patch,delete,deletecollection',
+      stage: 'ResponseComplete',
+      excludeDryRun: true,
+      ...(params ?? {}),
+    }),
+    [params?.project, params?.user, params?.q, params?.resource, params?.status, params?.actions]
+  );
 
-      fetcher.load(
-        `${ACTIVITY_LOGS_ROUTE_PATH}?${new URLSearchParams(queryParams as Record<string, string>).toString()}`
-      );
-    }
-  }, [params.projectId]);
+  // Fetch activity logs when query parameters change
+  useEffect(() => {
+    // Convert QueryParams to string record for URLSearchParams
+    const stringParams: Record<string, string> = {};
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        stringParams[key] = String(value);
+      }
+    });
+
+    fetcher.load(`${ACTIVITY_LOGS_ROUTE_PATH}?${new URLSearchParams(stringParams).toString()}`);
+  }, [queryParams]);
 
   const columns: ColumnDef<ActivityLogEntry>[] = useMemo(
     () => [
@@ -66,23 +82,20 @@ export const ActivityLogList = () => {
   }, [fetcher.data, fetcher.state]);
 
   return (
-    <div className="mx-auto flex h-full w-full max-w-3xl flex-col gap-6">
-      <DataTable
-        hideHeader
-        mode="card"
-        columns={columns}
-        data={logs}
-        emptyContent={{
-          title: 'No activity found.',
-        }}
-        tableTitle={{
-          title: 'Activity',
-        }}
-        tableClassName="table-fixed"
-        isLoading={isLoading}
-        loadingText="Loading activity..."
-        tableCardClassName="px-3 py-2"
-      />
-    </div>
+    <DataTable
+      hideHeader
+      mode="card"
+      columns={columns}
+      data={logs}
+      emptyContent={{
+        title: 'No activity found.',
+      }}
+      tableTitle={title ? { title } : undefined}
+      tableClassName="table-fixed"
+      isLoading={isLoading}
+      loadingText="Loading activity..."
+      tableCardClassName="px-3 py-2"
+      className={className}
+    />
   );
 };

--- a/app/features/edge/httpproxy/form.tsx
+++ b/app/features/edge/httpproxy/form.tsx
@@ -15,7 +15,6 @@ import { useConfirmationDialog } from '@/providers/confirmationDialog.provider';
 import { IHttpProxyControlResponse } from '@/resources/interfaces/http-proxy.interface';
 import { httpProxySchema } from '@/resources/schemas/http-proxy.schema';
 import { ROUTE_PATH as HTTP_PROXIES_ACTIONS_PATH } from '@/routes/api+/edge+/httpproxy+/actions';
-import { generateRandomString } from '@/utils/idGenerator';
 import {
   FormProvider,
   getFormProps,
@@ -43,33 +42,6 @@ export const HttpProxyForm = ({
   const submit = useSubmit();
 
   const inputRef = useRef<HTMLInputElement>(null);
-
-  /**
-   * Generates a resource name from an endpoint URL
-   * Handles both domain names and IP addresses
-   */
-  /* const generateNameFromEndpoint = (endpoint: string, randomSuffix: string): string => {
-    try {
-      // Add protocol if missing to make URL parsing work
-      const urlString = endpoint.includes('://') ? endpoint : `http://${endpoint}`;
-      const hostname = new URL(urlString).hostname;
-
-      // Check if the hostname is an IP address
-      const isIpAddress = /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname);
-
-      if (isIpAddress) {
-        // For IP addresses, use "ip-" prefix and replace dots with dashes
-        const ipFormatted = `ip-${hostname}`;
-        return generateId(ipFormatted, { randomText: randomSuffix });
-      } else {
-        // For regular domains
-        return generateId(hostname, { randomText: randomSuffix });
-      }
-    } catch {
-      // Fallback if URL parsing fails
-      return generateId(endpoint, { randomText: randomSuffix });
-    }
-  }; */
 
   const isEdit = useMemo(() => {
     return defaultValue?.uid !== undefined;
@@ -118,7 +90,6 @@ export const HttpProxyForm = ({
 
   const nameControl = useInputControl(fields.name);
   const endpointControl = useInputControl(fields.endpoint);
-  const randomSuffix = useMemo(() => generateRandomString(6), []);
 
   useEffect(() => {
     isHydrated && inputRef.current?.focus();

--- a/app/features/organization/settings/general-card.tsx
+++ b/app/features/organization/settings/general-card.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { useIsPending } from '@/hooks/useIsPending';
-import { IOrganization } from '@/resources/interfaces/organization.interface';
+import { IOrganization, OrganizationType } from '@/resources/interfaces/organization.interface';
 import { updateOrganizationSchema } from '@/resources/schemas/organization.schema';
 import { FormProvider, getFormProps, getInputProps, useForm } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
@@ -61,28 +61,34 @@ export const OrganizationGeneralCard = ({ organization }: { organization: IOrgan
 
             <div className="flex flex-col gap-6">
               <Field isRequired label="Description" errors={fields.description?.errors}>
-                <Input
-                  placeholder="e.g. My Organization"
-                  {...getInputProps(fields.description, { type: 'text' })}
-                />
+                {organization && organization?.type === OrganizationType.Personal ? (
+                  <TextCopyBox value={organization?.displayName ?? ''} />
+                ) : (
+                  <Input
+                    placeholder="e.g. My Organization"
+                    {...getInputProps(fields.description, { type: 'text' })}
+                  />
+                )}
               </Field>
               <Field label="Name">
                 <TextCopyBox value={organization?.name ?? ''} />
               </Field>
             </div>
           </CardContent>
-          <CardFooter className="flex justify-end gap-2">
-            {/* <Button type="button" variant="link" disabled={isPending} onClick={handleReset}>
+          {organization && organization?.type !== OrganizationType.Personal && (
+            <CardFooter className="flex justify-end gap-2">
+              {/* <Button type="button" variant="link" disabled={isPending} onClick={handleReset}>
               Cancel
             </Button> */}
-            <Button
-              variant="default"
-              type="submit"
-              disabled={isPending || !form.valid}
-              isLoading={isPending}>
-              {isPending ? 'Saving' : 'Save'}
-            </Button>
-          </CardFooter>
+              <Button
+                variant="default"
+                type="submit"
+                disabled={isPending || !form.valid}
+                isLoading={isPending}>
+                {isPending ? 'Saving' : 'Save'}
+              </Button>
+            </CardFooter>
+          )}
         </fetcher.Form>
       </FormProvider>
     </Card>

--- a/app/layouts/dashboard/dashboard.tsx
+++ b/app/layouts/dashboard/dashboard.tsx
@@ -27,7 +27,7 @@ export function DashboardLayout({
       <DashboardSidebar navItems={navItems} collapsible={sidebarCollapsible} />
       <SidebarInset>
         <Header currentProject={currentProject} title={headerTitle} />
-        <div className="mx-auto flex h-full w-full max-w-(--breakpoint-xl) flex-1 flex-col gap-6 px-6 py-5">
+        <div className="mx-auto flex h-full w-full flex-1 flex-col gap-6 px-6 py-5">
           {/* <Breadcrumb /> */}
           <div className={cn('flex max-w-full flex-1 flex-col gap-4', className)}>{children}</div>
         </div>

--- a/app/layouts/dashboard/header/user-dropdown.tsx
+++ b/app/layouts/dashboard/header/user-dropdown.tsx
@@ -76,9 +76,9 @@ export const UserDropdown = () => {
         <DropdownMenuGroup>
           <DropdownMenuItem
             className="cursor-pointer"
-            onClick={() => navigate(routes.account.settings)}>
+            onClick={() => navigate(routes.account.preferences)}>
             <UserCogIcon />
-            Account Settings
+            Account preferences
           </DropdownMenuItem>
         </DropdownMenuGroup>
 

--- a/app/layouts/tabs/tabs.tsx
+++ b/app/layouts/tabs/tabs.tsx
@@ -10,7 +10,7 @@ export default function TabsLayout({
   className,
   widthClassName = 'w-full max-w-5xl',
   tabsTitle,
-  navs,
+  navItems,
 }: TabsProps) {
   const pathname = useLocation().pathname;
 
@@ -40,7 +40,7 @@ export default function TabsLayout({
         <div className={cn('mx-auto px-5', widthClassName)}>
           <Tabs value={activeTab}>
             <TabsList className="bg-background flex w-full justify-start rounded-none p-0">
-              {(navs ?? []).map((nav) => (
+              {(navItems ?? []).map((nav) => (
                 <TabsLinkTrigger
                   key={nav.value}
                   value={nav.value}
@@ -60,8 +60,8 @@ export default function TabsLayout({
         </div>
       </div>
 
-      <div className={cn('mx-auto px-5', widthClassName)}>
-        <div className="flex flex-1 flex-col">{children}</div>
+      <div className={cn('mx-auto h-full px-5 pt-2', widthClassName)}>
+        <div className="flex h-full flex-1 flex-col">{children}</div>
       </div>
     </div>
   );

--- a/app/layouts/tabs/tabs.types.ts
+++ b/app/layouts/tabs/tabs.types.ts
@@ -5,7 +5,7 @@ export interface TabsProps {
   className?: string;
   widthClassName?: string;
   tabsTitle?: TabsTitleProps;
-  navs?: TabsNavProps[];
+  navItems?: TabsNavProps[];
 }
 
 export interface TabsNavProps {

--- a/app/modules/loki/client.ts
+++ b/app/modules/loki/client.ts
@@ -15,13 +15,35 @@ export const LOKI_CONFIG: LokiConfig = {
  * Builds LogQL query string with hybrid filtering approach
  */
 export function buildLogQLQuery(options: LogQLQueryOptions): string {
-  const { baseSelector, projectName, q, user, resource, status, actions } = options;
+  const {
+    baseSelector,
+    project,
+    user,
+    resource,
+    objectName,
+    apiGroup,
+    apiVersion,
+    status,
+    actions,
+    stage,
+    excludeDryRun,
+  } = options;
 
   let query = `${baseSelector} | json`;
 
+  // Add stage filter if specified
+  if (stage) {
+    query += ` | stage="${stage}"`;
+  }
+
+  // Add dry run exclusion filter if enabled
+  if (excludeDryRun) {
+    query += ` | requestURI !~ ".*dryRun=All.*"`;
+  }
+
   // Project filter (legacy support)
-  if (projectName) {
-    query += ` | annotations_resourcemanager_miloapis_com_project_name="${projectName}"`;
+  if (project) {
+    query += ` | annotations_resourcemanager_miloapis_com_project_name="${project}"`;
   }
 
   // Filter for specific verbs using regex (if verbs parameter is provided)
@@ -45,8 +67,21 @@ export function buildLogQLQuery(options: LogQLQueryOptions): string {
     query += ` | user_username="${user}"`;
   }
 
+  // ObjectRef filtering - complete Kubernetes resource identification
   if (resource) {
     query += ` | objectRef_resource="${resource}"`;
+  }
+
+  if (objectName) {
+    query += ` | objectRef_name="${objectName}"`;
+  }
+
+  if (apiGroup) {
+    query += ` | objectRef_apiGroup="${apiGroup}"`;
+  }
+
+  if (apiVersion) {
+    query += ` | objectRef_apiVersion="${apiVersion}"`;
   }
 
   if (status) {

--- a/app/modules/loki/service.ts
+++ b/app/modules/loki/service.ts
@@ -23,10 +23,9 @@ export class LokiActivityLogsService {
   async getActivityLogs(queryParams: QueryParams): Promise<ActivityLogsResponse> {
     // Validate and sanitize parameters
     const validatedParams = validateQueryParams(queryParams);
-    const projectName = queryParams.project;
 
     // Log the parameters for debugging
-    console.log('Loki query parameters:', { ...validatedParams, projectName });
+    console.log('Loki query parameters:', { ...validatedParams });
 
     // Create Loki client
     const client = createLokiClient(this.accessToken);
@@ -34,13 +33,18 @@ export class LokiActivityLogsService {
     // Build LogQL query
     const logQuery = buildLogQLQuery({
       baseSelector: '{telemetry_datumapis_com_audit_log="true"}',
-      projectName,
-      // Hybrid filtering approach
+      // Hybrid filtering approach with type conversion
+      project: queryParams.project,
       q: queryParams.q,
       user: queryParams.user,
       resource: queryParams.resource,
+      objectName: queryParams.objectName,
+      apiGroup: queryParams.apiGroup,
+      apiVersion: queryParams.apiVersion,
       status: queryParams.status,
       actions: queryParams.actions,
+      stage: queryParams.stage,
+      excludeDryRun: queryParams.excludeDryRun, // Pass boolean directly
     });
 
     // Execute query

--- a/app/modules/loki/types.ts
+++ b/app/modules/loki/types.ts
@@ -17,8 +17,15 @@ export interface QueryParams {
   // Hybrid filtering approach
   q?: string; // Flexible search across multiple fields (user, resource, action, etc.)
   user?: string; // Specific user filter
-  resource?: string; // Specific resource type filter
+  // ObjectRef filtering - supports complete Kubernetes resource identification
+  resource?: string; // objectRef_resource (e.g., "organizations", "locations")
+  objectName?: string; // objectRef_name (e.g., "personal-org-793a7f9c")
+  apiGroup?: string; // objectRef_apiGroup (e.g., "resourcemanager.miloapis.com")
+  apiVersion?: string; // objectRef_apiVersion (e.g., "v1alpha1")
   status?: string; // Status filter (success, error, or specific codes like 403)
+  // Loki-specific filtering
+  stage?: string; // Audit log stage filter (default: "ResponseComplete")
+  excludeDryRun?: boolean; // Exclude dry run requests (default: true)
   /**
    * Action filter
    * get - Read a specific resource
@@ -95,13 +102,20 @@ export interface ActivityLogsResponse {
 
 export interface LogQLQueryOptions {
   baseSelector: string;
-  projectName?: string;
   // Hybrid filtering approach
   q?: string; // Flexible search across multiple fields
+  project?: string;
   user?: string; // Specific user filter
   action?: string; // Specific action filter
-  resource?: string; // Specific resource type filter
+  // ObjectRef filtering - supports complete Kubernetes resource identification
+  resource?: string; // objectRef_resource (e.g., "organizations", "locations")
+  objectName?: string; // objectRef_name (e.g., "personal-org-793a7f9c")
+  apiGroup?: string; // objectRef_apiGroup (e.g., "resourcemanager.miloapis.com")
+  apiVersion?: string; // objectRef_apiVersion (e.g., "v1alpha1")
   status?: string; // Status filter (success, error, or specific codes)
+  // Loki-specific filtering
+  stage?: string; // Audit log stage filter (default: "ResponseComplete")
+  excludeDryRun?: boolean; // Exclude dry run requests (default: true)
   actions?: string; // Comma-separated list of verbs to filter (e.g., "create,update,delete")
 }
 

--- a/app/routes/_private+/$orgId+/_main+/_layout.tsx
+++ b/app/routes/_private+/$orgId+/_main+/_layout.tsx
@@ -12,15 +12,10 @@ export default function OrgLayout() {
 
   const navItems: NavItem[] = useMemo(() => {
     const orgId = organization?.name;
+    const settingsRoot = getPathWithParams(routes.org.settings.root, { orgId });
+    const settingsActivity = getPathWithParams(routes.org.settings.activity, { orgId });
+
     return [
-      /*      {
-        title: 'Home',
-        href: getPathWithParams(routes.org.root, {
-          orgId,
-        }),
-        type: 'link',
-        icon: HomeIcon,
-      }, */
       {
         title: 'Projects',
         href: getPathWithParams(routes.org.projects.root, { orgId }),
@@ -29,9 +24,10 @@ export default function OrgLayout() {
       },
       {
         title: 'Organization settings',
-        href: getPathWithParams(routes.org.settings.root, { orgId }),
+        href: settingsRoot,
         type: 'link',
         icon: SettingsIcon,
+        tabChildLinks: [settingsRoot, settingsActivity],
       },
     ];
   }, [organization]);

--- a/app/routes/_private+/$orgId+/_main+/_settings+/_layout.tsx
+++ b/app/routes/_private+/$orgId+/_main+/_settings+/_layout.tsx
@@ -1,0 +1,31 @@
+import { routes } from '@/constants/routes';
+import TabsLayout from '@/layouts/tabs/tabs';
+import { TabsNavProps } from '@/layouts/tabs/tabs.types';
+import { useApp } from '@/providers/app.provider';
+import { getPathWithParams } from '@/utils/path';
+import { useMemo } from 'react';
+import { Outlet } from 'react-router';
+
+export default function OrgSettingsLayout() {
+  const { organization } = useApp();
+  const navItems: TabsNavProps[] = useMemo(
+    () => [
+      {
+        value: 'preferences',
+        label: 'Preferences',
+        to: getPathWithParams(routes.org.settings.root, { orgId: organization?.name }),
+      },
+      {
+        value: 'activity',
+        label: 'Activity',
+        to: getPathWithParams(routes.org.settings.activity, { orgId: organization?.name }),
+      },
+    ],
+    [organization]
+  );
+  return (
+    <TabsLayout tabsTitle={{ title: 'Organization Settings' }} navItems={navItems}>
+      <Outlet />
+    </TabsLayout>
+  );
+}

--- a/app/routes/_private+/$orgId+/_main+/_settings+/activity.tsx
+++ b/app/routes/_private+/$orgId+/_main+/_settings+/activity.tsx
@@ -1,0 +1,16 @@
+import { ActivityLogList } from '@/features/activity-log/list';
+import { mergeMeta, metaObject } from '@/utils/meta';
+import { MetaFunction, useParams } from 'react-router';
+
+export const handle = {
+  breadcrumb: () => <span>Activity</span>,
+};
+
+export const meta: MetaFunction = mergeMeta(() => {
+  return metaObject('Activity');
+});
+
+export default function OrgActivityPage() {
+  const { orgId } = useParams();
+  return <ActivityLogList params={{ resource: 'organizations', objectName: orgId }} />;
+}

--- a/app/routes/_private+/$orgId+/_main+/_settings+/preferences.tsx
+++ b/app/routes/_private+/$orgId+/_main+/_settings+/preferences.tsx
@@ -1,4 +1,3 @@
-import { PageTitle } from '@/components/page-title/page-title';
 import { OrganizationDangerCard } from '@/features/organization/settings/danger-card';
 import { OrganizationGeneralCard } from '@/features/organization/settings/general-card';
 import { validateCSRF } from '@/modules/cookie/csrf.server';
@@ -17,11 +16,11 @@ import { Client } from '@hey-api/client-axios';
 import { ActionFunctionArgs, AppLoadContext, MetaFunction } from 'react-router';
 
 export const handle = {
-  breadcrumb: () => <span>Organization Settings</span>,
+  breadcrumb: () => <span>Preferences</span>,
 };
 
 export const meta: MetaFunction = mergeMeta(() => {
-  return metaObject('Organization Settings');
+  return metaObject('Preferences');
 });
 
 export const action = async ({ request, params, context }: ActionFunctionArgs) => {
@@ -74,18 +73,13 @@ export const action = async ({ request, params, context }: ActionFunctionArgs) =
   }
 };
 
-export default function OrgSettingsPage() {
+export default function OrgPreferencesPage() {
   const { organization } = useApp();
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
-      <PageTitle title="Organization Settings" />
-
+    <div className="mx-auto flex w-full flex-col gap-4">
       {/* General Settings */}
       <OrganizationGeneralCard organization={organization ?? {}} />
-
-      {/* Labels */}
-      {/* <OrganizationLabelCard labels={organization?.labels ?? {}} /> */}
 
       {/* Danger Zone */}
       {organization && organization?.type !== OrganizationType.Personal ? (

--- a/app/routes/_private+/$orgId+/_main+/projects+/_layout.tsx
+++ b/app/routes/_private+/$orgId+/_main+/projects+/_layout.tsx
@@ -1,9 +1,0 @@
-import { Outlet } from 'react-router';
-
-export const handle = {
-  breadcrumb: () => <span>Projects</span>,
-};
-
-export default function ProjectsLayout() {
-  return <Outlet />;
-}

--- a/app/routes/_private+/$orgId+/projects.$projectId+/activity.tsx
+++ b/app/routes/_private+/$orgId+/projects.$projectId+/activity.tsx
@@ -1,5 +1,8 @@
 import { ActivityLogList } from '@/features/activity-log/list';
+import { useParams } from 'react-router';
 
 export default function ProjectActivityLogsPage() {
-  return <ActivityLogList />;
+  const { projectId } = useParams();
+
+  return <ActivityLogList params={{ project: projectId }} title="Activity" className="max-w-3xl" />;
 }

--- a/app/routes/_private+/$orgId+/projects.$projectId+/settings.tsx
+++ b/app/routes/_private+/$orgId+/projects.$projectId+/settings.tsx
@@ -116,7 +116,7 @@ export default function ProjectSettingsPage() {
   const project = useRouteLoaderData('routes/_private+/$orgId+/projects.$projectId+/_layout');
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
       <PageTitle title="Project Settings" />
       {/* Project Name Section */}
       <ProjectGeneralCard project={project} />

--- a/app/routes/_private+/account+/_layout.tsx
+++ b/app/routes/_private+/account+/_layout.tsx
@@ -15,10 +15,11 @@ export default function AccountLayout() {
         icon: Building2Icon,
       },
       {
-        title: 'Account Settings',
-        href: routes.account.settings,
+        title: 'Account settings',
+        href: routes.account.preferences,
         type: 'link',
         icon: SettingsIcon,
+        tabChildLinks: [routes.account.preferences, routes.account.activity],
       },
     ];
   }, []);

--- a/app/routes/_private+/account+/_settings+/_layout.tsx
+++ b/app/routes/_private+/account+/_settings+/_layout.tsx
@@ -1,0 +1,24 @@
+import { routes } from '@/constants/routes';
+import TabsLayout from '@/layouts/tabs/tabs';
+import { TabsNavProps } from '@/layouts/tabs/tabs.types';
+import { Outlet } from 'react-router';
+
+export default function AccountSettingsLayout() {
+  const navItems: TabsNavProps[] = [
+    {
+      value: 'preferences',
+      label: 'Preferences',
+      to: routes.account.preferences,
+    },
+    {
+      value: 'activity',
+      label: 'Activity',
+      to: routes.account.activity,
+    },
+  ];
+  return (
+    <TabsLayout tabsTitle={{ title: 'Account Settings' }} navItems={navItems}>
+      <Outlet />
+    </TabsLayout>
+  );
+}

--- a/app/routes/_private+/account+/_settings+/activity.tsx
+++ b/app/routes/_private+/account+/_settings+/activity.tsx
@@ -1,0 +1,17 @@
+import { ActivityLogList } from '@/features/activity-log/list';
+import { useApp } from '@/providers/app.provider';
+import { mergeMeta, metaObject } from '@/utils/meta';
+import { MetaFunction } from 'react-router';
+
+export const handle = {
+  breadcrumb: () => <span>Activity</span>,
+};
+
+export const meta: MetaFunction = mergeMeta(() => {
+  return metaObject('Activity');
+});
+
+export default function AccountActivityPage() {
+  const { user } = useApp();
+  return <ActivityLogList params={{ user: user?.email }} />;
+}

--- a/app/routes/_private+/account+/_settings+/preferences.tsx
+++ b/app/routes/_private+/account+/_settings+/preferences.tsx
@@ -1,4 +1,3 @@
-import { PageTitle } from '@/components/page-title/page-title';
 import { routes } from '@/constants/routes';
 import { AccountGeneralCard } from '@/features/account/settings/general-card';
 import { validateCSRF } from '@/modules/cookie/csrf.server';
@@ -20,11 +19,11 @@ import {
 } from 'react-router';
 
 export const handle = {
-  breadcrumb: () => <span>Account settings</span>,
+  breadcrumb: () => <span>Preferences</span>,
 };
 
 export const meta: MetaFunction = mergeMeta(() => {
-  return metaObject('Account settings');
+  return metaObject('Preferences');
 });
 
 export const action = async ({ request, context }: ActionFunctionArgs) => {
@@ -65,7 +64,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   }
 };
 
-export default function AccountSettingsPage() {
+export default function AccountPreferencesPage() {
   const user = useActionData<typeof action>();
 
   const { setUser } = useApp();
@@ -76,11 +75,5 @@ export default function AccountSettingsPage() {
     }
   }, [user]);
 
-  return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
-      <PageTitle title="Account settings" />
-      {/* Project Name Section */}
-      <AccountGeneralCard />
-    </div>
-  );
+  return <AccountGeneralCard />;
 }

--- a/app/routes/_private+/account+/organizations+/_index.tsx
+++ b/app/routes/_private+/account+/organizations+/_index.tsx
@@ -32,7 +32,7 @@ export default function AccountOrganizations() {
       subtitle="You don't have any organizations"
     />
   ) : (
-    <>
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
       <PageTitle title="Your Organizations" />
       <div className="flex w-full flex-col gap-4">
         {(orgs ?? [])
@@ -50,6 +50,6 @@ export default function AccountOrganizations() {
 
         {/* <NewOrganizationCard /> */}
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive activity logs functionality to both account and organization settings, implementing a unified activity tracking system with enhanced filtering capabilities and improved navigation structure.

## Key Features Added

### 📊 Account & Organization Activity Logs
- **Account Activity Logs**: Added `/account/activity` route with user-specific activity filtering
- **Organization Activity Logs**: Added `/[orgId]/activity` route with organization-specific activity filtering
- **Enhanced Filtering**: Implemented complete Kubernetes objectRef filtering (resource, objectName, apiGroup, apiVersion)

### 🧭 Settings Navigation Enhancement
- **Account Settings**: Enhanced tabs navigation for preferences and activity
- **Organization Settings**: New tabs layout with preferences and activity sections

### 🎨 Organization Settings Improvements
- **Personal Organization Handling**: Read-only description field for personal organizations
- **Conditional Actions**: Hide save button for personal organizations where editing is restricted