### PR TITLE
refactor: TTL normalization logic in the DNS import helper to ensure valid TTL values during record transformation.

### DIFF
--- a/app/features/edge/dns-records/import-export/dns-record-import-action.tsx
+++ b/app/features/edge/dns-records/import-export/dns-record-import-action.tsx
@@ -154,7 +154,7 @@ export const DnsRecordImportAction = ({
 
       {/* Import Dialog - Preview and Result Views */}
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <Dialog.Content className="max-w-4xl sm:max-w-4xl">
+        <Dialog.Content className="max-w-[80vw] sm:max-w-[80vw]">
           {dialogView === 'preview' ? (
             <>
               <Dialog.Header

--- a/app/modules/datum-ui/components/data-table/core/data-table-card-view.tsx
+++ b/app/modules/datum-ui/components/data-table/core/data-table-card-view.tsx
@@ -80,18 +80,7 @@ export const DataTableCardView = <TData,>({
           ))}
         </>
       ) : (
-        <TableRow>
-          <TableCell
-            colSpan={columns.length + (rowActions.length > 0 ? 1 : 0)}
-            className="p-0 text-center">
-            <EmptyContent
-              variant="minimal"
-              {...{
-                title: "Try adjusting your search or filters to find what you're looking for.",
-              }}
-            />
-          </TableCell>
-        </TableRow>
+        <EmptyContent title="Try adjusting your search or filters" />
       )}
     </TableBody>
   );

--- a/app/modules/datum-ui/components/data-table/core/data-table-view.tsx
+++ b/app/modules/datum-ui/components/data-table/core/data-table-view.tsx
@@ -116,18 +116,7 @@ export const DataTableView = <TData,>({
           })}
         </>
       ) : (
-        <TableRow>
-          <TableCell
-            colSpan={columns.length + (rowActions.length > 0 ? 1 : 0)}
-            className="p-0 text-center">
-            <EmptyContent
-              variant="minimal"
-              {...{
-                title: "Try adjusting your search or filters to find what you're looking for.",
-              }}
-            />
-          </TableCell>
-        </TableRow>
+        <EmptyContent title="Try adjusting your search or filters" />
       )}
     </TableBody>
   );


### PR DESCRIPTION
ref: https://github.com/datum-cloud/cloud-portal/issues/879