### PR TITLE
feat: add error indicators for DNS zones

### DIFF
--- a/app/components/badge/README.md
+++ b/app/components/badge/README.md
@@ -1,0 +1,242 @@
+# Badge Components
+
+Centralized badge components for displaying status and error information across the application.
+
+## Components
+
+### BadgeStatus
+
+Universal status badge component that displays resource status with optional tooltips and icons.
+
+**Features:**
+- Supports multiple status types (success, pending, error, etc.)
+- Optional tooltip with status messages
+- Configurable icons
+- Legacy `IControlPlaneStatus` support
+
+**Usage:**
+
+```tsx
+import { BadgeStatus } from '@/components/badge/badge-status';
+
+// Basic usage
+<BadgeStatus
+  status="success"
+  label="Active"
+/>
+
+// With tooltip
+<BadgeStatus
+  status="pending"
+  label="Provisioning"
+  tooltipText="Resource is being provisioned"
+  showIcon={true}
+/>
+
+// Custom icon
+import { AlertCircle } from 'lucide-react';
+<BadgeStatus
+  status="error"
+  label="Critical"
+  tooltipText="Service unavailable"
+  showIcon={true}
+  customIcon={<AlertCircle className="size-3" />}
+/>
+
+// With legacy IControlPlaneStatus
+<BadgeStatus
+  status={transformedStatus}
+  showTooltip={true}
+/>
+```
+
+---
+
+### BadgeProgrammingError
+
+Specialized badge for displaying K8s Programmed condition errors. Highly flexible with configurable error reasons.
+
+**Features:**
+- Automatic error detection based on `isProgrammed` condition
+- Configurable error reason filtering
+- Default error reasons from centralized constants
+- Support for custom error reason lists
+- Option to show all errors without filtering
+
+**Usage:**
+
+#### 1. Basic Usage (Default Error Reasons)
+
+Uses default error reasons:
+- `InvalidDNSRecordSet`
+- `ProgrammingFailed`
+- `ConfigurationError`
+- `ValidationFailed`
+
+```tsx
+import { BadgeProgrammingError } from '@/components/badge/badge-programming-error';
+
+<BadgeProgrammingError
+  isProgrammed={record.isProgrammed}
+  programmedReason={record.programmedReason}
+  statusMessage={record.statusMessage}
+/>
+```
+
+#### 2. Custom Error Reasons
+
+Define your own error reason list for specific use cases:
+
+```tsx
+<BadgeProgrammingError
+  isProgrammed={record.isProgrammed}
+  programmedReason={record.programmedReason}
+  statusMessage={record.statusMessage}
+  errorReasons={['InvalidConfiguration', 'SyncFailed', 'DeploymentError']}
+/>
+```
+
+#### 3. Show All Errors (No Filtering)
+
+Pass `null` to show error badge for ANY programming failure:
+
+```tsx
+<BadgeProgrammingError
+  isProgrammed={record.isProgrammed}
+  programmedReason={record.programmedReason}
+  statusMessage={record.statusMessage}
+  errorReasons={null}
+/>
+```
+
+#### 4. Real-world Example: DNS Records Table
+
+```tsx
+import { BadgeProgrammingError } from '@/components/badge/badge-programming-error';
+
+const DnsRecordTable = ({ records }) => {
+  return (
+    <DataTable
+      columns={[
+        {
+          header: 'Type',
+          cell: ({ row }) => (
+            <div className="flex items-center gap-2">
+              <Badge type="quaternary">{row.original.type}</Badge>
+
+              {/* Show error badge for InvalidDNSRecordSet only */}
+              <BadgeProgrammingError
+                isProgrammed={row.original.isProgrammed}
+                programmedReason={row.original.programmedReason}
+                statusMessage={row.original.statusMessage}
+                errorReasons={['InvalidDNSRecordSet']}
+              />
+            </div>
+          ),
+        },
+      ]}
+      data={records}
+    />
+  );
+};
+```
+
+---
+
+## Best Practices
+
+### 1. Choose the Right Error Reason List
+- **Default (no prop)**: Use when displaying all common programming errors
+- **Custom array**: Use for resource-specific error handling (e.g., `['InvalidDNSRecordSet']` for DNS)
+- **null**: Use when you want to show all programming errors without filtering
+
+### 2. Consistent Usage Across Similar Components
+If you have multiple tables showing the same resource type, use the same `errorReasons` configuration.
+
+```tsx
+// DNS Records Overview Table
+<BadgeProgrammingError errorReasons={['InvalidDNSRecordSet']} {...props} />
+
+// DNS Records Detail Table
+<BadgeProgrammingError errorReasons={['InvalidDNSRecordSet']} {...props} />
+```
+
+### 3. Document Custom Error Reasons
+When using custom error reasons, add a comment explaining the logic:
+
+```tsx
+// Only show certificate-specific errors in this table
+<BadgeProgrammingError
+  errorReasons={[
+    'CertificateValidationFailed',
+    'CertificateExpired',
+    'InvalidCertificate',
+  ]}
+  {...props}
+/>
+```
+
+---
+
+## Migration Guide
+
+If you have existing custom error badge implementations:
+
+### Before (Custom Implementation)
+```tsx
+{row.original.isProgrammed === false &&
+  row.original.programmedReason === 'InvalidDNSRecordSet' && (
+    <Tooltip message={row.original.statusMessage} ...>
+      <Badge type="danger" theme="solid" ...>
+        <TriangleAlertIcon className="size-3" />
+        <span>Error</span>
+      </Badge>
+    </Tooltip>
+  )}
+```
+
+### After (Using BadgeProgrammingError)
+```tsx
+import { BadgeProgrammingError } from '@/components/badge/badge-programming-error';
+import { DNS_ERROR_REASONS } from '@/constants/k8s-error-reasons';
+
+<BadgeProgrammingError
+  isProgrammed={row.original.isProgrammed}
+  programmedReason={row.original.programmedReason}
+  statusMessage={row.original.statusMessage}
+  errorReasons={DNS_ERROR_REASONS}
+/>
+```
+
+**Benefits:**
+- 14 lines → 4 lines
+- Consistent styling across app
+- Centralized error reason management
+- Type-safe with TypeScript
+- Easy to update/maintain
+
+---
+
+## Type Definitions
+
+```tsx
+interface BadgeStatusProps {
+  status?: string | IControlPlaneStatus;
+  label?: string;
+  showIcon?: boolean;
+  showTooltip?: boolean;
+  tooltipText?: string | ReactNode;
+  className?: string;
+  badgeType?: BadgeProps['type'];
+  badgeTheme?: BadgeProps['theme'];
+  customIcon?: ReactNode;
+}
+
+interface BadgeProgrammingErrorProps {
+  isProgrammed?: boolean;
+  programmedReason?: string;
+  statusMessage?: string;
+  className?: string;
+  errorReasons?: string[] | null;
+}
+```

