### PR TITLE
fix: show error for record on InvalidDNSRecordSet

### DIFF
--- a/app/features/edge/dns-zone/overview/dns-records/dns-record-table.tsx
+++ b/app/features/edge/dns-zone/overview/dns-records/dns-record-table.tsx
@@ -32,7 +32,8 @@ export const DnsRecordTable = forwardRef<DataTableRef<IFlattenedDnsRecord>, DnsR
                   {row.original.type}
                 </Badge>
 
-                {row.original.status && row.original.status === ControlPlaneStatus.Pending && (
+                {row.original.isProgrammed === false &&
+                  row.original.programmedReason === 'InvalidDNSRecordSet' && (
                   <Tooltip
                     message={row.original.statusMessage}
                     contentClassName="max-w-64 bg-card text-destructive border"

--- a/app/resources/interfaces/dns.interface.ts
+++ b/app/resources/interfaces/dns.interface.ts
@@ -79,6 +79,8 @@ export interface IFlattenedDnsRecord {
   // Status (only for managed recordsets, undefined for discovery)
   status?: ControlPlaneStatus;
   statusMessage?: string; // Pending message from K8s conditions (only when status is Pending)
+  isProgrammed?: boolean; // Programmed condition state (True/False)
+  programmedReason?: string; // Reason from Programmed condition (e.g., InvalidDNSRecordSet)
 
   // Raw data for editing/display
   rawData: any;


### PR DESCRIPTION
This fixes an issue where we were showing errors on records that were valid and still being programmed. This change makes it so we only show errors when the reason is specifically InvalidDNSRecordSet. As a follow up, it might make sense to show a spinner or [Pending] chip until we either get an error or we get programmed/accepted == true.

**UI changes for error display:**

* Modified `DnsRecordTable` to show a destructive tooltip when a record is not programmed due to an `InvalidDNSRecordSet` reason, improving visibility of error states in the UI.