### PR TITLE
refactor: migrate DNS records from array-based to single-value schema

### DIFF
--- a/app/features/edge/dns-zone/form/dns-record-form.tsx
+++ b/app/features/edge/dns-zone/form/dns-record-form.tsx
@@ -81,13 +81,13 @@ export function DnsRecordForm({
       name: '',
       ttl: null, // Auto by default
       a: { content: '' },
-      // Initialize all array types with single empty item
-      mx: [{ exchange: '', preference: 10 }],
-      srv: [{ target: '', port: 443, priority: 10, weight: 5 }],
-      caa: [{ flag: 0, tag: 'issue', value: '' }],
-      tlsa: [{ usage: 3, selector: 1, matchingType: 1, certData: '' }],
-      https: [{ priority: 1, target: '', params: {} }],
-      svcb: [{ priority: 1, target: '', params: {} }],
+      // Initialize all complex types with single object (not arrays)
+      mx: { exchange: '', preference: 10 },
+      srv: { target: '', port: 443, priority: 10, weight: 5 },
+      caa: { flag: 0, tag: 'issue', value: '' },
+      tlsa: { usage: 3, selector: 1, matchingType: 1, certData: '' },
+      https: { priority: 1, target: '', params: {} },
+      svcb: { priority: 1, target: '', params: {} },
       dnsZoneRef: dnsZoneName ? { name: dnsZoneName } : undefined,
     } as Partial<CreateDnsRecordSchema>;
   };