--- a/app/components/badge/badge-programming-error.tsx
+++ b/app/components/badge/badge-programming-error.tsx
@@ -1,0 +1,104 @@
+import { BadgeStatus } from '@/components/badge/badge-status';
+import { TriangleAlertIcon } from 'lucide-react';
+
+/**
+ * Common programming error reasons from K8s Programmed condition
+ * These are the default error reasons that trigger the error badge
+ */
+const DEFAULT_ERROR_REASONS: string[] = [
+  'InvalidDNSRecordSet',
+  'ProgrammingFailed',
+  'ConfigurationError',
+  'ValidationFailed',
+];
+
+/**
+ * Props for programming error badge
+ * Displays K8s Programmed condition errors
+ */
+export interface BadgeProgrammingErrorProps {
+  isProgrammed?: boolean;
+  programmedReason?: string;
+  statusMessage?: string;
+  className?: string;
+  /**
+   * List of error reasons that should trigger the error badge
+   * @default ['InvalidDNSRecordSet', 'ProgrammingFailed', 'ConfigurationError', 'ValidationFailed']
+   *
+   * @example
+   * // Custom error reasons for specific use case
+   * errorReasons={['InvalidConfiguration', 'SyncFailed']}
+   *
+   * @example
+   * // Show error for any reason (no filtering)
+   * errorReasons={null}
+   */
+  errorReasons?: string[] | null;
+}
+
+/**
+ * Specialized badge for K8s Programmed condition errors
+ *
+ * Shows error badge when:
+ * - isProgrammed === false
+ * - programmedReason matches configured error patterns (or any reason if errorReasons is null)
+ *
+ * @example Basic usage with default error reasons
+ * <BadgeProgrammingError
+ *   isProgrammed={record.isProgrammed}
+ *   programmedReason={record.programmedReason}
+ *   statusMessage={record.statusMessage}
+ * />
+ *
+ * @example Custom error reasons
+ * <BadgeProgrammingError
+ *   isProgrammed={record.isProgrammed}
+ *   programmedReason={record.programmedReason}
+ *   statusMessage={record.statusMessage}
+ *   errorReasons={['InvalidConfiguration', 'SyncFailed']}
+ * />
+ *
+ * @example Show all programming errors (no filtering)
+ * <BadgeProgrammingError
+ *   isProgrammed={record.isProgrammed}
+ *   programmedReason={record.programmedReason}
+ *   statusMessage={record.statusMessage}
+ *   errorReasons={null}
+ * />
+ */
+export const BadgeProgrammingError = ({
+  isProgrammed,
+  programmedReason,
+  statusMessage,
+  className,
+  errorReasons = DEFAULT_ERROR_REASONS,
+}: BadgeProgrammingErrorProps) => {
+  // Only show when there's a programming error
+  if (isProgrammed !== false || !programmedReason) {
+    return null;
+  }
+
+  // If errorReasons is null, show error for any reason (no filtering)
+  // Otherwise, check if programmedReason matches the allowed list
+  const shouldShowError = errorReasons === null || errorReasons.includes(programmedReason);
+
+  if (!shouldShowError) {
+    return null;
+  }
+
+  return (
+    <BadgeStatus
+      status="error"
+      label="Error"
+      tooltipText={statusMessage || `Programming failed: ${programmedReason}`}
+      showTooltip={true}
+      showIcon={true}
+      customIcon={<TriangleAlertIcon className="size-3" />}
+      badgeType="danger"
+      badgeTheme="solid"
+      className={className}
+      tooltipContentClassName="max-w-64 bg-card text-destructive border"
+      tooltipArrowClassName="fill-card drop-shadow-[0_1px_0_var(--border)]"
+    />
+  );
+};

