### PR TITLE
fix: allow leading underscore

### DIFF
--- a/app/resources/schemas/dns-record.schema.ts
+++ b/app/resources/schemas/dns-record.schema.ts
@@ -50,7 +50,7 @@ export const baseRecordFieldSchema = z.object({
   name: z
     .string({ error: 'Name is required.' })
     .min(1, 'Name is required.')
-    .regex(/^(@|[a-zA-Z0-9]([a-zA-Z0-9-_.]*[a-zA-Z0-9])?)$/, {
+    .regex(/^(@|[_a-zA-Z0-9]([a-zA-Z0-9-_.]*[a-zA-Z0-9])?)$/, {
       message:
         'Name must be @ (root domain) or contain only alphanumeric characters, hyphens, underscores, and dots.',
     }),


### PR DESCRIPTION
This pull request makes a minor adjustment to the DNS record field validation schema to allow underscores at the beginning of record names.

* Validation update: The regular expression for the `name` field in `baseRecordFieldSchema` (`dns-record.schema.ts`) was modified to permit underscores as the first character, supporting valid DNS record names that start with an underscore.