### PR TITLE
Remove the requirement for a proxy endpoint to be a domain name

### DIFF
--- a/app/resources/schemas/http-proxy.schema.ts
+++ b/app/resources/schemas/http-proxy.schema.ts
@@ -11,31 +11,14 @@ export const httpProxySchema = z
     endpoint: z.string({ error: 'Endpoint is required' }).refine(
       (value) => {
         try {
-          // Must have http:// or https:// protocol
-          if (!value.startsWith('http://') && !value.startsWith('https://')) {
-            return false;
-          }
-
-          // Parse as URL to validate format
           const url = new URL(value);
-
-          // Check if it's an IP address (not allowed)
-          const ipPattern = /^\d{1,3}(\.\d{1,3}){3}$/;
-          if (ipPattern.test(url.hostname)) {
-            return false;
-          }
-
-          // Ensure no path component (pathname should be just '/')
-          if (url.pathname !== '/' && url.pathname !== '') {
-            return false;
-          }
-
-          return true;
+          // Must have http:// or https:// protocol
+          return url.protocol === 'http:' || url.protocol === 'https:';
         } catch {
           return false;
         }
       },
-      { message: 'Endpoint must be a domain with HTTP/HTTPS protocol and no path' }
+      { message: 'Endpoint must be a valid URL with HTTP/HTTPS protocol' }
     ),
   })
   .and(httpProxyHostnameSchema)


### PR DESCRIPTION
The endpoint field now accepts any valid HTTP/HTTPS URL, including IPs, DNS hostnames, custom ports, and paths, matching the backend specification.

Ref: #828 