### PR TITLE
fix: update login tests to use data-e2e attributes 

### DIFF
--- a/cypress/e2e/log-in.cy.ts
+++ b/cypress/e2e/log-in.cy.ts
@@ -13,7 +13,8 @@ describe('Log in', () => {
     // Check if we're redirected to the OIDC provider
     cy.url().should('include', Cypress.env('AUTH_OIDC_ISSUER'));
 
-    cy.contains('.provider-name', 'Google').should('be.visible');
-    cy.contains('.provider-name', 'GitHub').should('be.visible');
+    // Use data-e2e attributes for more reliable testing
+    cy.get('[e2e="google"]').should('be.visible');
+    cy.get('[e2e="github"]').should('be.visible');
   });
 });


### PR DESCRIPTION
- Replaced class selectors with data-e2e attributes for Google and GitHub provider visibility checks in the login test.
- This change enhances test reliability by reducing dependency on class names.
