### PR TITLE
feat: add DNS record status route and enhance DNS record components

### DIFF
--- a/app/features/edge/dns-zone/discovery-preview.tsx
+++ b/app/features/edge/dns-zone/discovery-preview.tsx
@@ -187,6 +187,8 @@ export const DnsZoneDiscoveryPreview = ({
             </CardHeader>
             <CardContent className="p-5">
               <DnsRecordTable
+                projectId={projectId}
+                showStatus={false}
                 className="rounded-xl"
                 tableContainerClassName="rounded-xl"
                 data={dnsRecords}

--- a/app/features/edge/dns-zone/overview/dns-records/dns-record-card.tsx
+++ b/app/features/edge/dns-zone/overview/dns-records/dns-record-card.tsx
@@ -9,6 +9,7 @@ import { useMemo } from 'react';
  */
 export const DnsRecordCard = ({
   records,
+  projectId,
   maxRows = 5,
   title = 'DNS Records',
   actions,
@@ -28,7 +29,7 @@ export const DnsRecordCard = ({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <DnsRecordTable data={displayData} mode="compact" />
+        <DnsRecordTable projectId={projectId} data={displayData} mode="compact" />
       </CardContent>
     </Card>
   );

--- a/app/features/edge/dns-zone/overview/dns-records/dns-record-status.tsx
+++ b/app/features/edge/dns-zone/overview/dns-records/dns-record-status.tsx
@@ -1,0 +1,125 @@
+import { BadgeProgrammingError } from '@/components/badge/badge-programming-error';
+import { BadgeStatus } from '@/components/badge/badge-status';
+import { IExtendedControlPlaneStatus } from '@/resources/interfaces/control-plane.interface';
+import { IFlattenedDnsRecord } from '@/resources/interfaces/dns.interface';
+import { ROUTE_PATH as DNS_RECORD_STATUS_ROUTE_PATH } from '@/routes/api/dns-records/status';
+import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+import { useEffect, useRef, useState } from 'react';
+import { useFetcher } from 'react-router';
+
+interface DnsRecordStatusProps {
+  record: IFlattenedDnsRecord;
+  projectId: string;
+  className?: string;
+}
+
+/**
+ * DNS Record Status Component
+ *
+ * Simplified status logic:
+ * - status?.programmedReason === 'InvalidDNSRecordSet' → Show BadgeProgrammingError
+ * - isProgrammed === true → No badge (success state), stop polling
+ * - Other states → Show BadgeStatus with programmedReason as tooltip, start polling
+ * - Discovery records → No badge
+ */
+export const DnsRecordStatus = ({ record, projectId, className }: DnsRecordStatusProps) => {
+  const fetcher = useFetcher({ key: `dns-record-status-${record.recordSetName}` });
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [extendedStatus, setExtendedStatus] = useState<IExtendedControlPlaneStatus>();
+
+  // Initialize extended status from record fields (already extended)
+  useEffect(() => {
+    // If record has extended fields, use them directly
+    if (record.status) {
+      setExtendedStatus(record.status);
+    }
+  }, [record.status]);
+
+  useEffect(() => {
+    // Only set up polling for managed records that have recordSetId
+    if (!projectId || !record.recordSetName) {
+      return;
+    }
+
+    const loadStatus = () => {
+      if (record.recordSetName && projectId) {
+        fetcher.load(
+          `${getPathWithParams(DNS_RECORD_STATUS_ROUTE_PATH, { id: record.recordSetName })}?projectId=${projectId}`
+        );
+      }
+    };
+
+    // Initial load if:
+    // 1. No current status exists, or
+    // 2. Current status is pending
+    if (
+      !record.status ||
+      (!record.status?.isProgrammed && record.status?.programmedReason !== 'InvalidDNSRecordSet')
+    ) {
+      loadStatus();
+
+      // Set up polling interval
+      intervalRef.current = setInterval(loadStatus, 10000);
+    }
+
+    // Clean up interval on unmount
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [projectId, record]);
+
+  useEffect(() => {
+    if (fetcher.data && fetcher.state === 'idle') {
+      const statusData = transformControlPlaneStatus(fetcher.data.data, {
+        includeConditionDetails: true,
+        requiredConditions: ['Accepted', 'Programmed'],
+      });
+
+      setExtendedStatus(statusData);
+      if (
+        (statusData.isProgrammed === true ||
+          statusData.programmedReason === 'InvalidDNSRecordSet') &&
+        intervalRef.current
+      ) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }
+  }, [fetcher.data, fetcher.state, intervalRef]);
+
+  if (extendedStatus?.isProgrammed) {
+    return null;
+  }
+
+  // 2. Error state - show BadgeProgrammingError for InvalidDNSRecordSet
+  if (extendedStatus?.programmedReason === 'InvalidDNSRecordSet') {
+    return (
+      <BadgeProgrammingError
+        className={className}
+        isProgrammed={extendedStatus?.isProgrammed}
+        programmedReason={extendedStatus?.programmedReason}
+        statusMessage={extendedStatus?.message}
+        errorReasons={['InvalidDNSRecordSet']}
+      />
+    );
+  }
+
+  // 4. Other states (pending, other errors, unknown) - show BadgeStatus
+  const tooltipText =
+    extendedStatus?.message || extendedStatus?.programmedReason || 'DNS record is being validated';
+
+  return (
+    <BadgeStatus
+      status={extendedStatus?.status}
+      label="Validating"
+      showIcon={true}
+      showTooltip={true}
+      tooltipText={tooltipText}
+      className={className}
+    />
+  );
+};

--- a/app/features/edge/dns-zone/overview/dns-records/dns-record-table.tsx
+++ b/app/features/edge/dns-zone/overview/dns-records/dns-record-table.tsx
@@ -1,5 +1,5 @@
+import { DnsRecordStatus } from './dns-record-status';
 import type { DnsRecordTableProps } from './types';
-import { BadgeProgrammingError } from '@/components/badge/badge-programming-error';
 import { DataTable } from '@/modules/datum-ui/components/data-table';
 import { DataTableRef } from '@/modules/datum-ui/components/data-table';
 import { IFlattenedDnsRecord } from '@/resources/interfaces/dns.interface';
@@ -17,13 +17,25 @@ import { forwardRef, useMemo } from 'react';
  * Each value in DNS records becomes a separate row
  */
 export const DnsRecordTable = forwardRef<DataTableRef<IFlattenedDnsRecord>, DnsRecordTableProps>(
-  ({ data, mode = 'compact', className, emptyContent, tableContainerClassName, ...props }, ref) => {
+  (
+    {
+      data,
+      mode = 'compact',
+      className,
+      emptyContent,
+      tableContainerClassName,
+      projectId,
+      showStatus = true,
+      ...props
+    },
+    ref
+  ) => {
     const columns: ColumnDef<IFlattenedDnsRecord>[] = useMemo(
       () => [
         {
           header: 'Type',
           accessorKey: 'type',
-          size: 80,
+          size: 120,
           cell: ({ row }) => {
             return (
               <div className="flex items-center gap-2">
@@ -31,13 +43,13 @@ export const DnsRecordTable = forwardRef<DataTableRef<IFlattenedDnsRecord>, DnsR
                   {row.original.type}
                 </Badge>
 
-                <BadgeProgrammingError
-                  className="rounded-lg px-2 py-0.5"
-                  isProgrammed={row.original.isProgrammed}
-                  programmedReason={row.original.programmedReason}
-                  statusMessage={row.original.statusMessage}
-                  errorReasons={['InvalidDNSRecordSet']}
-                />
+                {showStatus && (
+                  <DnsRecordStatus
+                    record={row.original}
+                    projectId={projectId}
+                    className="rounded-lg px-2 py-0.5"
+                  />
+                )}
               </div>
             );
           },

--- a/app/features/edge/dns-zone/overview/dns-records/types.ts
+++ b/app/features/edge/dns-zone/overview/dns-records/types.ts
@@ -14,9 +14,11 @@ import { IFlattenedDnsRecord } from '@/resources/interfaces/dns.interface';
  */
 export interface DnsRecordTableBaseProps {
   data: IFlattenedDnsRecord[];
+  projectId: string;
   className?: string;
   tableContainerClassName?: string;
   emptyContent?: EmptyContentProps;
+  showStatus?: boolean;
 }
 
 /**
@@ -55,6 +57,7 @@ export type DnsRecordTableProps = DnsRecordTableCompactProps | DnsRecordTableFul
  */
 export interface DnsRecordCardProps {
   records: IFlattenedDnsRecord[];
+  projectId: string;
   maxRows?: number;
   title?: string;
   actions?: React.ReactNode;

--- a/app/resources/control-plane/dns-networking/dns-record-set.control.ts
+++ b/app/resources/control-plane/dns-networking/dns-record-set.control.ts
@@ -6,11 +6,17 @@ import {
   listDnsNetworkingMiloapisComV1Alpha1NamespacedDnsRecordSet,
   patchDnsNetworkingMiloapisComV1Alpha1NamespacedDnsRecordSet,
   readDnsNetworkingMiloapisComV1Alpha1NamespacedDnsRecordSet,
+  readDnsNetworkingMiloapisComV1Alpha1NamespacedDnsRecordSetStatus,
 } from '@/modules/control-plane/dns-networking';
+import {
+  IControlPlaneStatus,
+  IExtendedControlPlaneStatus,
+} from '@/resources/interfaces/control-plane.interface';
 import {
   IDnsRecordSetControlResponse,
   IFlattenedDnsRecord,
 } from '@/resources/interfaces/dns.interface';
+import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
 import { flattenDnsRecordSets } from '@/utils/helpers/dns-record.helper';
 import { generateId, generateRandomString } from '@/utils/helpers/text.helper';
 import { Client } from '@hey-api/client-axios';
@@ -208,6 +214,28 @@ export const createDnsRecordSetsControl = (client: Client) => {
       const dnsRecordSets = response.data as ComMiloapisNetworkingDnsV1Alpha1DnsRecordSetList;
       const items = dnsRecordSets.items.map(transformDnsRecordSet);
       return items.length > 0 ? items[0] : undefined;
+    },
+
+    /**
+     * Get status of a DNS Record Set
+     */
+    getStatus: async (
+      projectId: string,
+      recordSetId: string
+    ): Promise<ComMiloapisNetworkingDnsV1Alpha1DnsRecordSet['status']> => {
+      try {
+        const response = await readDnsNetworkingMiloapisComV1Alpha1NamespacedDnsRecordSetStatus({
+          client,
+          baseURL: `${baseUrl}/projects/${projectId}/control-plane`,
+          path: { namespace: 'default', name: recordSetId },
+        });
+
+        const dnsRecordSet = response.data as ComMiloapisNetworkingDnsV1Alpha1DnsRecordSet;
+
+        return dnsRecordSet.status;
+      } catch (e) {
+        throw e;
+      }
     },
   };
 };

--- a/app/resources/interfaces/dns.interface.ts
+++ b/app/resources/interfaces/dns.interface.ts
@@ -4,7 +4,11 @@ import {
   ComMiloapisNetworkingDnsV1Alpha1DnsZoneDiscovery,
 } from '@/modules/control-plane/dns-networking';
 import { ComDatumapisNetworkingV1AlphaDomain } from '@/modules/control-plane/networking';
-import { ControlPlaneStatus } from '@/resources/interfaces/control-plane.interface';
+import {
+  ControlPlaneStatus,
+  IControlPlaneStatus,
+  IExtendedControlPlaneStatus,
+} from '@/resources/interfaces/control-plane.interface';
 
 // ============================================
 // DNS Zone Interfaces
@@ -77,10 +81,7 @@ export interface IFlattenedDnsRecord {
   ttl?: number;
 
   // Status (only for managed recordsets, undefined for discovery)
-  status?: ControlPlaneStatus;
-  statusMessage?: string; // Pending message from K8s conditions (only when status is Pending)
-  isProgrammed?: boolean; // Programmed condition state (True/False)
-  programmedReason?: string; // Reason from Programmed condition (e.g., InvalidDNSRecordSet)
+  status?: IExtendedControlPlaneStatus;
 
   // Raw data for editing/display
   rawData: any;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -264,6 +264,7 @@ export default [
       route('dns-records', 'routes/api/dns-records/index.ts'),
       route('dns-records/bulk-import', 'routes/api/dns-records/bulk-import.ts'),
       route('dns-records/:id', 'routes/api/dns-records/$id.ts'),
+      route('dns-records/:id/status', 'routes/api/dns-records/status.ts'),
 
       // DNS Zone Discoveries
       route('dns-zone-discoveries', 'routes/api/dns-zone-discoveries/index.ts'),

--- a/app/routes/api/dns-records/status.ts
+++ b/app/routes/api/dns-records/status.ts
@@ -1,0 +1,34 @@
+import { createDnsRecordSetsControl } from '@/resources/control-plane';
+import { BadRequestError } from '@/utils/errors';
+import { Client } from '@hey-api/client-axios';
+import { AppLoadContext, LoaderFunctionArgs, data } from 'react-router';
+
+export const ROUTE_PATH = '/api/dns-records/:id/status' as const;
+
+export const loader = async ({ params, context, request }: LoaderFunctionArgs) => {
+  try {
+    const { id } = params;
+
+    if (!id) {
+      throw new BadRequestError('DNS Record ID is required');
+    }
+
+    const url = new URL(request.url);
+    const projectId = url.searchParams.get('projectId');
+
+    if (!projectId) {
+      throw new BadRequestError('Project ID and DNS Record ID are required');
+    }
+
+    const { controlPlaneClient } = context as AppLoadContext;
+    const dnsRecordSetsControl = createDnsRecordSetsControl(controlPlaneClient as Client);
+
+    const status = await dnsRecordSetsControl.getStatus(projectId, id);
+    return data({ success: true, data: status }, { status: 200 });
+  } catch (error: any) {
+    return data(
+      { success: false, error: error?.message ?? 'An unexpected error occurred' },
+      { status: 500 }
+    );
+  }
+};

--- a/app/routes/project/detail/edge/dns-zones/detail/dns-records.tsx
+++ b/app/routes/project/detail/edge/dns-zones/detail/dns-records.tsx
@@ -114,10 +114,15 @@ export default function DnsRecordsPage() {
   }, [fetcher.data, fetcher.state]);
 
   const handleOnSuccess = (mode: 'create' | 'edit' = 'create') => {
-    // Reload data after successful add/save
-    toast.success(`DNS record ${mode === 'create' ? 'added' : 'saved'} successfully`, {
-      description: `The ${mode === 'create' ? 'DNS record has been added' : 'DNS record has been saved'} successfully`,
-    });
+    if (mode === 'create') {
+      toast.success('DNS record submitted. Validating…', {
+        description: 'The DNS record is being validated by the DNS server.',
+      });
+    } else {
+      toast.success('DNS record updated. Validating…', {
+        description: 'The DNS record changes are being validated by the DNS server.',
+      });
+    }
 
     revalidator.revalidate();
   };
@@ -134,6 +139,7 @@ export default function DnsRecordsPage() {
       <DnsRecordTable
         mode="full"
         data={dnsRecordSets}
+        projectId={projectId!}
         emptyContent={{
           title: 'No DNS records found',
           actions: [
@@ -154,7 +160,11 @@ export default function DnsRecordsPage() {
               type="primary"
               theme="solid"
               size="small"
-              onClick={() => tableRef.current?.openCreate()}>
+              onClick={() =>
+                dnsRecordSets.length > 0
+                  ? tableRef.current?.openCreate()
+                  : dnsRecordModalFormRef.current?.show('create')
+              }>
               <PlusIcon className="size-4" />
               Add record
             </Button>

--- a/app/routes/project/detail/edge/dns-zones/detail/layout.tsx
+++ b/app/routes/project/detail/edge/dns-zones/detail/layout.tsx
@@ -3,6 +3,7 @@ import { SubLayout } from '@/layouts';
 import { createDomainsControl } from '@/resources/control-plane';
 import { createDnsZonesControl } from '@/resources/control-plane/dns-networking';
 import { IDnsZoneControlResponse } from '@/resources/interfaces/dns.interface';
+import { IDomainControlResponse } from '@/resources/interfaces/domain.interface';
 import { paths } from '@/utils/config/paths.config';
 import { BadRequestError, NotFoundError } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
@@ -47,9 +48,12 @@ export const loader = async ({ context, params }: LoaderFunctionArgs) => {
     throw new NotFoundError('DNS not found');
   }
 
-  // Get Domain Detail
-  const domainsControl = createDomainsControl(controlPlaneClient as Client);
-  const domain = await domainsControl.detail(projectId, dnsZone.status?.domainRef?.name ?? '');
+  let domain: IDomainControlResponse | null = null;
+  if (dnsZone.status?.domainRef?.name) {
+    // Get Domain Detail
+    const domainsControl = createDomainsControl(controlPlaneClient as Client);
+    domain = await domainsControl.detail(projectId, dnsZone.status?.domainRef?.name ?? '');
+  }
 
   return data({ dnsZone, domain });
 };

--- a/app/routes/project/detail/edge/dns-zones/detail/overview.tsx
+++ b/app/routes/project/detail/edge/dns-zones/detail/overview.tsx
@@ -97,6 +97,7 @@ export default function DnsZoneOverviewPage() {
       <Col span={24}>
         <TaskRecordCard projectId={projectId ?? ''} dnsZone={dnsZone!} />
         {/* <DnsRecordCard
+          projectId={projectId ?? ''}
           records={flattenedRecords}
           maxRows={5}
           title="DNS Records"

--- a/app/utils/helpers/dns-record.helper.ts
+++ b/app/utils/helpers/dns-record.helper.ts
@@ -1,5 +1,8 @@
 import { ComMiloapisNetworkingDnsV1Alpha1DnsRecordSet } from '@/modules/control-plane/dns-networking';
-import { ControlPlaneStatus } from '@/resources/interfaces/control-plane.interface';
+import {
+  ControlPlaneStatus,
+  IExtendedControlPlaneStatus,
+} from '@/resources/interfaces/control-plane.interface';
 import {
   IDnsRecordSetControlResponse,
   IDnsZoneDiscoveryRecordSet,
@@ -151,10 +154,7 @@ function flattenManagedRecordSets(
       recordSetName: recordSet.name || '',
       createdAt: recordSet.createdAt || new Date(),
       dnsZoneId: recordSet.dnsZoneId || '',
-      status: statusInfo.status,
-      statusMessage: statusInfo.message,
-      isProgrammed: statusInfo.isProgrammed,
-      programmedReason: statusInfo.programmedReason,
+      status: statusInfo,
     });
 
     flattened.push(...entries);
@@ -210,10 +210,7 @@ function flattenRecordEntries(
     recordSetName?: string;
     createdAt?: Date;
     dnsZoneId: string;
-    status?: ControlPlaneStatus;
-    statusMessage?: string;
-    isProgrammed?: boolean;
-    programmedReason?: string;
+    status?: IExtendedControlPlaneStatus;
   }
 ): IFlattenedDnsRecord[] {
   const flattened: IFlattenedDnsRecord[] = [];


### PR DESCRIPTION
- Introduced a new route for fetching the status of DNS records.
- Updated DnsRecordTable and DnsRecordCard components to accept projectId and showStatus props.
- Enhanced DnsZoneDiscoveryPreview to pass projectId to DnsRecordTable.
- Refactored DNS record status handling to utilize IExtendedControlPlaneStatus for improved status management.