### PR TITLE
fix: update invitation team member full name to use email address

### DIFF
--- a/app/routes/org/detail/team/index.tsx
+++ b/app/routes/org/detail/team/index.tsx
@@ -94,7 +94,7 @@ export const loader = async ({ params, context }: LoaderFunctionArgs) => {
   const invitationTeamMembers: ITeamMember[] = await Promise.all(
     filteredInvitations.map(async (invitation) => ({
       id: invitation.name,
-      fullName: `${invitation.givenName ?? ''} ${invitation.familyName ?? ''}`.trim(),
+      fullName: invitation.email ?? '',
       email: invitation.email ?? '',
       roles: invitation.role ? [await resolveRoleDetails(invitation.role, 'datum-cloud')] : [],
       invitationState: invitation.state,


### PR DESCRIPTION
- Changed the fullName property in the invitation team member object to use the email address instead of the concatenated given and family names for better clarity.
