### PR TITLE
fix: update confirmation inputs to be id of resource being deleted

### DIFF
--- a/app/components/confirmation-dialog/confirmation-dialog.tsx
+++ b/app/components/confirmation-dialog/confirmation-dialog.tsx
@@ -42,7 +42,8 @@ export const ConfirmationDialog = ({
   const [isPending, setIsPending] = useState(false);
 
   const [confirmValidationValue, setConfirmValidationValue] = useState('');
-  const [dialogProps, setDialogProps] = useState<ConfirmationDialogProps>({
+
+  const defaultDialogProps: ConfirmationDialogProps = {
     title: '',
     description: '',
     submitText: 'Confirm',
@@ -61,13 +62,15 @@ export const ConfirmationDialog = ({
     confirmInputLabel: 'Type "DELETE" to confirm.',
     confirmInputPlaceholder: 'Type in here...',
     confirmValue: 'DELETE',
-  });
+  };
+
+  const [dialogProps, setDialogProps] = useState<ConfirmationDialogProps>(defaultDialogProps);
 
   const resolveRef = useRef<(value: boolean) => void>(null);
 
   useImperativeHandle(ref, () => ({
     show: (options) => {
-      setDialogProps({ ...dialogProps, ...options });
+      setDialogProps({ ...defaultDialogProps, ...options });
       setIsOpen(true);
       return new Promise<boolean>((resolve) => {
         resolveRef.current = resolve;
@@ -137,7 +140,7 @@ export const ConfirmationDialog = ({
               </Alert>
             )}
             {dialogProps.showConfirmInput && (
-              <div className="flex flex-col gap-3">
+              <div className="mb-1 flex flex-col gap-3">
                 <Label>{dialogProps.confirmInputLabel}</Label>
                 <Input
                   type="text"

--- a/app/features/edge/dns-zone/form.tsx
+++ b/app/features/edge/dns-zone/form.tsx
@@ -57,6 +57,8 @@ export const DnsZoneForm = ({
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: defaultValue?.domainName,
+      confirmInputLabel: `Type "${defaultValue?.domainName}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/features/edge/proxy/form.tsx
+++ b/app/features/edge/proxy/form.tsx
@@ -62,6 +62,8 @@ export const HttpProxyForm = ({
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: defaultValue?.name,
+      confirmInputLabel: `Type "${defaultValue?.name}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/features/organization/settings/danger-card.tsx
+++ b/app/features/organization/settings/danger-card.tsx
@@ -28,6 +28,8 @@ export const OrganizationDangerCard = ({ organization }: { organization: IOrgani
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: organization?.name,
+      confirmInputLabel: `Type "${organization?.name}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/features/policy-binding/form/policy-binding-form.tsx
+++ b/app/features/policy-binding/form/policy-binding-form.tsx
@@ -63,6 +63,8 @@ export const PolicyBindingForm = ({
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: defaultValue?.name,
+      confirmInputLabel: `Type "${defaultValue?.name}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/features/project/settings/danger-card.tsx
+++ b/app/features/project/settings/danger-card.tsx
@@ -23,6 +23,8 @@ export const ProjectDangerCard = ({ project }: { project: IProjectControlRespons
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: project?.name,
+      confirmInputLabel: `Type "${project?.name}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/features/secret/form/edit/edit-keys.tsx
+++ b/app/features/secret/form/edit/edit-keys.tsx
@@ -38,6 +38,8 @@ export const EditSecretKeys = ({ defaultValue }: { defaultValue?: ISecretControl
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: variable,
+      confirmInputLabel: `Type "${variable}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/routes/org/detail/policy-bindings/index.tsx
+++ b/app/routes/org/detail/policy-bindings/index.tsx
@@ -61,6 +61,8 @@ export default function OrgPolicyBindingsPage() {
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: policyBinding.name,
+      confirmInputLabel: `Type "${policyBinding.name}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/routes/org/detail/settings/policy-bindings.tsx
+++ b/app/routes/org/detail/settings/policy-bindings.tsx
@@ -61,6 +61,8 @@ export default function OrgPolicyBindingsPage() {
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: policyBinding.name,
+      confirmInputLabel: `Type "${policyBinding.name}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/routes/project/detail/config/secrets/index.tsx
+++ b/app/routes/project/detail/config/secrets/index.tsx
@@ -58,6 +58,8 @@ export default function SecretsPage() {
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: secret.name,
+      confirmInputLabel: `Type "${secret.name}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/routes/project/detail/edge/dns-zones/detail/settings.tsx
+++ b/app/routes/project/detail/edge/dns-zones/detail/settings.tsx
@@ -33,6 +33,8 @@ export default function DnsZoneSettingsPage() {
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: dnsZone?.domainName,
+      confirmInputLabel: `Type "${dnsZone?.domainName}" to confirm.`,
       onSubmit: async () => {
         closeConfirmationDialog();
         await fetcher.submit(

--- a/app/routes/project/detail/edge/dns-zones/index.tsx
+++ b/app/routes/project/detail/edge/dns-zones/index.tsx
@@ -163,6 +163,8 @@ export default function DnsZonesPage() {
         cancelText: 'Cancel',
         variant: 'destructive',
         showConfirmInput: true,
+        confirmValue: dnsZone.domainName,
+        confirmInputLabel: `Type "${dnsZone.domainName}" to confirm.`,
         onSubmit: async () => {
           await deleteFetcher.submit(
             {

--- a/app/routes/project/detail/edge/proxy/detail/tabs/layout.tsx
+++ b/app/routes/project/detail/edge/proxy/detail/tabs/layout.tsx
@@ -54,6 +54,8 @@ export default function HttpProxyDetailLayout() {
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: httpProxy.name,
+      confirmInputLabel: `Type "${httpProxy?.name}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/routes/project/detail/edge/proxy/index.tsx
+++ b/app/routes/project/detail/edge/proxy/index.tsx
@@ -66,6 +66,8 @@ export default function HttpProxyPage() {
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: httpProxy.name,
+      confirmInputLabel: `Type "${httpProxy.name}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {

--- a/app/routes/project/detail/metrics/export-policies/index.tsx
+++ b/app/routes/project/detail/metrics/export-policies/index.tsx
@@ -69,6 +69,8 @@ export default function ExportPoliciesPage() {
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
+      confirmValue: exportPolicy.name,
+      confirmInputLabel: `Type "${exportPolicy.name}" to confirm.`,
       onSubmit: async () => {
         await fetcher.submit(
           {


### PR DESCRIPTION
This PR improves the deletion confirmation label and value. Before you had to type "DELETE" to delete a resource, now you have to type it's ID. I've changed this everywhere applicable. 

<img width="570" height="307" alt="Screenshot 2025-12-22 at 14 45 11" src="https://github.com/user-attachments/assets/9a0becd9-4292-415a-8725-1abe3a5d77fa" />

- Added small amount of margin to the bottom of the input to stop the active state getting cut off
- Changed deletion warning in places where applicable
- Updated the confirmation dialog to always use fresh state, start with defaults then update