### PR TITLE
Change "DNS Providers" heading to "DNS Host"

### DIFF
--- a/app/routes/project/detail/edge/domains/index.tsx
+++ b/app/routes/project/detail/edge/domains/index.tsx
@@ -134,7 +134,7 @@ export default function DomainsPage() {
       },
       {
         id: 'nameservers',
-        header: 'DNS Providers',
+        header: 'DNS Host',
         accessorKey: 'nameservers',
         cell: ({ row }) => {
           return <DomainDnsProviders nameservers={row.original?.nameservers} maxVisible={2} />;


### PR DESCRIPTION
# Pull Request Guidelines

## Title

Change the `DNS Providers` heading in the domain window to `DNS Host`.

## Description

This is purely cosmetic, but it communicates a singular, more specific function that the vendor is currently serving rather than a more general purpose.

Opted to _not_ change all the code references to DomainDnsProviders due to unknown implications of that, but not opposed to it.