--- a/app/components/badge/badge-status.tsx
+++ b/app/components/badge/badge-status.tsx
@@ -93,6 +93,10 @@ export interface BadgeStatusProps {
   // Override centralized config (use sparingly)
   badgeType?: BadgeProps['type'];
   badgeTheme?: BadgeProps['theme'];
+  // Custom icon (overrides default config icon)
+  customIcon?: ReactNode;
+  tooltipContentClassName?: string;
+  tooltipArrowClassName?: string;
 }
 
 export const BadgeStatus = ({
@@ -104,6 +108,9 @@ export const BadgeStatus = ({
   className,
   badgeType: overrideBadgeType,
   badgeTheme: overrideBadgeTheme,
+  tooltipContentClassName,
+  tooltipArrowClassName,
+  customIcon,
 }: BadgeStatusProps) => {
   // Handle legacy IControlPlaneStatus format
   let statusValue: string;
@@ -148,7 +155,7 @@ export const BadgeStatus = ({
         customColorClasses,
         className
       )}>
-      {showIcon && config.icon}
+      {showIcon && (customIcon || config.icon)}
       {displayLabel}
     </Badge>
   );
@@ -157,7 +164,12 @@ export const BadgeStatus = ({
   if (showTooltip && finalTooltipText && statusValue !== 'active') {
     return (
       <div className="w-fit">
-        <Tooltip message={finalTooltipText}>{badgeContent}</Tooltip>
+        <Tooltip
+          message={finalTooltipText}
+          contentClassName={tooltipContentClassName}
+          arrowClassName={tooltipArrowClassName}>
+          {badgeContent}
+        </Tooltip>
       </div>
     );
   }

--- a/app/features/edge/dns-zone/overview/dns-records/dns-record-table.tsx
+++ b/app/features/edge/dns-zone/overview/dns-records/dns-record-table.tsx
@@ -1,11 +1,11 @@
 import type { DnsRecordTableProps } from './types';
+import { BadgeProgrammingError } from '@/components/badge/badge-programming-error';
 import { DataTable } from '@/modules/datum-ui/components/data-table';
 import { DataTableRef } from '@/modules/datum-ui/components/data-table';
 import { IFlattenedDnsRecord } from '@/resources/interfaces/dns.interface';
 import { formatTTL } from '@/utils/helpers/dns-record.helper';
 import { Badge, Tooltip } from '@datum-ui/components';
 import { ColumnDef } from '@tanstack/react-table';
-import { TriangleAlertIcon } from 'lucide-react';
 import { forwardRef, useMemo } from 'react';
 
 /**
@@ -31,21 +31,13 @@ export const DnsRecordTable = forwardRef<DataTableRef<IFlattenedDnsRecord>, DnsR
                   {row.original.type}
                 </Badge>
 
-                {row.original.isProgrammed === false &&
-                  row.original.programmedReason === 'InvalidDNSRecordSet' && (
-                    <Tooltip
-                      message={row.original.statusMessage}
-                      contentClassName="max-w-64 bg-card text-destructive border"
-                      arrowClassName="fill-card drop-shadow-[0_1px_0_var(--border)]">
-                      <Badge
-                        type="danger"
-                        theme="solid"
-                        className="flex cursor-pointer items-center gap-1 rounded-lg px-2 py-0.5">
-                        <TriangleAlertIcon className="size-3" />
-                        <span className="text-xs font-semibold">Error</span>
-                      </Badge>
-                    </Tooltip>
-                  )}
+                <BadgeProgrammingError
+                  className="rounded-lg px-2 py-0.5"
+                  isProgrammed={row.original.isProgrammed}
+                  programmedReason={row.original.programmedReason}
+                  statusMessage={row.original.statusMessage}
+                  errorReasons={['InvalidDNSRecordSet']}
+                />
               </div>
             );
           },

--- a/app/resources/interfaces/control-plane.interface.ts
+++ b/app/resources/interfaces/control-plane.interface.ts
@@ -11,3 +11,23 @@ export interface IControlPlaneStatus {
 
   [key: string]: any;
 }
+
+/**
+ * Extended status response with detailed condition information
+ * Used by transformControlPlaneStatus when includeConditionDetails is true
+ */
+export interface IExtendedControlPlaneStatus extends IControlPlaneStatus {
+  // Condition-specific fields (only when includeConditionDetails = true)
+  isProgrammed?: boolean;
+  programmedReason?: string;
+  isAccepted?: boolean;
+  acceptedReason?: string;
+
+  // All conditions for advanced usage
+  conditions?: Array<{
+    type: string;
+    status: 'True' | 'False' | 'Unknown';
+    reason?: string;
+    message?: string;
+  }>;
+}

--- a/app/routes/project/detail/edge/dns-zones/index.tsx
+++ b/app/routes/project/detail/edge/dns-zones/index.tsx
@@ -1,3 +1,4 @@
+import { BadgeProgrammingError } from '@/components/badge/badge-programming-error';
 import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
 import { DateTime } from '@/components/date-time';
 import { DnsHostChips } from '@/components/dns-host-chips';
@@ -7,6 +8,7 @@ import { ROUTE_PATH as DNS_ZONES_ACTIONS_PATH } from '@/routes/api/dns-zones';
 import { ROUTE_PATH as DOMAINS_REFRESH_PATH } from '@/routes/api/domains/refresh';
 import { paths } from '@/utils/config/paths.config';
 import { BadRequestError } from '@/utils/errors';
+import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Button, DataTable, DataTableRowActionsProps, toast } from '@datum-ui/components';
@@ -101,7 +103,22 @@ export default function DnsZonesPage() {
         header: 'Zone Name',
         accessorKey: 'domainName',
         cell: ({ row }) => {
-          return <span className="font-medium">{row.original.domainName}</span>;
+          const status = transformControlPlaneStatus(row.original.status, {
+            includeConditionDetails: true,
+          });
+          console.log('status', status);
+          return (
+            <div className="flex items-center gap-2">
+              <span className="font-medium">{row.original.domainName}</span>
+              <BadgeProgrammingError
+                className="rounded-lg px-2 py-0.5"
+                isProgrammed={status.isProgrammed}
+                programmedReason={status.programmedReason}
+                statusMessage={status.message}
+                errorReasons={null}
+              />
+            </div>
+          );
         },
       },
       {

--- a/app/routes/project/detail/home.tsx
+++ b/app/routes/project/detail/home.tsx
@@ -29,6 +29,7 @@ export default function ProjectDashboardPage() {
   const REVALIDATE_INTERVAL = 5000;
 
   const status = useMemo(() => {
+    console.log('project', project);
     if (project) {
       return transformControlPlaneStatus(project.status);
     }

--- a/app/utils/helpers/control-plane.helper.ts
+++ b/app/utils/helpers/control-plane.helper.ts
@@ -1,24 +1,209 @@
 import {
   ControlPlaneStatus,
   IControlPlaneStatus,
+  IExtendedControlPlaneStatus,
 } from '@/resources/interfaces/control-plane.interface';
 
-export function transformControlPlaneStatus(status: any): IControlPlaneStatus {
-  if (!status) return { status: ControlPlaneStatus.Pending, message: '' };
+/**
+ * Enhanced status extraction options
+ */
+export interface TransformStatusOptions {
+  /**
+   * Which conditions must be True for Success status
+   * @default Auto-detect - Uses intelligent detection based on available conditions
+   *
+   * Auto-detection modes:
+   * - undefined (default): Smart detection based on condition types
+   * - null: Check ALL conditions (all must be True for success)
+   * - string[]: Check specific conditions only
+   *
+   * Auto-detection priority (when undefined):
+   * 1. If 'Ready' condition exists → use ['Ready']
+   * 2. If 'Accepted' + 'Programmed' exist → use ['Accepted', 'Programmed']
+   * 3. If only 'Accepted' exists → use ['Accepted']
+   * 4. Otherwise → use first condition
+   *
+   * Manual override examples:
+   * - ['Ready'] - Projects, most core resources
+   * - ['Accepted', 'Programmed'] - DNS records, complex resources
+   * - null - Check all conditions (strictest mode)
+   */
+  requiredConditions?: string[] | null;
 
-  const { conditions, ...rest } = status;
-  if (status && (conditions ?? []).length > 0) {
-    const condition = conditions?.[0];
+  /**
+   * Whether to include detailed condition info
+   * @default false
+   */
+  includeConditionDetails?: boolean;
+}
+
+/**
+ * Auto-detect required conditions based on available conditions
+ * Uses intelligent priority-based detection for common K8s patterns
+ *
+ * Priority order:
+ * 1. 'Ready' - Most common for core resources (Projects, etc.)
+ * 2. 'Accepted' + 'Programmed' - Complex resources (DNS records, etc.)
+ * 3. 'Accepted' alone - Simple accepted resources
+ * 4. First available condition - Fallback
+ */
+function autoDetectRequiredConditions(conditionMap: Map<string, any>): string[] {
+  // Priority 1: Ready condition (most common for core resources)
+  if (conditionMap.has('Ready')) {
+    return ['Ready'];
+  }
+
+  // Priority 2: Accepted + Programmed (complex resources like DNS)
+  if (conditionMap.has('Accepted') && conditionMap.has('Programmed')) {
+    return ['Accepted', 'Programmed'];
+  }
+
+  // Priority 3: Accepted only (simple resources)
+  if (conditionMap.has('Accepted')) {
+    return ['Accepted'];
+  }
+
+  // Fallback: Use first available condition
+  const firstCondition = Array.from(conditionMap.keys())[0];
+  return firstCondition ? [firstCondition] : [];
+}
+
+/**
+ * Universal status transformer for all Control Plane resources
+ *
+ * Supports both simple (single condition) and complex (multiple conditions) resources
+ * Includes automatic condition detection for maximum flexibility
+ *
+ * @param status - K8s status object from resource
+ * @param options - Extraction options
+ *
+ * @example Auto-detection (recommended - smart default)
+ * transformControlPlaneStatus(project.status)
+ * // Auto-detects 'Ready' condition → { status: 'success', message: '' }
+ *
+ * @example Check ALL conditions (strictest mode)
+ * transformControlPlaneStatus(resource.status, {
+ *   requiredConditions: null
+ * })
+ * // All conditions must be True for success
+ *
+ * @example Manual override for DNS records
+ * transformControlPlaneStatus(dnsRecord.status, {
+ *   requiredConditions: ['Accepted', 'Programmed'],
+ *   includeConditionDetails: true
+ * })
+ * // → { status: 'pending', message: '...', isProgrammed: false, programmedReason: 'InvalidDNSRecordSet' }
+ */
+export function transformControlPlaneStatus(
+  status: any,
+  options: TransformStatusOptions = {}
+): IExtendedControlPlaneStatus {
+  const { includeConditionDetails = false } = options;
+
+  // No status object
+  if (!status) {
     return {
-      status:
-        condition?.status === 'True' ? ControlPlaneStatus.Success : ControlPlaneStatus.Pending,
-      message: condition?.message ?? '',
-      ...rest,
+      status: ControlPlaneStatus.Pending,
+      message: 'Resource is being provisioned',
     };
   }
 
-  return {
-    status: ControlPlaneStatus.Pending,
-    message: 'Resource is being provisioned',
+  const { conditions = [], ...rest } = status;
+
+  // No conditions available
+  if (conditions.length === 0) {
+    return {
+      status: ControlPlaneStatus.Pending,
+      message: 'Resource is being provisioned',
+    };
+  }
+
+  // Parse conditions into a map for easy lookup
+  const conditionMap = new Map<string, any>();
+  conditions.forEach((c: any) => {
+    conditionMap.set(c.type, c);
+  });
+
+  // Determine which conditions to check
+  let requiredConditions: string[];
+
+  if (options.requiredConditions === null) {
+    // Mode 1: Check ALL conditions (strictest)
+    requiredConditions = Array.from(conditionMap.keys());
+  } else if (options.requiredConditions === undefined) {
+    // Mode 2: Auto-detect (smart default)
+    requiredConditions = autoDetectRequiredConditions(conditionMap);
+  } else {
+    // Mode 3: Use specified conditions (manual override)
+    requiredConditions = options.requiredConditions;
+  }
+
+  // Check if all required conditions are True
+  const allConditionsMet = requiredConditions.every((condType) => {
+    const condition = conditionMap.get(condType);
+    return condition?.status === 'True';
+  });
+
+  // Determine status
+  let finalStatus: ControlPlaneStatus;
+  let finalMessage: string = '';
+
+  if (allConditionsMet) {
+    finalStatus = ControlPlaneStatus.Success;
+  } else {
+    finalStatus = ControlPlaneStatus.Pending;
+
+    // Collect messages from non-True conditions
+    const messages: string[] = [];
+    const seenMessages = new Set<string>(); // Track duplicates
+
+    requiredConditions.forEach((condType) => {
+      const condition = conditionMap.get(condType);
+      if (condition?.status !== 'True') {
+        const message = condition?.message || `Awaiting ${condType.toLowerCase()}`;
+
+        // Only add if we haven't seen this exact message before
+        if (!seenMessages.has(message.toLowerCase())) {
+          messages.push(message);
+          seenMessages.add(message.toLowerCase());
+        }
+      }
+    });
+
+    finalMessage =
+      messages.length > 0 ? messages.join('; ') : 'Resource is being provisioned';
+  }
+
+  // Base response
+  const response: IExtendedControlPlaneStatus = {
+    status: finalStatus,
+    message: finalMessage,
+    ...rest,
   };
+
+  // Add detailed condition info if requested
+  if (includeConditionDetails) {
+    const programmed = conditionMap.get('Programmed');
+    const accepted = conditionMap.get('Accepted');
+
+    if (programmed) {
+      response.isProgrammed = programmed.status === 'True';
+      response.programmedReason = programmed.reason;
+    }
+
+    if (accepted) {
+      response.isAccepted = accepted.status === 'True';
+      response.acceptedReason = accepted.reason;
+    }
+
+    // Include all conditions for advanced usage
+    response.conditions = conditions.map((c: any) => ({
+      type: c.type,
+      status: c.status,
+      reason: c.reason,
+      message: c.message,
+    }));
+  }
+
+  return response;
 }


### PR DESCRIPTION
- Add BadgeProgrammingError component for consistent error display
- Extend BadgeStatus with custom icon and tooltip styling options
- Enhance control-plane helper with unified status transformation
- Add error indicators to DNS zone overview and DNS record tables
- Support detailed condition information for better error context
- Improve status message handling and deduplication
