### PR TITLE
refactor(routes): comment out policy bindings routes 

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -61,18 +61,18 @@ export default [
         ]),
 
         // Policy Bindings of an organization
-        route('policy-bindings/new', 'routes/org/detail/policy-bindings/new.tsx'),
+        /* route('policy-bindings/new', 'routes/org/detail/policy-bindings/new.tsx'),
         route(
           'policy-bindings/:policyBindingId/edit',
           'routes/org/detail/policy-bindings/edit.tsx'
-        ),
+        ), */
 
         // Settings of an organization
         layout('routes/org/detail/settings/layout.tsx', [
           route('preferences', 'routes/org/detail/settings/preferences.tsx'),
           route('quotas', 'routes/org/detail/settings/quotas.tsx'),
           route('activity', 'routes/org/detail/settings/activity.tsx'),
-          route('policy-bindings', 'routes/org/detail/settings/policy-bindings.tsx'),
+          // route('policy-bindings', 'routes/org/detail/settings/policy-bindings.tsx'),
         ]),
       ]),
     ]),
@@ -219,7 +219,7 @@ export default [
       route('activity', 'routes/api/activity/index.ts'),
 
       // Policy Bindings
-      route('policy-bindings', 'routes/api/policy-bindings/index.ts'),
+      // route('policy-bindings', 'routes/api/policy-bindings/index.ts'),
 
       // Groups
       route('groups', 'routes/api/groups/index.ts'),

--- a/app/routes/org/detail/layout.tsx
+++ b/app/routes/org/detail/layout.tsx
@@ -52,9 +52,9 @@ export default function OrgLayout() {
     const settingsPreferences = getPathWithParams(paths.org.detail.settings.preferences, { orgId });
     const settingsActivity = getPathWithParams(paths.org.detail.settings.activity, { orgId });
     const settingsQuotas = getPathWithParams(paths.org.detail.settings.quotas, { orgId });
-    const settingsPolicyBindings = getPathWithParams(paths.org.detail.policyBindings.root, {
-      orgId,
-    });
+    // const settingsPolicyBindings = getPathWithParams(paths.org.detail.policyBindings.root, {
+    //   orgId,
+    // });
 
     return [
       {
@@ -79,7 +79,7 @@ export default function OrgLayout() {
           settingsPreferences,
           settingsActivity,
           settingsQuotas,
-          settingsPolicyBindings,
+          // settingsPolicyBindings,
         ],
       },
     ];

--- a/app/routes/org/detail/settings/layout.tsx
+++ b/app/routes/org/detail/settings/layout.tsx
@@ -1,6 +1,6 @@
 import TabsLayout from '@/layouts/tabs/tabs';
 import { TabsNavProps } from '@/layouts/tabs/tabs.types';
-import { IOrganization, OrganizationType } from '@/resources/interfaces/organization.interface';
+import { IOrganization } from '@/resources/interfaces/organization.interface';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { useMemo } from 'react';
@@ -17,12 +17,12 @@ export default function OrgSettingsLayout() {
         label: 'Preferences',
         to: getPathWithParams(paths.org.detail.settings.preferences, { orgId }),
       },
-      {
+      /* {
         value: 'policy-bindings',
         label: 'Policy bindings',
         to: getPathWithParams(paths.org.detail.policyBindings.root, { orgId }),
         hidden: org?.type === OrganizationType.Personal,
-      },
+      }, */
       {
         value: 'quotas',
         label: 'Quotas',


### PR DESCRIPTION
- Commented out the 'policy-bindings' routes in the main routes file and the settings layout.
- Updated the organization detail layout to reflect the changes in policy bindings.
- This refactor prepares for potential future adjustments to the policy bindings feature.
