### PR TITLE
chore: add avatar URL to member types

### DIFF
--- a/app/components/content-wrapper/content-wrapper.tsx
+++ b/app/components/content-wrapper/content-wrapper.tsx
@@ -8,13 +8,11 @@ export function ContentWrapper({
   contentClassName,
 }: ContentWrapperProps) {
   return (
-    <div
-      className={cn(
-        'mx-auto flex h-full w-full max-w-[1600px] flex-col gap-5 p-9',
-        containerClassName
-      )}>
-      <Breadcrumb className="w-full" />
-      <div className={cn('flex w-full flex-1 flex-col', contentClassName)}>{children}</div>
+    <div className={cn('flex h-full w-full flex-col gap-5 p-9', containerClassName)}>
+      <Breadcrumb className="mx-auto w-full max-w-[1600px]" />
+      <div className={cn('mx-auto flex w-full max-w-[1600px] flex-1 flex-col', contentClassName)}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/app/modules/control-plane/resource-manager/types.gen.ts
+++ b/app/modules/control-plane/resource-manager/types.gen.ts
@@ -223,6 +223,11 @@ export type ComMiloapisResourcemanagerV1Alpha1OrganizationMembership = {
        * GivenName is the given name of the user in the membership.
        */
       givenName?: string;
+
+      /**
+       * AvatarURL is the URL of the user's avatar.
+       */
+      avatarURL?: string;
     };
   };
 };

--- a/app/resources/control-plane/resource-manager/members.control.ts
+++ b/app/resources/control-plane/resource-manager/members.control.ts
@@ -49,7 +49,6 @@ export const createMembersControl = (client: Client) => {
 
         const members =
           response.data as ComMiloapisResourcemanagerV1Alpha1OrganizationMembershipList;
-
         return members.items?.map((item) => transform(item)) ?? [];
       } catch (error) {
         throw error;

--- a/app/resources/interfaces/member.interface.ts
+++ b/app/resources/interfaces/member.interface.ts
@@ -10,6 +10,7 @@ export interface IMemberControlResponse {
     email?: string;
     familyName?: string;
     givenName?: string;
+    avatarUrl?: string;
   };
   organization: {
     id: string;

--- a/app/routes/org/detail/team/index.tsx
+++ b/app/routes/org/detail/team/index.tsx
@@ -58,6 +58,7 @@ interface ITeamMember {
   invitationState?: 'Pending' | 'Accepted' | 'Declined';
   type: 'member' | 'invitation';
   name?: string;
+  avatarUrl?: string;
 }
 
 export const loader = async ({ params, context }: LoaderFunctionArgs) => {
@@ -128,6 +129,7 @@ export const loader = async ({ params, context }: LoaderFunctionArgs) => {
         : [],
       type: 'member' as const,
       name: member.name,
+      avatarUrl: member.user.avatarUrl,
     }))
   );
 
@@ -333,10 +335,13 @@ export default function OrgTeamPage() {
           const name = row.original.fullName ?? row.original.email;
           const subtitle = row.original.email;
 
+          console.log(row.original);
+
           return (
             <div className="flex w-full items-center justify-between gap-2">
               <div className="flex items-center gap-3">
                 <ProfileIdentity
+                  avatarSrc={row.original.avatarUrl}
                   className="min-w-48"
                   fallbackIcon={row.original.type === 'invitation' ? UserIcon : undefined}
                   name={name}


### PR DESCRIPTION
- Updated ContentWrapper component to center content and improve layout.
- Added avatarURL property to organization membership type for user avatars.
- Included avatarUrl in member interface and team member loader for better user representation.

Ref: https://github.com/datum-cloud/cloud-portal/issues/845

<img width="1512" height="585" alt="Screenshot 2025-12-23 at 14 42 57" src="https://github.com/user-attachments/assets/e1d9e9eb-42d1-44ee-bc9e-4f573344a4e2" />
