### PR TITLE
refactor: update DNS zone filtering to use domainName instead of name

### DIFF
--- a/app/resources/control-plane/dns-networking/dns-zones.control.ts
+++ b/app/resources/control-plane/dns-networking/dns-zones.control.ts
@@ -177,7 +177,8 @@ export const createDnsZonesControl = (client: Client) => {
             namespace: 'default',
           },
           query: {
-            fieldSelector: `status.domainRef.name=${domainRef}`, // use domain ref to filter DNS zones since dns zones can create multiple DNS zones for the same domain
+            // fieldSelector: `status.domainRef.name=${domainRef}`, // use domain ref to filter DNS zones since dns zones can create multiple DNS zones for the same domain
+            fieldSelector: `spec.domainName=${domainRef}`, // use domain name to filter DNS zones since dns zones can create multiple DNS zones for the same domain
             limit,
           },
         });

--- a/app/routes/project/detail/config/domains/detail/layout.tsx
+++ b/app/routes/project/detail/config/domains/detail/layout.tsx
@@ -47,8 +47,8 @@ export const loader = async ({ context, params }: LoaderFunctionArgs) => {
   }
 
   let dnsZone: IDnsZoneControlResponse | null = null;
-  if (domain?.name) {
-    const dnsZones = await dnsZonesControl.listByDomainRef(projectId, domain?.name ?? '', 1);
+  if (domain?.domainName) {
+    const dnsZones = await dnsZonesControl.listByDomainRef(projectId, domain?.domainName ?? '', 1);
     dnsZone = dnsZones?.[0] ?? null;
   }
 

--- a/app/routes/project/detail/config/domains/index.tsx
+++ b/app/routes/project/detail/config/domains/index.tsx
@@ -71,8 +71,8 @@ export const loader = async ({ context, params }: LoaderFunctionArgs) => {
 
       // Fetch DNS zone for this domain (if domain has a name)
       let dnsZone: IDnsZoneControlResponse | undefined;
-      if (domain?.name) {
-        const dnsZones = await dnsZonesControl.listByDomainRef(projectId, domain.name, 1);
+      if (domain?.domainName) {
+        const dnsZones = await dnsZonesControl.listByDomainRef(projectId, domain.domainName, 1);
         dnsZone = dnsZones?.[0] ?? null;
       }
 


### PR DESCRIPTION
- Changed the field selector in the DNS zones control to filter by `spec.domainName` for improved accuracy.
- Updated references in the project detail loader to use `domain.domainName` instead of `domain.name` for consistency.


