### PR TITLE
feat: enable organization deletion flow and improve organization listing

### DIFF
--- a/app/features/organization/settings/danger-card.tsx
+++ b/app/features/organization/settings/danger-card.tsx
@@ -34,7 +34,9 @@ export const OrganizationDangerCard = ({ organization }: { organization: IOrgani
       showConfirmInput: true,
       onSubmit: async () => {
         await fetcher.submit(
-          {},
+          {
+            redirectUri: paths.account.organizations.root,
+          },
           {
             method: 'DELETE',
             action: getPathWithParams(ORG_ACTION_PATH, { id: organization?.name }),
@@ -48,12 +50,7 @@ export const OrganizationDangerCard = ({ organization }: { organization: IOrgani
     if (fetcher.data && fetcher.state === 'idle') {
       const { success } = fetcher.data;
 
-      if (success) {
-        navigate(paths.account.organizations.root);
-        toast.success('Organization deleted successfully', {
-          description: 'The organization has been deleted successfully',
-        });
-      } else {
+      if (!success) {
         toast.error('Failed to delete organization', {
           description: fetcher.data?.error,
         });

--- a/app/routes/account/organizations/index.tsx
+++ b/app/routes/account/organizations/index.tsx
@@ -12,7 +12,7 @@ import { useMemo } from 'react';
 import { useLoaderData, LoaderFunctionArgs, data, Link, useNavigate } from 'react-router';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  const req = await fetch(`${process.env.APP_URL}${ORG_LIST_PATH}`, {
+  const req = await fetch(`${process.env.APP_URL}${ORG_LIST_PATH}?noCache=true`, {
     method: 'GET',
     headers: {
       Cookie: request.headers.get('Cookie') || '',

--- a/app/routes/invitation/index.tsx
+++ b/app/routes/invitation/index.tsx
@@ -113,10 +113,8 @@ export default function InvitationPage() {
       <Card className="w-full max-w-md rounded-lg border py-11 shadow-none">
         <CardHeader className="space-y-3 px-9 pb-6">
           <div className="space-y-2 text-center">
-            <CardTitle className="text-navy text-xl font-semibold">
-              You&apos;ve been invited!
-            </CardTitle>
-            <CardDescription className="text-navy text-sm font-normal">
+            <CardTitle className="text-xl font-semibold">You&apos;ve been invited!</CardTitle>
+            <CardDescription className="text-sm font-normal">
               Join your team and start collaborating
             </CardDescription>
           </div>

--- a/app/routes/org/detail/settings/preferences.tsx
+++ b/app/routes/org/detail/settings/preferences.tsx
@@ -1,5 +1,7 @@
+import { OrganizationDangerCard } from '@/features/organization';
 import { OrganizationGeneralCard } from '@/features/organization/settings/general-card';
 import { createOrganizationsControl } from '@/resources/control-plane';
+import { OrganizationType } from '@/resources/interfaces/organization.interface';
 import {
   UpdateOrganizationSchema,
   updateOrganizationSchema,
@@ -78,9 +80,9 @@ export default function OrgPreferencesPage() {
       <OrganizationGeneralCard organization={organization ?? {}} />
 
       {/* Danger Zone */}
-      {/* {organization && organization?.type !== OrganizationType.Personal ? (
+      {organization && organization?.type !== OrganizationType.Personal && (
         <OrganizationDangerCard organization={organization ?? {}} />
-      ) : null} */}
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Enable organization deletion for standard (non-personal) organizations
- Add proper cache invalidation to refresh organization list after deletion

Closes https://github.com/datum-cloud/enhancements/issues/452