### PR TITLE
fix: dedupe isAuthenticated requests where possible

### DIFF
--- a/app/layouts/private.layout.tsx
+++ b/app/layouts/private.layout.tsx
@@ -62,8 +62,7 @@ export const loader = withMiddleware(
 );
 
 export default function PrivateLayout() {
-  const data: { user: IUser; helpscoutSignature: string | null; ENV: any } =
-    useLoaderData<typeof loader>();
+  const data = useLoaderData<{ user: IUser; helpscoutSignature: string | null; ENV: any }>();
 
   const [helpscoutEnv, setHelpscoutEnv] = useState<{
     HELPSCOUT_BEACON_ID: string;

--- a/app/layouts/public.layout.tsx
+++ b/app/layouts/public.layout.tsx
@@ -1,12 +1,18 @@
 import { paths } from '@/utils/config/paths.config';
-import { getSession, isAuthenticated } from '@/utils/cookies';
+import { isAuthenticated, isAuthenticatedResult } from '@/utils/cookies';
 import { LoaderFunctionArgs, Outlet, redirect } from 'react-router';
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const isLoggedIn = await isAuthenticated(request);
-  if (isLoggedIn) {
-    const session = await getSession(request);
-    return redirect(paths.home, { headers: session?.headers });
+  const result = await isAuthenticated(request);
+
+  // If result is a Response (redirect), return it
+  if (result instanceof Response) {
+    return result;
+  }
+
+  // If authenticated, use the headers from isAuthenticated (which includes refreshed tokens)
+  if (isAuthenticatedResult(result)) {
+    return redirect(paths.home, { headers: result.headers });
   }
 
   return null;

--- a/app/utils/cookies/session.server.ts
+++ b/app/utils/cookies/session.server.ts
@@ -4,6 +4,8 @@ import { IAuthSession } from '@/resources/interfaces/auth.interface';
 import { isProduction } from '@/utils/config/env.config';
 import { paths } from '@/utils/config/paths.config';
 import { setRedirectIntent } from '@/utils/cookies/redirect-intent.server';
+import { getRefreshedSession, setRefreshedSession } from '@/utils/middlewares/middleware';
+import { cache } from 'react';
 import { createCookie, createCookieSessionStorage, redirect } from 'react-router';
 
 /**
@@ -78,6 +80,18 @@ export async function setSession(
  * @returns Response with session data and headers
  */
 export async function getSession(request: Request): Promise<SessionResponse> {
+  // Check if there's a refreshed session in context (from isAuthenticated)
+  const refreshedSession = getRefreshedSession(request);
+  if (refreshedSession) {
+    // Use the refreshed session data and get headers from it
+    const session = await sessionStorage.getSession(request.headers.get('Cookie'));
+    // Set the refreshed session data
+    session.set(SESSION_KEY, refreshedSession);
+    const cookieHeader = await sessionStorage.commitSession(session);
+    return createSessionResponse(refreshedSession, cookieHeader);
+  }
+
+  // Otherwise, read from cookies as normal
   const session = await sessionStorage.getSession(request.headers.get('Cookie'));
   const sessionData = session.get(SESSION_KEY);
   const cookieHeader = await sessionStorage.commitSession(session);
@@ -98,17 +112,41 @@ export async function destroySession(request: Request): Promise<SessionResponse>
 }
 
 /**
- * Checks if the user is authenticated and redirects to the login page if not
- * @param request Request object
- * @param redirectTo Optional redirect URL
- * @param noAuthRedirect Optional flag to redirect to the login page if the user is not authenticated
- * @returns Response with either a redirect to the login page or the original request
+ * Result type for isAuthenticated when user is authenticated
  */
-export async function isAuthenticated(
+export type AuthenticatedResult = {
+  authenticated: true;
+  headers: Headers;
+};
+
+/**
+ * Type guard to check if a value is an AuthenticatedResult
+ */
+export function isAuthenticatedResult(value: unknown): value is AuthenticatedResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'authenticated' in value &&
+    (value as AuthenticatedResult).authenticated === true &&
+    'headers' in value &&
+    (value as AuthenticatedResult).headers instanceof Headers
+  );
+}
+
+/**
+ * In-flight refresh operations map to prevent concurrent refreshes
+ * Key: refresh token, Value: Promise that resolves when refresh completes
+ */
+const refreshLocks = new Map<string, Promise<IAuthSession>>();
+
+/**
+ * Internal implementation of isAuthenticated (wrapped with cache to prevent duplicate token refreshes)
+ */
+const _isAuthenticated = async (
   request: Request,
   redirectTo?: string,
   noAuthRedirect?: boolean
-) {
+): Promise<Response | AuthenticatedResult> => {
   const { session, headers } = await getSession(request);
   let currentHeaders = headers;
 
@@ -128,13 +166,15 @@ export async function isAuthenticated(
     url.search = '';
 
     // Redirect to OIDC Page and include the redirect intent cookie in the response
-    // The authenticator throws a redirect Response, so we need to catch it
+    // The authenticator throws a redirect Response when not authenticated, so we need to catch it
     try {
-      const authResponse = await authenticator.authenticate(
-        'zitadel',
-        new Request(url.toString(), request)
-      );
-      return authResponse;
+      await authenticator.authenticate('zitadel', new Request(url.toString(), request));
+      // If we get here, authentication succeeded (shouldn't happen in this flow)
+      // But TypeScript requires handling this case
+      // In practice, authenticate throws a Response redirect when not authenticated
+      return redirect(paths.auth.logOut, {
+        headers: redirectIntentHeaders,
+      });
     } catch (error) {
       // If the authenticator throws a Response (redirect), add our cookie to it
       if (error instanceof Response) {
@@ -158,25 +198,117 @@ export async function isAuthenticated(
       });
     }
 
-    // Only refresh token if it's about to expire (e.g., within 5 minutes)
+    // Only refresh token if it's about to expire
     const FIVE_MINUTES = 5 * 60 * 1000; // 5 minutes in milliseconds
     const currentTime = Date.now();
     const timeUntilExpiry = tokenExpiryTime - currentTime;
 
-    // Refresh token only if it's about to expire (within 5 minutes) or already expired
     if (session.refreshToken && timeUntilExpiry < FIVE_MINUTES) {
+      // First, check if there's already a refreshed session in the context
+      // This handles the case where another call in the same request already refreshed
+      const alreadyRefreshed = getRefreshedSession(request);
+      if (alreadyRefreshed) {
+        const refreshedExpiryTime = new Date(alreadyRefreshed.expiredAt).getTime();
+        const refreshedTimeUntilExpiry = refreshedExpiryTime - Date.now();
+        // Only use the refreshed session if it's still valid and not about to expire
+        if (refreshedTimeUntilExpiry >= FIVE_MINUTES) {
+          const { headers: refreshedHeaders } = await getSession(request);
+          currentHeaders = refreshedHeaders;
+          // Skip refresh since we already have a valid refreshed session
+          if (redirectTo) {
+            return redirect(redirectTo, { headers: currentHeaders });
+          }
+          return { authenticated: true, headers: currentHeaders };
+        }
+        // The refreshed session is also about to expire, continue with refresh
+      }
+
+      const refreshToken = session.refreshToken;
+
+      // Check if there's already a refresh in progress for this token
+      let refreshPromise = refreshLocks.get(refreshToken);
+
+      if (!refreshPromise) {
+        // No refresh in progress, start a new one
+        refreshPromise = (async (): Promise<IAuthSession> => {
+          try {
+            const refreshSession = await zitadelStrategy.refreshToken(refreshToken);
+
+            const refreshedSessionData = {
+              ...session,
+              accessToken: refreshSession.accessToken(),
+              refreshToken: refreshSession.refreshToken(),
+              expiredAt: refreshSession.accessTokenExpiresAt(),
+            };
+
+            // Store refreshed session in context so getSession can use it
+            setRefreshedSession(request, refreshedSessionData);
+
+            const { headers: sessionHeaders } = await setSession(request, refreshedSessionData);
+
+            currentHeaders = sessionHeaders;
+
+            // Update the lock to use the new refresh token
+            // This prevents concurrent calls with the new token from refreshing again
+            const newRefreshToken = refreshedSessionData.refreshToken;
+            if (newRefreshToken && newRefreshToken !== refreshToken) {
+              refreshLocks.set(newRefreshToken, Promise.resolve(refreshedSessionData));
+            }
+
+            // Clean up the old lock after a delay
+            setTimeout(() => {
+              refreshLocks.delete(refreshToken);
+            }, 1000);
+
+            return refreshedSessionData;
+          } catch (error) {
+            // Remove lock on error so retry is possible
+            refreshLocks.delete(refreshToken);
+            throw error;
+          }
+        })();
+
+        // Store the refresh promise in the lock map
+        refreshLocks.set(refreshToken, refreshPromise);
+      }
+
+      // Wait for refresh to complete (either the one we started or an existing one)
       try {
-        const refreshSession = await zitadelStrategy.refreshToken(session.refreshToken);
+        const refreshedSessionData = await refreshPromise;
 
-        const { headers: sessionHeaders } = await setSession(request, {
-          accessToken: refreshSession.accessToken(),
-          refreshToken: refreshSession.refreshToken(),
-          expiredAt: refreshSession.accessTokenExpiresAt(),
-        });
+        // Verify the refreshed session is valid
+        if (!refreshedSessionData || !refreshedSessionData.accessToken) {
+          return redirect(paths.auth.logOut, {
+            headers: currentHeaders,
+          });
+        }
 
-        currentHeaders = sessionHeaders;
+        // Update the session variable to use the refreshed data
+        // This ensures we're working with the latest token
+        const refreshedExpiryTime = new Date(refreshedSessionData.expiredAt).getTime();
+        if (refreshedExpiryTime < Date.now()) {
+          // Refreshed token is already expired, log out
+          return redirect(paths.auth.logOut, {
+            headers: currentHeaders,
+          });
+        }
+
+        // Double-check that the refreshed session is in context
+        // This ensures getSession will return the refreshed data
+        const contextRefreshed = getRefreshedSession(request);
+        if (
+          !contextRefreshed ||
+          contextRefreshed.accessToken !== refreshedSessionData.accessToken
+        ) {
+          // If not in context, set it again (shouldn't happen, but defensive)
+          setRefreshedSession(request, refreshedSessionData);
+        }
+
+        // Update headers from the refreshed session
+        const { headers: refreshedHeaders } = await getSession(request);
+        currentHeaders = refreshedHeaders;
       } catch (error) {
-        console.error('Refresh token failed:', error);
+        console.log('Refresh token failed:', error);
         // If refresh fails, log the user out
         return redirect(paths.auth.logOut, {
           headers: currentHeaders,
@@ -188,6 +320,18 @@ export async function isAuthenticated(
       return redirect(redirectTo, { headers: currentHeaders });
     }
 
-    return true;
+    return { authenticated: true, headers: currentHeaders };
   }
-}
+};
+
+/**
+ * Checks if the user is authenticated and redirects to the login page if not
+ * Wrapped with cache to prevent duplicate token refresh calls when
+ * multiple loaders call this function in parallel during the same request.
+ *
+ * @param request Request object
+ * @param redirectTo Optional redirect URL
+ * @param noAuthRedirect Optional flag to redirect to the login page if the user is not authenticated
+ * @returns Response with redirect, or AuthenticatedResult with headers (including refreshed token headers)
+ */
+export const isAuthenticated = cache(_isAuthenticated);

--- a/app/utils/middlewares/auth.middleware.ts
+++ b/app/utils/middlewares/auth.middleware.ts
@@ -1,6 +1,7 @@
-import { NextFunction } from './middleware';
-import { isAuthenticated } from '@/utils/cookies';
+import { NextFunction, setAuthHeaders } from './middleware';
+import { isAuthenticated, isAuthenticatedResult } from '@/utils/cookies';
 import { AuthenticationError } from '@/utils/errors';
+import { combineHeaders } from '@/utils/helpers/path.helper';
 
 /**
  * Authentication middleware that checks if a user is authenticated
@@ -18,9 +19,26 @@ export async function authMiddleware(request: Request, next: NextFunction): Prom
     return result;
   }
 
-  // If result is true (user is authenticated), proceed to next middleware
-  if (result === true) {
-    return next();
+  // If result is AuthenticatedResult (user is authenticated), proceed to next middleware
+  // and merge the auth headers (including refreshed token) with the response headers
+  if (isAuthenticatedResult(result)) {
+    // Store auth headers in context so withMiddleware can merge them with data() returns
+    setAuthHeaders(request, result.headers);
+
+    const response = await next();
+
+    // If response is a Response, merge the auth headers with it
+    if (response instanceof Response) {
+      const mergedHeaders = combineHeaders(result.headers, response.headers);
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: mergedHeaders,
+      });
+    }
+
+    // If response is not a Response (e.g., data object), withMiddleware will handle merging
+    return response;
   }
 
   // This should not happen if isAuthenticated is properly implemented,

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cloud-portal",


### PR DESCRIPTION
Dedupe isAuthenticated requests where possible and add in memory lock to make sure only one refresh can happen

Multiple `isAuthenticated` calls happen in parallel which causes the refreshed token not to be used in some of the requests leading to being logged out. This PR fixes these by using `cache` to dedupe multiple function calls with the same arguments and add a lock on the refresh token to make sure only one call to get a new token is sent. It then merges the new token into the session context to make sure all requests have the latest token. 

Caveat:

If a users requests are spread across different pods this won't work. We could do the following on the deployment to force requests to the same pod?

```
    sessionAffinity: ClientIP
    sessionAffinityConfig:
      clientIP:
        timeoutSeconds: 10800
```