--- a/app/features/edge/dns-zone/form/types/caa-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/caa-record-field.tsx
@@ -16,11 +16,7 @@ export const CAARecordField = ({
   fields: ReturnType<typeof useForm<CAARecordSchema>>[1];
   defaultValue?: CAARecordSchema;
 }) => {
-  // Always use the first (and only) item in the array
-  const caaList = fields.caa.getFieldList();
-  const caaFields = caaList[0]?.getFieldset();
-
-  if (!caaFields) return null;
+  const caaFields = fields.caa.getFieldset();
 
   return (
     <>

--- a/app/features/edge/dns-zone/form/types/https-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/https-record-field.tsx
@@ -11,17 +11,15 @@ export const HTTPSRecordField = ({
   fields: ReturnType<typeof useForm<HTTPSRecordSchema>>[1];
   defaultValue?: HTTPSRecordSchema;
 }) => {
-  // Always use the first (and only) item in the array
-  const httpsList = fields.https.getFieldList();
-  const httpsFields = httpsList[0]?.getFieldset();
+  const httpsFields = fields.https.getFieldset();
 
   // State for params string representation
   const [paramsString, setParamsString] = useState('');
 
   // Initialize params string from defaultValue
   useEffect(() => {
-    if (defaultValue?.https?.[0]?.params) {
-      const params = defaultValue.https[0].params;
+    if (defaultValue?.https?.params) {
+      const params = defaultValue.https.params;
       const paramsStr = Object.entries(params)
         .map(([key, value]) => `${key}="${value}"`)
         .join(' ');

--- a/app/features/edge/dns-zone/form/types/mx-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/mx-record-field.tsx
@@ -9,11 +9,7 @@ export const MXRecordField = ({
   fields: ReturnType<typeof useForm<MXRecordSchema>>[1];
   defaultValue?: MXRecordSchema;
 }) => {
-  // Always use the first (and only) item in the array
-  const mxList = fields.mx.getFieldList();
-  const mxFields = mxList[0]?.getFieldset();
-
-  if (!mxFields) return null;
+  const mxFields = fields.mx.getFieldset();
 
   return (
     <>

--- a/app/features/edge/dns-zone/form/types/srv-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/srv-record-field.tsx
@@ -9,11 +9,7 @@ export const SRVRecordField = ({
   fields: ReturnType<typeof useForm<SRVRecordSchema>>[1];
   defaultValue?: SRVRecordSchema;
 }) => {
-  // Always use the first (and only) item in the array
-  const srvList = fields.srv.getFieldList();
-  const srvFields = srvList[0]?.getFieldset();
-
-  if (!srvFields) return null;
+  const srvFields = fields.srv.getFieldset();
 
   return (
     <>

--- a/app/features/edge/dns-zone/form/types/svcb-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/svcb-record-field.tsx
@@ -11,17 +11,15 @@ export const SVCBRecordField = ({
   fields: ReturnType<typeof useForm<SVCBRecordSchema>>[1];
   defaultValue?: SVCBRecordSchema;
 }) => {
-  // Always use the first (and only) item in the array
-  const svcbList = fields.svcb.getFieldList();
-  const svcbFields = svcbList[0]?.getFieldset();
+  const svcbFields = fields.svcb.getFieldset();
 
   // State for params string representation
   const [paramsString, setParamsString] = useState('');
 
   // Initialize params string from defaultValue
   useEffect(() => {
-    if (defaultValue?.svcb?.[0]?.params) {
-      const params = defaultValue.svcb[0].params;
+    if (defaultValue?.svcb?.params) {
+      const params = defaultValue.svcb.params;
       const paramsStr = Object.entries(params)
         .map(([key, value]) => `${key}="${value}"`)
         .join(' ');

--- a/app/features/edge/dns-zone/form/types/tlsa-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/tlsa-record-field.tsx
@@ -10,11 +10,7 @@ export const TLSARecordField = ({
   fields: ReturnType<typeof useForm<TLSARecordSchema>>[1];
   defaultValue?: TLSARecordSchema;
 }) => {
-  // Always use the first (and only) item in the array
-  const tlsaList = fields.tlsa.getFieldList();
-  const tlsaFields = tlsaList[0]?.getFieldset();
-
-  if (!tlsaFields) return null;
+  const tlsaFields = fields.tlsa.getFieldset();
 
   return (
     <>

--- a/app/features/edge/dns-zone/overview/dns-records/dns-record-inline-form.tsx
+++ b/app/features/edge/dns-zone/overview/dns-records/dns-record-inline-form.tsx
@@ -40,62 +40,49 @@ export function DnsRecordInlineForm({
         ...(initialData.type === 'NS' && { ns: { content: initialData.value || '' } }),
         ...(initialData.type === 'PTR' && { ptr: { content: initialData.value || '' } }),
 
-        // Array types (wrap in array) - TODO: enhance based on IFlattenedDnsRecord structure
+        // Complex types (use raw K8s data from record)
         ...(initialData.type === 'MX' && {
-          mx: [
-            {
-              // Decode pipe-separated format: "preference|exchange"
-              exchange: initialData.value?.split('|')[1] || '',
-              preference: Number(initialData.value?.split('|')[0]) || 10,
-            },
-          ],
+          mx: initialData.rawData?.mx || {
+            exchange: '',
+            preference: 10,
+          },
         }),
         ...(initialData.type === 'SRV' && {
-          srv: [
-            {
-              target: initialData.value || '',
-              port: (initialData as any).port || 443,
-              priority: (initialData as any).priority || 10,
-              weight: (initialData as any).weight || 5,
-            },
-          ],
+          srv: initialData.rawData?.srv || {
+            target: '',
+            port: 443,
+            priority: 10,
+            weight: 5,
+          },
         }),
         ...(initialData.type === 'CAA' && {
-          caa: [
-            {
-              flag: (initialData as any).flag || 0,
-              tag: (initialData as any).tag || 'issue',
-              value: initialData.value || '',
-            },
-          ],
+          caa: initialData.rawData?.caa || {
+            flag: 0,
+            tag: 'issue',
+            value: '',
+          },
         }),
         ...(initialData.type === 'TLSA' && {
-          tlsa: [
-            {
-              usage: (initialData as any).usage || 3,
-              selector: (initialData as any).selector || 1,
-              matchingType: (initialData as any).matchingType || 1,
-              certData: initialData.value || '',
-            },
-          ],
+          tlsa: initialData.rawData?.tlsa || {
+            usage: 3,
+            selector: 1,
+            matchingType: 1,
+            certData: '',
+          },
         }),
         ...(initialData.type === 'HTTPS' && {
-          https: [
-            {
-              priority: (initialData as any).priority || 1,
-              target: initialData.value || '',
-              params: (initialData as any).params || {},
-            },
-          ],
+          https: initialData.rawData?.https || {
+            priority: 1,
+            target: '',
+            params: {},
+          },
         }),
         ...(initialData.type === 'SVCB' && {
-          svcb: [
-            {
-              priority: (initialData as any).priority || 1,
-              target: initialData.value || '',
-              params: (initialData as any).params || {},
-            },
-          ],
+          svcb: initialData.rawData?.svcb || {
+            priority: 1,
+            target: '',
+            params: {},
+          },
         }),
         ...(initialData.type === 'SOA' &&
           (() => {

--- a/app/modules/control-plane/dns-networking/types.gen.ts
+++ b/app/modules/control-plane/dns-networking/types.gen.ts
@@ -62,38 +62,50 @@ export type ComMiloapisNetworkingDnsV1Alpha1DnsRecordSet = {
        * Exactly one of the following type-specific fields should be set matching RecordType.
        */
       a?: {
-        content: Array<string>;
+        content: string;
       };
       aaaa?: {
-        content: Array<string>;
+        content: string;
       };
-      caa?: Array<{
+      caa?: {
+        /**
+         * 0–255 flag
+         */
         flag: number;
+        /**
+         * RFC-style tags: keep it simple: [a-z0-9]+
+         */
         tag: string;
         value: string;
-      }>;
+      };
       cname?: {
         content: string;
       };
-      https?: Array<{
+      https?: {
         params?: {
           [key: string]: string;
         };
         priority: number;
         target: string;
-      }>;
-      mx?: Array<{
+      };
+      mx?: {
         exchange: string;
         preference: number;
-      }>;
+      };
       /**
        * Name is the owner name (relative to the zone or FQDN).
        */
       name: string;
-      /**
-       * Raw contains raw RDATA strings when used instead of typed fields.
-       */
-      raw?: Array<string>;
+      ns?: {
+        /**
+         * Require a hostname (FQDN or relative), allow optional trailing dot, no underscores.
+         * Labels: 1-63 chars, alphanum with interior hyphens, total length <=253.
+         */
+        content: string;
+      };
+      ptr?: {
+        content: string;
+      };
       soa?: {
         expire?: number;
         mname: string;
@@ -103,31 +115,31 @@ export type ComMiloapisNetworkingDnsV1Alpha1DnsRecordSet = {
         serial?: number;
         ttl?: number;
       };
-      srv?: Array<{
+      srv?: {
         port: number;
         priority: number;
         target: string;
         weight: number;
-      }>;
-      svcb?: Array<{
+      };
+      svcb?: {
         params?: {
           [key: string]: string;
         };
         priority: number;
         target: string;
-      }>;
-      tlsa?: Array<{
+      };
+      tlsa?: {
         certData: string;
         matchingType: number;
         selector: number;
         usage: number;
-      }>;
+      };
       /**
        * TTL optionally overrides TTL for this owner/RRset.
        */
       ttl?: bigint | number;
       txt?: {
-        content: Array<string>;
+        content: string;
       };
     }>;
   };

--- a/app/modules/datum-ui/components/form/README.md
+++ b/app/modules/datum-ui/components/form/README.md
@@ -64,7 +64,7 @@ import { Input } from '@datum-ui/components';
   type="text"
   placeholder="Enter your name"
   className="custom-class" // Datum-specific or custom classes
-/>
+/>;
 ```
 
 ### Example: Checkbox
@@ -72,11 +72,7 @@ import { Input } from '@datum-ui/components';
 ```tsx
 import { Checkbox } from '@datum-ui/components';
 
-<Checkbox
-  checked={isChecked}
-  onCheckedChange={setIsChecked}
-  className="custom-class"
-/>
+<Checkbox checked={isChecked} onCheckedChange={setIsChecked} className="custom-class" />;
 ```
 
 ### Example: Select Dropdown
@@ -98,7 +94,7 @@ import {
     <SelectItem value="option1">Option 1</SelectItem>
     <SelectItem value="option2">Option 2</SelectItem>
   </SelectContent>
-</Select>
+</Select>;
 ```
 
 ### Example: Radio Group
@@ -116,7 +112,7 @@ import { Label } from '@datum-ui/components';
     <RadioGroupItem value="option2" id="option2" />
     <Label htmlFor="option2">Option 2</Label>
   </div>
-</RadioGroup>
+</RadioGroup>;
 ```
 
 ## Customization
@@ -135,8 +131,8 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
         className={cn(
           // Add Datum-specific defaults here
           'focus-visible:ring-primary/20', // Custom focus ring
-          'border-border/50',                // Softer border
-          className                          // User classes (highest priority)
+          'border-border/50', // Softer border
+          className // User classes (highest priority)
         )}
         {...props}
       />
@@ -150,13 +146,10 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
 These components work seamlessly with Conform form validation:
 
 ```tsx
-import { Input } from '@datum-ui/components';
 import { getInputProps } from '@conform-to/react';
+import { Input } from '@datum-ui/components';
 
-<Input
-  {...getInputProps(field, { type: 'text' })}
-  placeholder="Enter text..."
-/>
+<Input {...getInputProps(field, { type: 'text' })} placeholder="Enter text..." />;
 ```
 
 ## Migration from shadcn
@@ -164,12 +157,14 @@ import { getInputProps } from '@conform-to/react';
 If you're currently using shadcn components directly:
 
 **Before:**
+
 ```tsx
-import { Input } from '@shadcn/ui/input';
 import { Checkbox } from '@shadcn/ui/checkbox';
+import { Input } from '@shadcn/ui/input';
 ```
 
 **After:**
+
 ```tsx
 import { Input, Checkbox } from '@datum-ui/components';
 ```
@@ -189,4 +184,3 @@ The API is identical, so no code changes are needed beyond the import path.
 - [shadcn/ui Documentation](https://ui.shadcn.com/)
 - [Datum UI Components](../README.md)
 - [Conform Form Library](https://conform.guide/)
-

--- a/app/resources/schemas/dns-record.schema.ts
+++ b/app/resources/schemas/dns-record.schema.ts
@@ -251,15 +251,15 @@ export const txtRecordSchema = baseRecordFieldSchema.extend({
 });
 
 export const mxRecordSchema = baseRecordFieldSchema.extend({
-  mx: z.array(mxRecordDataSchema).min(1, 'At least one MX record is required.'),
+  mx: mxRecordDataSchema,
 });
 
 export const srvRecordSchema = baseRecordFieldSchema.extend({
-  srv: z.array(srvRecordDataSchema).min(1, 'At least one SRV record is required.'),
+  srv: srvRecordDataSchema,
 });
 
 export const caaRecordSchema = baseRecordFieldSchema.extend({
-  caa: z.array(caaRecordDataSchema).min(1, 'At least one CAA record is required.'),
+  caa: caaRecordDataSchema,
 });
 
 export const nsRecordSchema = baseRecordFieldSchema.extend({
@@ -275,15 +275,15 @@ export const ptrRecordSchema = baseRecordFieldSchema.extend({
 });
 
 export const tlsaRecordSchema = baseRecordFieldSchema.extend({
-  tlsa: z.array(tlsaRecordDataSchema).min(1, 'At least one TLSA record is required.'),
+  tlsa: tlsaRecordDataSchema,
 });
 
 export const httpsRecordSchema = baseRecordFieldSchema.extend({
-  https: z.array(httpsRecordDataSchema).min(1, 'At least one HTTPS record is required.'),
+  https: httpsRecordDataSchema,
 });
 
 export const svcbRecordSchema = baseRecordFieldSchema.extend({
-  svcb: z.array(svcbRecordDataSchema).min(1, 'At least one SVCB record is required.'),
+  svcb: svcbRecordDataSchema,
 });
 
 // Main DNS Record Set Schema

--- a/app/routes/project/detail/edge/dns-zones/new.tsx
+++ b/app/routes/project/detail/edge/dns-zones/new.tsx
@@ -1,6 +1,5 @@
 import { DnsZoneForm } from '@/features/edge/dns-zone/form';
 import { createDnsZonesControl } from '@/resources/control-plane/dns-networking';
-import { IDnsZoneControlResponse } from '@/resources/interfaces/dns.interface';
 import { formDnsZoneSchema } from '@/resources/schemas/dns-zone.schema';
 import { paths } from '@/utils/config/paths.config';
 import { dataWithToast, validateCSRF } from '@/utils/cookies';

--- a/app/utils/helpers/dns-record.helper.ts
+++ b/app/utils/helpers/dns-record.helper.ts
@@ -51,7 +51,7 @@ export function formatTTL(ttlSeconds?: number): string {
 
 /**
  * Flattened DNS record for UI display
- * Each VALUE in each record becomes a separate row
+ * Each record object becomes a separate row
  */
 export interface IFlattenedDnsRecord {
   // RecordSet metadata
@@ -75,7 +75,7 @@ export interface IFlattenedDnsRecord {
 
 /**
  * Transform K8s DNSRecordSet array to flattened records for UI display
- * Each value in spec.records[].raw/soa/mx/etc becomes a separate table row
+ * Each record in spec.records[] becomes a separate table row
  */
 export function flattenDnsRecordSets(
   recordSets: IDnsRecordSetControlResponse[]
@@ -86,24 +86,22 @@ export function flattenDnsRecordSets(
     const records = recordSet.records || [];
     const status = extractStatus(recordSet.status);
 
+    // Each record object contains exactly one value in the new schema
     records.forEach((record: any) => {
-      const values = extractValues(record, recordSet.recordType);
+      const value = extractValue(record, recordSet.recordType);
       const ttl = extractTTL(record);
 
-      // Create one row per value
-      values.forEach((value) => {
-        flattened.push({
-          recordSetId: recordSet.uid || '',
-          recordSetName: recordSet.name || '',
-          createdAt: recordSet.createdAt || new Date(),
-          dnsZoneId: recordSet.dnsZoneId || '',
-          type: recordSet.recordType || '',
-          name: record.name || '',
-          value: value,
-          ttl: ttl,
-          status: status,
-          rawData: record,
-        });
+      flattened.push({
+        recordSetId: recordSet.uid || '',
+        recordSetName: recordSet.name || '',
+        createdAt: recordSet.createdAt || new Date(),
+        dnsZoneId: recordSet.dnsZoneId || '',
+        type: recordSet.recordType || '',
+        name: record.name || '',
+        value: value,
+        ttl: ttl,
+        status: status,
+        rawData: record,
       });
     });
   });
@@ -127,123 +125,104 @@ export function flattenDnsRecordSets(
 }
 
 /**
- * Extract values from different record types based on K8s schema
- * Returns array of strings, each will become a separate row
+ * Extract value from a record based on its type
+ * Returns a single string value to be displayed in the UI
  * Reference: ComMiloapisNetworkingDnsV1Alpha1DnsRecordSet['spec']['records']
  */
-function extractValues(record: any, recordType: string | undefined): string[] {
+export function extractValue(record: any, recordType: string | undefined): string {
   switch (recordType) {
     case 'A':
-      // record.a.content: Array<string>
-      return record.a?.content || [];
+      // record.a.content: string (single value)
+      return record.a?.content || '';
 
     case 'AAAA':
-      // record.aaaa.content: Array<string>
-      return record.aaaa?.content || [];
+      // record.aaaa.content: string (single value)
+      return record.aaaa?.content || '';
 
     case 'CNAME':
-      // record.cname.content: string (single value, not array)
-      return record.cname?.content ? [record.cname.content] : [];
+      // record.cname.content: string (single value)
+      return record.cname?.content || '';
 
     case 'TXT':
-      // record.txt.content: Array<string>
-      return record.txt?.content || [];
+      // record.txt.content: string (single value)
+      return record.txt?.content || '';
 
     case 'NS':
+      // record.ns.content: string (single value)
+      return record.ns?.content || '';
+
     case 'PTR':
-      // record.raw: Array<string>
-      return record.raw || [];
+      // record.ptr.content: string (single value)
+      return record.ptr?.content || '';
 
     case 'SOA':
       // record.soa: { mname, rname, refresh, retry, expire, serial, ttl }
       // Return as JSON string to preserve object structure for editing
       // Format will be applied in table cell renderer
-      if (record.soa) {
-        return [JSON.stringify(record.soa)];
-      }
-      return [];
+      return record.soa ? JSON.stringify(record.soa) : '';
 
     case 'MX':
-      // record.mx: Array<{ exchange: string, preference: number }>
+      // record.mx: { exchange: string, preference: number } (single object)
       // Format: "preference|exchange" (pipe separator for UI parsing)
-      if (record.mx) {
-        return record.mx.map((mx: any) => `${mx.preference}|${mx.exchange}`);
-      }
-      return [];
+      return record.mx ? `${record.mx.preference}|${record.mx.exchange}` : '';
 
     case 'SRV':
-      // record.srv: Array<{ priority, weight, port, target }>
+      // record.srv: { priority, weight, port, target } (single object)
       // Format: "priority weight port target"
-      if (record.srv) {
-        return record.srv.map(
-          (srv: any) => `${srv.priority} ${srv.weight} ${srv.port} ${srv.target}`
-        );
-      }
-      return [];
+      return record.srv
+        ? `${record.srv.priority} ${record.srv.weight} ${record.srv.port} ${record.srv.target}`
+        : '';
 
     case 'CAA':
-      // record.caa: Array<{ flag, tag, value }>
+      // record.caa: { flag, tag, value } (single object)
       // Format: "flag tag value"
-      if (record.caa) {
-        return record.caa.map((caa: any) => `${caa.flag} ${caa.tag} "${caa.value}"`);
-      }
-      return [];
+      return record.caa ? `${record.caa.flag} ${record.caa.tag} "${record.caa.value}"` : '';
 
     case 'TLSA':
-      // record.tlsa: Array<{ usage, selector, matchingType, certData }>
+      // record.tlsa: { usage, selector, matchingType, certData } (single object)
       // Format: "usage selector matchingType certData"
-      if (record.tlsa) {
-        return record.tlsa.map(
-          (tlsa: any) => `${tlsa.usage} ${tlsa.selector} ${tlsa.matchingType} ${tlsa.certData}`
-        );
-      }
-      return [];
+      return record.tlsa
+        ? `${record.tlsa.usage} ${record.tlsa.selector} ${record.tlsa.matchingType} ${record.tlsa.certData}`
+        : '';
 
     case 'HTTPS':
-      // record.https: Array<{ priority, target, params }>
+      // record.https: { priority, target, params } (single object)
       // Format: "priority target [params]"
-      if (record.https) {
-        return record.https.map((https: any) => {
-          const params = https.params
-            ? ` ${Object.entries(https.params)
-                .map(([k, v]) => `${k}=${v}`)
-                .join(' ')}`
-            : '';
-          return `${https.priority} ${https.target}${params}`;
-        });
-      }
-      return [];
+      if (!record.https) return '';
+      const httpsParams = record.https.params
+        ? ` ${Object.entries(record.https.params)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ')}`
+        : '';
+      return `${record.https.priority} ${record.https.target}${httpsParams}`;
 
     case 'SVCB':
-      // record.svcb: Array<{ priority, target, params }>
+      // record.svcb: { priority, target, params } (single object)
       // Format: "priority target [params]"
-      if (record.svcb) {
-        return record.svcb.map((svcb: any) => {
-          const params = svcb.params
-            ? ` ${Object.entries(svcb.params)
-                .map(([k, v]) => `${k}=${v}`)
-                .join(' ')}`
-            : '';
-          return `${svcb.priority} ${svcb.target}${params}`;
-        });
-      }
-      return [];
+      if (!record.svcb) return '';
+      const svcbParams = record.svcb.params
+        ? ` ${Object.entries(record.svcb.params)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' ')}`
+        : '';
+      return `${record.svcb.priority} ${record.svcb.target}${svcbParams}`;
 
     default:
-      // Fallback to raw if available
-      return record.raw || [];
+      // Fallback to content if available
+      return record.content || '';
   }
 }
 
 /**
  * Extract TTL from record
+ * Handles both bigint and number types, converting bigint to number for UI display
  */
 function extractTTL(record: any): number | undefined {
-  // SOA has TTL in soa.ttl
-  // if (record.soa?.ttl) return record.soa.ttl;
-
-  // Other types might have TTL at record level
-  if (record.ttl) return record.ttl;
+  // TTL can be bigint or number in the new schema
+  if (record.ttl !== undefined && record.ttl !== null) {
+    // Convert bigint to number if needed
+    return typeof record.ttl === 'bigint' ? Number(record.ttl) : record.ttl;
+  }
 
   return undefined;
 }
@@ -288,15 +267,17 @@ export function transformFormToRecord(
   switch (recordType) {
     case 'A':
       // Form: { a: { content: string } }
-      // K8s:  { a: { content: string[] } }
+      // K8s:  { a: { content: string } }
       if (typeData.a) {
-        record.a = { content: [typeData.a.content] };
+        record.a = { content: typeData.a.content };
       }
       break;
 
     case 'AAAA':
+      // Form: { aaaa: { content: string } }
+      // K8s:  { aaaa: { content: string } }
       if (typeData.aaaa) {
-        record.aaaa = { content: [typeData.aaaa.content] };
+        record.aaaa = { content: typeData.aaaa.content };
       }
       break;
 
@@ -309,58 +290,72 @@ export function transformFormToRecord(
       break;
 
     case 'TXT':
+      // Form: { txt: { content: string } }
+      // K8s:  { txt: { content: string } }
       if (typeData.txt) {
-        record.txt = { content: [typeData.txt.content] };
+        record.txt = { content: typeData.txt.content };
       }
       break;
 
     case 'NS':
       // Form: { ns: { content: string } }
-      // K8s:  { raw: string[] }
+      // K8s:  { ns: { content: string } }
       if (typeData.ns) {
-        record.raw = [typeData.ns.content];
+        record.ns = { content: typeData.ns.content };
       }
       break;
 
     case 'PTR':
+      // Form: { ptr: { content: string } }
+      // K8s:  { ptr: { content: string } }
       if (typeData.ptr) {
-        record.raw = [typeData.ptr.content];
+        record.ptr = { content: typeData.ptr.content };
       }
       break;
 
     case 'MX':
-      // Form: { mx: [{ exchange, preference }] }
-      // K8s:  { mx: [{ exchange, preference }] }
+      // Form: { mx: { exchange, preference } }
+      // K8s:  { mx: { exchange, preference } }
       if (typeData.mx) {
         record.mx = typeData.mx;
       }
       break;
 
     case 'SRV':
+      // Form: { srv: { priority, weight, port, target } }
+      // K8s:  { srv: { priority, weight, port, target } }
       if (typeData.srv) {
         record.srv = typeData.srv;
       }
       break;
 
     case 'CAA':
+      // Form: { caa: { flag, tag, value } }
+      // K8s:  { caa: { flag, tag, value } }
       if (typeData.caa) {
         record.caa = typeData.caa;
       }
       break;
 
     case 'TLSA':
+      // Form: { tlsa: { usage, selector, matchingType, certData } }
+      // K8s:  { tlsa: { usage, selector, matchingType, certData } }
       if (typeData.tlsa) {
         record.tlsa = typeData.tlsa;
       }
       break;
 
     case 'HTTPS':
+      // Form: { https: { priority, target, params } }
+      // K8s:  { https: { priority, target, params } }
       if (typeData.https) {
         record.https = typeData.https;
       }
       break;
 
     case 'SVCB':
+      // Form: { svcb: { priority, target, params } }
+      // K8s:  { svcb: { priority, target, params } }
       if (typeData.svcb) {
         record.svcb = typeData.svcb;
       }
@@ -379,459 +374,37 @@ export function transformFormToRecord(
 }
 
 /**
- * Merge new record values into existing record
- * For types with content arrays (A, AAAA, TXT, NS, PTR), merges the arrays
- * For types with object arrays (MX, SRV, CAA, etc.), appends to the array
- * For single-value types (CNAME, SOA), replaces the value
- */
-export function mergeRecordValues(existingRecord: any, newRecord: any, recordType: string): any {
-  const merged = { ...existingRecord };
-
-  switch (recordType) {
-    case 'A':
-      // Merge content arrays, avoiding duplicates
-      if (newRecord.a?.content && existingRecord.a?.content) {
-        const existingContent = existingRecord.a.content;
-        const newContent = newRecord.a.content;
-        merged.a = {
-          content: [
-            ...existingContent,
-            ...newContent.filter((ip: string) => !existingContent.includes(ip)),
-          ],
-        };
-      } else if (newRecord.a) {
-        merged.a = newRecord.a;
-      }
-      break;
-
-    case 'AAAA':
-      if (newRecord.aaaa?.content && existingRecord.aaaa?.content) {
-        const existingContent = existingRecord.aaaa.content;
-        const newContent = newRecord.aaaa.content;
-        merged.aaaa = {
-          content: [
-            ...existingContent,
-            ...newContent.filter((ip: string) => !existingContent.includes(ip)),
-          ],
-        };
-      } else if (newRecord.aaaa) {
-        merged.aaaa = newRecord.aaaa;
-      }
-      break;
-
-    case 'TXT':
-      if (newRecord.txt?.content && existingRecord.txt?.content) {
-        const existingContent = existingRecord.txt.content;
-        const newContent = newRecord.txt.content;
-        merged.txt = {
-          content: [
-            ...existingContent,
-            ...newContent.filter((text: string) => !existingContent.includes(text)),
-          ],
-        };
-      } else if (newRecord.txt) {
-        merged.txt = newRecord.txt;
-      }
-      break;
-
-    case 'NS':
-    case 'PTR':
-      if (newRecord.raw && existingRecord.raw) {
-        const existingRaw = existingRecord.raw;
-        const newRaw = newRecord.raw;
-        merged.raw = [
-          ...existingRaw,
-          ...newRaw.filter((value: string) => !existingRaw.includes(value)),
-        ];
-      } else if (newRecord.raw) {
-        merged.raw = newRecord.raw;
-      }
-      break;
-
-    case 'MX':
-      // Append to array, check for duplicates by exchange
-      if (newRecord.mx && existingRecord.mx) {
-        const existingExchanges = existingRecord.mx.map((mx: any) => mx.exchange);
-        const newMx = newRecord.mx.filter((mx: any) => !existingExchanges.includes(mx.exchange));
-        merged.mx = [...existingRecord.mx, ...newMx];
-      } else if (newRecord.mx) {
-        merged.mx = newRecord.mx;
-      }
-      break;
-
-    case 'SRV':
-      // Append to array, check for duplicates by target
-      if (newRecord.srv && existingRecord.srv) {
-        const existingTargets = existingRecord.srv.map((srv: any) => srv.target);
-        const newSrv = newRecord.srv.filter((srv: any) => !existingTargets.includes(srv.target));
-        merged.srv = [...existingRecord.srv, ...newSrv];
-      } else if (newRecord.srv) {
-        merged.srv = newRecord.srv;
-      }
-      break;
-
-    case 'CAA':
-      // Append to array, check for duplicates by value
-      if (newRecord.caa && existingRecord.caa) {
-        const existingValues = existingRecord.caa.map((caa: any) => caa.value);
-        const newCaa = newRecord.caa.filter((caa: any) => !existingValues.includes(caa.value));
-        merged.caa = [...existingRecord.caa, ...newCaa];
-      } else if (newRecord.caa) {
-        merged.caa = newRecord.caa;
-      }
-      break;
-
-    case 'TLSA':
-      // Append to array, check for duplicates by certData
-      if (newRecord.tlsa && existingRecord.tlsa) {
-        const existingCerts = existingRecord.tlsa.map((tlsa: any) => tlsa.certData);
-        const newTlsa = newRecord.tlsa.filter(
-          (tlsa: any) => !existingCerts.includes(tlsa.certData)
-        );
-        merged.tlsa = [...existingRecord.tlsa, ...newTlsa];
-      } else if (newRecord.tlsa) {
-        merged.tlsa = newRecord.tlsa;
-      }
-      break;
-
-    case 'HTTPS':
-      // Append to array, check for duplicates by target
-      if (newRecord.https && existingRecord.https) {
-        const existingTargets = existingRecord.https.map((https: any) => https.target);
-        const newHttps = newRecord.https.filter(
-          (https: any) => !existingTargets.includes(https.target)
-        );
-        merged.https = [...existingRecord.https, ...newHttps];
-      } else if (newRecord.https) {
-        merged.https = newRecord.https;
-      }
-      break;
-
-    case 'SVCB':
-      // Append to array, check for duplicates by target
-      if (newRecord.svcb && existingRecord.svcb) {
-        const existingTargets = existingRecord.svcb.map((svcb: any) => svcb.target);
-        const newSvcb = newRecord.svcb.filter(
-          (svcb: any) => !existingTargets.includes(svcb.target)
-        );
-        merged.svcb = [...existingRecord.svcb, ...newSvcb];
-      } else if (newRecord.svcb) {
-        merged.svcb = newRecord.svcb;
-      }
-      break;
-
-    case 'CNAME':
-    case 'SOA':
-      // Single-value types: replace entirely
-      return { ...existingRecord, ...newRecord };
-
-    default:
-      // Fallback: replace entirely
-      return { ...existingRecord, ...newRecord };
-  }
-
-  // Update TTL if provided in new record
-  // If newRecord.ttl is null, it means "Auto" - don't include it (delete from merged)
-  // If newRecord.ttl is a number, update it
-  // If newRecord.ttl is undefined, keep existing TTL
-  if (newRecord.ttl !== undefined) {
-    if (newRecord.ttl === null) {
-      delete merged.ttl; // Remove TTL to use default
-    } else {
-      merged.ttl = newRecord.ttl;
-    }
-  }
-
-  return merged;
-}
-
-/**
- * Update a specific value in a record's value array
- * Used for editing individual values (e.g., changing one IP to another in A record)
- * @param record - The existing record
- * @param newRecord - The new record data containing the updated value
- * @param recordType - The DNS record type
- * @param oldValue - The old value to find and replace
- */
-export function updateValueInRecord(
-  record: any,
-  newRecord: any,
-  recordType: string,
-  oldValue: string
-): any {
-  const updatedRecord = { ...record };
-
-  switch (recordType) {
-    case 'A':
-      if (record.a?.content && newRecord.a?.content?.[0]) {
-        const newValue = newRecord.a.content[0];
-        updatedRecord.a = {
-          content: record.a.content.map((ip: string) => (ip === oldValue ? newValue : ip)),
-        };
-      }
-      break;
-
-    case 'AAAA':
-      if (record.aaaa?.content && newRecord.aaaa?.content?.[0]) {
-        const newValue = newRecord.aaaa.content[0];
-        updatedRecord.aaaa = {
-          content: record.aaaa.content.map((ip: string) => (ip === oldValue ? newValue : ip)),
-        };
-      }
-      break;
-
-    case 'TXT':
-      if (record.txt?.content && newRecord.txt?.content?.[0]) {
-        const newValue = newRecord.txt.content[0];
-        updatedRecord.txt = {
-          content: record.txt.content.map((text: string) => (text === oldValue ? newValue : text)),
-        };
-      }
-      break;
-
-    case 'NS':
-    case 'PTR':
-      if (record.raw && newRecord.raw?.[0]) {
-        const newValue = newRecord.raw[0];
-        updatedRecord.raw = record.raw.map((value: string) =>
-          value === oldValue ? newValue : value
-        );
-      }
-      break;
-
-    case 'MX':
-      if (record.mx && newRecord.mx?.[0]) {
-        const newMx = newRecord.mx[0];
-        // oldValue format: "preference|exchange"
-        updatedRecord.mx = record.mx.map((mx: any) =>
-          `${mx.preference}|${mx.exchange}` === oldValue ? newMx : mx
-        );
-      }
-      break;
-
-    case 'SRV':
-      if (record.srv && newRecord.srv?.[0]) {
-        const newSrv = newRecord.srv[0];
-        // oldValue format: "priority weight port target"
-        updatedRecord.srv = record.srv.map((srv: any) =>
-          `${srv.priority} ${srv.weight} ${srv.port} ${srv.target}` === oldValue ? newSrv : srv
-        );
-      }
-      break;
-
-    case 'CAA':
-      if (record.caa && newRecord.caa?.[0]) {
-        const newCaa = newRecord.caa[0];
-        // oldValue format: "flag tag "value""
-        updatedRecord.caa = record.caa.map((caa: any) =>
-          `${caa.flag} ${caa.tag} "${caa.value}"` === oldValue ? newCaa : caa
-        );
-      }
-      break;
-
-    case 'TLSA':
-      if (record.tlsa && newRecord.tlsa?.[0]) {
-        const newTlsa = newRecord.tlsa[0];
-        // oldValue is certData
-        updatedRecord.tlsa = record.tlsa.map((tlsa: any) =>
-          tlsa.certData === oldValue ? newTlsa : tlsa
-        );
-      }
-      break;
-
-    case 'HTTPS':
-      if (record.https && newRecord.https?.[0]) {
-        const newHttps = newRecord.https[0];
-        // oldValue is the target
-        updatedRecord.https = record.https.map((https: any) =>
-          https.target === oldValue ? newHttps : https
-        );
-      }
-      break;
-
-    case 'SVCB':
-      if (record.svcb && newRecord.svcb?.[0]) {
-        const newSvcb = newRecord.svcb[0];
-        // oldValue is the target
-        updatedRecord.svcb = record.svcb.map((svcb: any) =>
-          svcb.target === oldValue ? newSvcb : svcb
-        );
-      }
-      break;
-
-    case 'CNAME':
-    case 'SOA':
-      // Single-value types: replace entirely
-      return { ...record, ...newRecord };
-
-    default:
-      // Fallback: replace entirely
-      return { ...record, ...newRecord };
-  }
-
-  // Update TTL if provided in new record
-  if (newRecord.ttl !== undefined) {
-    if (newRecord.ttl === null) {
-      delete updatedRecord.ttl; // Remove TTL to use default
-    } else {
-      updatedRecord.ttl = newRecord.ttl;
-    }
-  }
-
-  return updatedRecord;
-}
-
-/**
- * Remove a specific value from a record's value array
- * Used for deleting individual values (e.g., one IP from A record with multiple IPs)
- */
-export function removeValueFromRecord(record: any, recordType: string, valueToRemove: string): any {
-  const updatedRecord = { ...record };
-
-  switch (recordType) {
-    case 'A':
-      if (record.a?.content) {
-        updatedRecord.a = {
-          content: record.a.content.filter((ip: string) => ip !== valueToRemove),
-        };
-      }
-      break;
-
-    case 'AAAA':
-      if (record.aaaa?.content) {
-        updatedRecord.aaaa = {
-          content: record.aaaa.content.filter((ip: string) => ip !== valueToRemove),
-        };
-      }
-      break;
-
-    case 'TXT':
-      if (record.txt?.content) {
-        updatedRecord.txt = {
-          content: record.txt.content.filter((text: string) => text !== valueToRemove),
-        };
-      }
-      break;
-
-    case 'NS':
-    case 'PTR':
-      if (record.raw) {
-        updatedRecord.raw = record.raw.filter((value: string) => value !== valueToRemove);
-      }
-      break;
-
-    case 'MX':
-      if (record.mx) {
-        // valueToRemove format: "preference|exchange"
-        updatedRecord.mx = record.mx.filter(
-          (mx: any) => `${mx.preference}|${mx.exchange}` !== valueToRemove
-        );
-      }
-      break;
-
-    case 'SRV':
-      if (record.srv) {
-        // valueToRemove format: "priority weight port target"
-        updatedRecord.srv = record.srv.filter(
-          (srv: any) => `${srv.priority} ${srv.weight} ${srv.port} ${srv.target}` !== valueToRemove
-        );
-      }
-      break;
-
-    case 'CAA':
-      if (record.caa) {
-        // valueToRemove format: "flag tag "value""
-        updatedRecord.caa = record.caa.filter(
-          (caa: any) => `${caa.flag} ${caa.tag} "${caa.value}"` !== valueToRemove
-        );
-      }
-      break;
-
-    case 'TLSA':
-      if (record.tlsa) {
-        // valueToRemove format: "usage selector matchingType certData"
-        updatedRecord.tlsa = record.tlsa.filter(
-          (tlsa: any) =>
-            `${tlsa.usage} ${tlsa.selector} ${tlsa.matchingType} ${tlsa.certData}` !== valueToRemove
-        );
-      }
-      break;
-
-    case 'HTTPS':
-      if (record.https) {
-        // valueToRemove format: "priority target [params]"
-        updatedRecord.https = record.https.filter((https: any) => {
-          const params = https.params
-            ? ` ${Object.entries(https.params)
-                .map(([k, v]) => `${k}=${v}`)
-                .join(' ')}`
-            : '';
-          return `${https.priority} ${https.target}${params}` !== valueToRemove;
-        });
-      }
-      break;
-
-    case 'SVCB':
-      if (record.svcb) {
-        updatedRecord.svcb = record.svcb.filter((svcb: any) => {
-          const params = svcb.params
-            ? ` ${Object.entries(svcb.params)
-                .map(([k, v]) => `${k}=${v}`)
-                .join(' ')}`
-            : '';
-          return `${svcb.priority} ${svcb.target}${params}` !== valueToRemove;
-        });
-      }
-      break;
-
-    case 'CNAME':
-      // CNAME is single-value, so removing it means setting content to undefined/null
-      if (record.cname?.content === valueToRemove) {
-        delete updatedRecord.cname;
-      }
-      break;
-
-    case 'SOA':
-      // SOA is single-value, so removing it means deleting the soa object
-      if (record.soa && JSON.stringify(record.soa) === valueToRemove) {
-        delete updatedRecord.soa;
-      }
-      break;
-  }
-
-  return updatedRecord;
-}
-
-/**
- * Check if a record has no more values left
+ * Check if a record has no value
+ * With the new schema, each record contains a single value (not arrays)
  */
 export function isRecordEmpty(record: any, recordType: string): boolean {
   switch (recordType) {
     case 'A':
-      return !record.a?.content || record.a.content.length === 0;
+      return !record.a?.content;
     case 'AAAA':
-      return !record.aaaa?.content || record.aaaa.content.length === 0;
+      return !record.aaaa?.content;
     case 'CNAME':
       return !record.cname?.content;
     case 'TXT':
-      return !record.txt?.content || record.txt.content.length === 0;
+      return !record.txt?.content;
     case 'NS':
+      return !record.ns?.content;
     case 'PTR':
-      return !record.raw || record.raw.length === 0;
+      return !record.ptr?.content;
     case 'SOA':
       return !record.soa;
     case 'MX':
-      return !record.mx || record.mx.length === 0;
+      return !record.mx;
     case 'SRV':
-      return !record.srv || record.srv.length === 0;
+      return !record.srv;
     case 'CAA':
-      return !record.caa || record.caa.length === 0;
+      return !record.caa;
     case 'TLSA':
-      return !record.tlsa || record.tlsa.length === 0;
+      return !record.tlsa;
     case 'HTTPS':
-      return !record.https || record.https.length === 0;
+      return !record.https;
     case 'SVCB':
-      return !record.svcb || record.svcb.length === 0;
+      return !record.svcb;
     default:
       return true;
   }


### PR DESCRIPTION
## Summary

This PR refactors the entire DNS record handling system to align with the new Kubernetes API schema where each record contains exactly **one value** instead of arrays of values. This dramatically simplifies the codebase by removing ~500 lines of complex array manipulation logic.

**Schema Changes:**
- Records changed from arrays to single objects for all types
- A, AAAA, TXT, NS, PTR now use single `content: string` instead of `content: string[]`
- MX, SRV, CAA, TLSA, HTTPS, SVCB are now single objects instead of arrays
- NS/PTR use `ns.content`/`ptr.content` instead of `raw`