### PR TITLE
chore: edit view nameservers button

### DIFF
--- a/app/routes/project/detail/edge/dns-zones/detail/overview.tsx
+++ b/app/routes/project/detail/edge/dns-zones/detail/overview.tsx
@@ -82,7 +82,7 @@ export default function DnsZoneOverviewPage() {
                 icon={<PencilIcon size={12} />}
                 iconPosition="right"
                 size="xs">
-                Edit nameservers
+                View nameservers
               </LinkButton>
             }
           />


### PR DESCRIPTION
This pull request makes a minor update to the `DnsZoneOverviewPage` component. The button label for managing nameservers has been changed to better reflect its functionality.

* The button previously labeled "Edit nameservers" is now labeled "View nameservers" in the `DnsZoneOverviewPage` component.