### PR TITLE
chore: update main nav to bring inline with updated designs

### DIFF
--- a/app/components/header/header.tsx
+++ b/app/components/header/header.tsx
@@ -8,7 +8,7 @@ import { IProjectControlResponse } from '@/resources/interfaces/project.interfac
 import { paths } from '@/utils/config/paths.config';
 import { Button } from '@datum-ui/components';
 import { Tooltip } from '@datum-ui/components';
-import { BookOpen, SlashIcon } from 'lucide-react';
+import { BookOpen } from 'lucide-react';
 import { Link } from 'react-router';
 
 export const Header = ({
@@ -22,14 +22,28 @@ export const Header = ({
     <header className="bg-background sticky top-0 z-50 flex h-[54px] w-full max-w-screen shrink-0 items-center justify-between gap-4 border-b px-4 py-3.5">
       {/* Left Section */}
       <div className="flex flex-1 items-center">
-        <Link to={paths.account.root} className="mr-6 flex size-7 items-center gap-2">
+        <Link to={paths.account.root} className="mr-6 flex items-center justify-center">
           <LogoIcon width={21} />
         </Link>
         {currentOrg && <OrganizationSwitcher currentOrg={currentOrg} />}
         {currentProject && (
           <>
-            <SlashIcon size={14} className="text-foreground/10 mx-2.5" />
-            <ProjectSwitcher currentProject={currentProject} triggerClassName="h-7 w-fit" />
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 14 14"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg">
+              <path
+                opacity="0.1"
+                className="stroke-foreground"
+                d="M9.96004 1.31641L4.04004 12.6837"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+
+            <ProjectSwitcher currentProject={currentProject} triggerClassName="w-4 h-4" />
           </>
         )}
       </div>
@@ -42,8 +56,8 @@ export const Header = ({
                 type="quaternary"
                 theme="outline"
                 size="small"
-                className="h-7 w-7 rounded-xl p-0">
-                <BookOpen className="text-quaternary-foreground size-3.5" />
+                className="h-7 w-7 rounded-lg p-0">
+                <BookOpen className="text-icon-primary size-3.5" />
               </Button>
             </Link>
           </Tooltip>

--- a/app/components/header/org-switcher.tsx
+++ b/app/components/header/org-switcher.tsx
@@ -12,20 +12,20 @@ export const OrganizationSwitcher = ({ currentOrg }: { currentOrg: IOrganization
   const navigate = useNavigate();
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-2.5">
       <Link
         to={getPathWithParams(paths.org.detail.projects.root, { orgId: currentOrg?.name })}
-        className="flex w-fit items-center justify-between text-left">
-        <Building className="text-secondary/60 h-3.5" />
-        <span className="ml-2.5 max-w-[120px] truncate text-sm leading-3.5 sm:max-w-36 md:max-w-none">
+        className="flex w-fit items-center justify-between gap-3 text-left">
+        <Building className="text-icon-primary h-3.5 w-fit" />
+        <span className="max-w-[120px] truncate text-sm leading-3.5 sm:max-w-36 md:max-w-none">
           {currentOrg?.displayName ?? currentOrg?.name}
         </span>
         {currentOrg?.type === OrganizationType.Personal && (
-          <PersonalBadge className="ml-3 hidden sm:block" />
+          <PersonalBadge className="hidden sm:block" />
         )}
       </Link>
       <SelectOrganization
-        triggerClassName="h-3.5"
+        triggerClassName="h-4 w-4 p-0 mr-2.5"
         currentOrg={currentOrg!}
         hideContent
         onSelect={(org: IOrganization) => {

--- a/app/components/header/project-switcher.tsx
+++ b/app/components/header/project-switcher.tsx
@@ -70,14 +70,14 @@ export const ProjectSwitcher = ({
   }, [fetcher.data, fetcher.state]);
 
   return (
-    <div className="flex items-center gap-1 pl-2">
+    <div className="flex items-center gap-2.5 pl-2.5">
       <Link
         to={getPathWithParams(paths.project.detail.home, {
           projectId: currentProject.name,
         })}
-        className="flex w-fit items-center justify-between text-left">
-        <FolderRoot className="text-secondary/60 h-3.5" />
-        <span className="ml-2.5 max-w-[100px] truncate text-sm leading-3.5 sm:max-w-36 md:max-w-none">
+        className="flex w-fit items-center justify-between gap-2.5 text-left">
+        <FolderRoot className="text-icon-primary h-3.5 w-fit" />
+        <span className="max-w-[100px] truncate text-sm leading-3.5 sm:max-w-36 md:max-w-none">
           {currentProject?.description}
         </span>
       </Link>
@@ -88,11 +88,14 @@ export const ProjectSwitcher = ({
             theme="borderless"
             size="small"
             className={cn(
-              'flex h-3.5 w-full cursor-pointer gap-2 border-none p-0 px-2 hover:bg-transparent active:bg-transparent data-[state=open]:bg-transparent',
+              'flex cursor-pointer gap-2 border-none p-0 hover:bg-transparent active:bg-transparent data-[state=open]:bg-transparent',
               triggerClassName
             )}>
             <ChevronDown
-              className={cn('text-secondary/60 size-4 transition-all', open && 'rotate-180')}
+              className={cn(
+                'text-icon-secondary size-4 w-fit transition-all',
+                open && 'rotate-180'
+              )}
             />
           </Button>
         </PopoverTrigger>

--- a/app/components/header/user-dropdown.tsx
+++ b/app/components/header/user-dropdown.tsx
@@ -31,12 +31,12 @@ export const UserDropdown = ({ className }: { className?: string }) => {
           theme="solid"
           size="small"
           className={cn(
-            'h-7 w-7 cursor-pointer rounded-xl border-none p-0 focus-visible:ring-0 focus-visible:ring-offset-0',
+            'h-7 w-7 cursor-pointer rounded-lg border-none p-0 focus-visible:ring-0 focus-visible:ring-offset-0',
             className
           )}>
-          <Avatar className="size-full rounded-xl">
+          <Avatar className="size-full rounded-lg">
             {/* <AvatarImage src={user?.avatarRemoteURL} alt={fullName} /> */}
-            <AvatarFallback className="rounded-xl bg-transparent font-semibold">
+            <AvatarFallback className="rounded-lg bg-transparent font-semibold">
               {getInitials(user?.fullName || '')}
             </AvatarFallback>
           </Avatar>

--- a/app/components/notification/notification-bell.tsx
+++ b/app/components/notification/notification-bell.tsx
@@ -14,9 +14,9 @@ export function NotificationBell({ unreadCount }: NotificationBellProps) {
         type="quaternary"
         theme="outline"
         size="small"
-        className="relative h-7 w-7 cursor-pointer rounded-xl p-0"
+        className="relative h-7 w-7 cursor-pointer rounded-lg p-0"
         aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}>
-        <Bell className="text-quaternary-foreground size-3.5" />
+        <Bell className="text-icon-primary size-3.5" />
         {unreadCount > 0 && (
           <Badge
             type="tertiary"

--- a/app/components/personal-badge/personal-badge.tsx
+++ b/app/components/personal-badge/personal-badge.tsx
@@ -6,7 +6,10 @@ export const PersonalBadge = ({ className }: { className?: string }) => {
     <Badge
       type="primary"
       theme="light"
-      className={cn('text-2xs px-1 py-1 leading-none uppercase', className)}>
+      className={cn(
+        'text-2xs px-1 py-1 leading-none font-medium tracking-wide uppercase',
+        className
+      )}>
       Personal
     </Badge>
   );

--- a/app/components/select-organization/select-organization.tsx
+++ b/app/components/select-organization/select-organization.tsx
@@ -68,13 +68,13 @@ export const SelectOrganization = ({
           theme="borderless"
           size="small"
           className={cn(
-            'flex h-full w-full cursor-pointer gap-2 border-none p-0 px-2 hover:bg-transparent active:bg-transparent data-[state=open]:bg-transparent',
+            'flex cursor-pointer gap-2 border-none p-0 px-2 hover:bg-transparent active:bg-transparent data-[state=open]:bg-transparent',
             triggerClassName
           )}>
           {!hideContent &&
             (selectedContent ?? <OrganizationItem org={currentOrg} className="flex-1" />)}
           <ChevronDown
-            className={cn('text-secondary/60 size-4 transition-all', open && 'rotate-180')}
+            className={cn('text-icon-secondary size-4 w-fit transition-all', open && 'rotate-180')}
           />
         </Button>
       </PopoverTrigger>

--- a/app/layouts/dashboard.layout.tsx
+++ b/app/layouts/dashboard.layout.tsx
@@ -1,5 +1,5 @@
 import { ContentWrapper } from '@/components/content-wrapper';
-import { Header } from '@/components/header/header';
+import { Header } from '@/components/header';
 import { IOrganization } from '@/resources/interfaces/organization.interface';
 import { IProjectControlResponse } from '@/resources/interfaces/project.interface';
 import { SidebarInset, SidebarProvider, useSidebar } from '@datum-ui/components';

--- a/app/modules/datum-ui/components/badge/badge.tsx
+++ b/app/modules/datum-ui/components/badge/badge.tsx
@@ -47,7 +47,7 @@ const badgeVariants = cva(
         type: 'primary',
         theme: 'light',
         className:
-          'border-[var(--color-badge-primary)] text-[var(--color-badge-primary)] bg-[var(--color-badge-primary)]/20 dark:border-[var(--color-badge-primary)] dark:text-[var(--color-badge-primary)] dark:bg-[var(--color-badge-primary)]/20',
+          'border-[var(--color-badge-primary)]/30 text-[var(--color-badge-primary)] bg-[var(--color-badge-primary)]/10 dark:border-[var(--color-badge-primary)] dark:text-[var(--color-badge-primary)] dark:bg-[var(--color-badge-primary)]/20',
       },
 
       // Secondary badge variants

--- a/app/styles/themes/alpha.css
+++ b/app/styles/themes/alpha.css
@@ -144,6 +144,13 @@ Scope variables to the theme class so we can swap themes by class
   --btn-tertiary: var(--tertiary);
   --btn-quaternary: var(--quaternary);
 
+  /* Icon Colors */
+  --icon-primary: var(--app-dark-utility-3);
+  --icon-secondary: var(--app-dark-utility-4);
+  --icon-tertiary: var(--app-dark-utility-5);
+  --icon-quaternary: var(--app-dark-utility-2);
+  --icon-quinary: var(--app-dark-utility-1);
+
   /* ========================================
    DARK MODE OVERRIDES
    ======================================== */
@@ -253,6 +260,13 @@ Scope variables to the theme class so we can swap themes by class
     --btn-secondary: var(--btn-primary);
     --btn-tertiary: var(--btn-primary);
     --btn-quaternary: var(--quaternary);
+
+    /* Icon Colors */
+    --icon-primary: var(--app-dark-utility-4);
+    --icon-secondary: var(--app-dark-utility-4);
+    --icon-tertiary: var(--app-dark-utility-3);
+    --icon-quaternary: var(--app-dark-utility-2);
+    --icon-quinary: var(--app-dark-utility-1);
   }
 }
 
@@ -279,6 +293,13 @@ TAILWIND CUSTOM UTILITIES FOR THEME
   --color-table-accent: var(--table-accent);
   --color-table-cell: var(--table-cell);
   --color-table-cell-hover: var(--table-cell-hover);
+
+  /* Icon Colors */
+  --color-icon-primary: var(--icon-primary);
+  --color-icon-secondary: var(--icon-secondary);
+  --color-icon-tertiary: var(--icon-tertiary);
+  --color-icon-quaternary: var(--icon-quaternary);
+  --color-icon-quinary: var(--icon-quinary);
 
   /* Font Sizes */
   --text-sm: 13px;


### PR DESCRIPTION
Small changes to bring the main top nav bar inline with the cloud-portal design. 

Added some new css variables for icons to make picking colors for icons easier in the future.

**New**
<img width="757" height="28" alt="Screenshot 2025-12-10 at 15 24 40" src="https://github.com/user-attachments/assets/23c099b9-fac8-4ac1-b833-3822fa5e31d2" />

**Old**
<img width="757" height="28" alt="Screenshot 2025-12-10 at 15 25 00" src="https://github.com/user-attachments/assets/40beb8de-88fe-43e9-affe-0d5314bf09fc" />

