### PR TITLE
chore: add formatting function and use updated DNS api

### DIFF
--- a/app/features/edge/dns-records/dns-record-status.tsx
+++ b/app/features/edge/dns-records/dns-record-status.tsx
@@ -1,6 +1,9 @@
 import { BadgeProgrammingError } from '@/components/badge/badge-programming-error';
 import { BadgeStatus } from '@/components/badge/badge-status';
-import { IExtendedControlPlaneStatus } from '@/resources/interfaces/control-plane.interface';
+import {
+  ControlPlaneStatus,
+  IExtendedControlPlaneStatus,
+} from '@/resources/interfaces/control-plane.interface';
 import { IFlattenedDnsRecord } from '@/resources/interfaces/dns.interface';
 import { ROUTE_PATH as DNS_RECORD_STATUS_ROUTE_PATH } from '@/routes/api/dns-records/status';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
@@ -12,6 +15,134 @@ interface DnsRecordStatusProps {
   record: IFlattenedDnsRecord;
   projectId: string;
   className?: string;
+}
+
+/**
+ * Process DNS record status from raw API response
+ * Extracts and matches recordSet conditions to the current record
+ *
+ * @param rawStatus - Raw status object from API
+ * @param record - The DNS record to match against
+ * @returns Processed status information
+ */
+function processDnsRecordStatus(
+  rawStatus: any,
+  record: IFlattenedDnsRecord
+): {
+  extendedStatus: IExtendedControlPlaneStatus | undefined;
+  hasRecordSetError: boolean;
+  hasOtherRecordSetErrors: boolean;
+  shouldStopPolling: boolean;
+} {
+  const recordSets = rawStatus?.recordSets || [];
+
+  // Transform status for compatibility
+  const statusData = transformControlPlaneStatus(rawStatus, {
+    includeConditionDetails: true,
+    requiredConditions: ['Accepted', 'Programmed'],
+  });
+
+  // Add recordSets to statusData for reference
+  statusData.recordSets = recordSets.map((recordSet: any) => ({
+    name: recordSet.name,
+    conditions: recordSet.conditions?.map((condition: any) => ({
+      type: condition.type,
+      status: condition.status,
+      reason: condition.reason,
+      message: condition.message,
+      lastTransitionTime: condition.lastTransitionTime,
+      observedGeneration: condition.observedGeneration,
+    })),
+  }));
+
+  // Find recordSet conditions with status 'False' (ignore top-level conditions)
+  const falseRecordSetConditions = recordSets.flatMap((recordSet: any) =>
+    (recordSet.conditions || [])
+      .filter((condition: any) => condition.status === 'False')
+      .map((condition: any) => ({
+        ...condition,
+        recordSetName: recordSet.name,
+      }))
+  );
+
+  // Find conditions that match this specific record
+  // recordSets are grouped by (type, name) - all records with the same name and type share status
+  // Match by recordSet name to record name (normalize by removing trailing dots)
+  const normalizedRecordName = record.name.replace(/\.$/, '').toLowerCase();
+  const matchingConditions = falseRecordSetConditions.filter((condition: any) => {
+    // Match the recordSet name (which is the owner name) to the record name
+    const recordSetName = (condition.recordSetName || '').replace(/\.$/, '').toLowerCase();
+    return recordSetName === normalizedRecordName || recordSetName === record.name.toLowerCase();
+  });
+
+  // If we have matching false conditions in recordSets, use those for status
+  if (matchingConditions.length > 0) {
+    // Use the first matching condition's reason and message
+    const firstMatchingCondition = matchingConditions[0];
+    const isErrorReason =
+      firstMatchingCondition.reason === 'InvalidDNSRecordSet' ||
+      firstMatchingCondition.reason === 'PDNSError';
+
+    const updatedStatus: IExtendedControlPlaneStatus = {
+      ...statusData,
+      status: ControlPlaneStatus.Pending,
+      message: firstMatchingCondition.message || statusData.message,
+      programmedReason: firstMatchingCondition.reason || statusData.programmedReason,
+      isProgrammed: false, // If there's a False condition, it's not programmed
+    };
+
+    return {
+      extendedStatus: updatedStatus,
+      hasRecordSetError: isErrorReason,
+      hasOtherRecordSetErrors: false,
+      shouldStopPolling: isErrorReason,
+    };
+  }
+
+  // There are errors in recordSets but they don't match this record
+  if (falseRecordSetConditions.length > 0) {
+    return {
+      extendedStatus: undefined,
+      hasRecordSetError: false,
+      hasOtherRecordSetErrors: true,
+      shouldStopPolling: false,
+    };
+  }
+
+  // No false conditions in recordSets - check if all are True (success)
+  if (recordSets.length > 0) {
+    const allRecordSetConditionsTrue = recordSets.every((recordSet: any) =>
+      (recordSet.conditions || []).every((condition: any) => condition.status === 'True')
+    );
+
+    if (allRecordSetConditionsTrue) {
+      // All recordSet conditions are True, so it's successful
+      const updatedStatus: IExtendedControlPlaneStatus = {
+        ...statusData,
+        status: ControlPlaneStatus.Success,
+        isProgrammed: true,
+        message: '',
+      };
+
+      return {
+        extendedStatus: updatedStatus,
+        hasRecordSetError: false,
+        hasOtherRecordSetErrors: false,
+        shouldStopPolling: true,
+      };
+    }
+  }
+
+  // Fall back to top-level conditions (shouldn't happen in normal flow)
+  const shouldStopPolling =
+    statusData.isProgrammed === true || statusData.programmedReason === 'InvalidDNSRecordSet';
+
+  return {
+    extendedStatus: statusData,
+    hasRecordSetError: false,
+    hasOtherRecordSetErrors: false,
+    shouldStopPolling,
+  };
 }
 
 /**
@@ -27,12 +158,17 @@ export const DnsRecordStatus = ({ record, projectId, className }: DnsRecordStatu
   const fetcher = useFetcher({ key: `dns-record-status-${record.recordSetName}` });
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const [extendedStatus, setExtendedStatus] = useState<IExtendedControlPlaneStatus>();
+  const [hasRecordSetError, setHasRecordSetError] = useState(false);
+  const [hasOtherRecordSetErrors, setHasOtherRecordSetErrors] = useState(false);
 
   // Initialize extended status from record fields (already extended)
   useEffect(() => {
     // If record has extended fields, use them directly
     if (record.status) {
       setExtendedStatus(record.status);
+      // Reset recordSet error flags when record status changes
+      setHasRecordSetError(false);
+      setHasOtherRecordSetErrors(false);
     }
   }, [record.status]);
 
@@ -84,36 +220,43 @@ export const DnsRecordStatus = ({ record, projectId, className }: DnsRecordStatu
 
   useEffect(() => {
     if (fetcher.data && fetcher.state === 'idle') {
-      const statusData = transformControlPlaneStatus(fetcher.data.data, {
-        includeConditionDetails: true,
-        requiredConditions: ['Accepted', 'Programmed'],
-      });
+      const rawStatus = fetcher.data.data;
+      const processed = processDnsRecordStatus(rawStatus, record);
 
-      setExtendedStatus(statusData);
-      if (
-        (statusData.isProgrammed === true ||
-          statusData.programmedReason === 'InvalidDNSRecordSet') &&
-        intervalRef.current
-      ) {
+      setExtendedStatus(processed.extendedStatus);
+      setHasRecordSetError(processed.hasRecordSetError);
+      setHasOtherRecordSetErrors(processed.hasOtherRecordSetErrors);
+
+      // Stop polling if needed
+      if (processed.shouldStopPolling && intervalRef.current) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
       }
     }
-  }, [fetcher.data, fetcher.state, intervalRef]);
+  }, [fetcher.data, fetcher.state, intervalRef, record]);
+
+  // If there are errors on other records in the recordSet, don't show any badge
+  if (hasOtherRecordSetErrors) {
+    return null;
+  }
 
   if (extendedStatus?.isProgrammed) {
     return null;
   }
 
-  // 2. Error state - show BadgeProgrammingError for InvalidDNSRecordSet
-  if (extendedStatus?.programmedReason === 'InvalidDNSRecordSet') {
+  // 2. Error state - show BadgeProgrammingError only if error is from a recordSet condition
+  if (
+    hasRecordSetError &&
+    (extendedStatus?.programmedReason === 'InvalidDNSRecordSet' ||
+      extendedStatus?.programmedReason === 'PDNSError')
+  ) {
     return (
       <BadgeProgrammingError
         className={className}
         isProgrammed={extendedStatus?.isProgrammed}
         programmedReason={extendedStatus?.programmedReason}
         statusMessage={extendedStatus?.message}
-        errorReasons={['InvalidDNSRecordSet']}
+        errorReasons={['InvalidDNSRecordSet', 'PDNSError']}
       />
     );
   }

--- a/app/features/edge/dns-zone/form/dns-record-form.tsx
+++ b/app/features/edge/dns-zone/form/dns-record-form.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/resources/schemas/dns-record.schema';
 import { ROUTE_PATH as DNS_RECORDS_ACTIONS_PATH } from '@/routes/api/dns-records';
 import { ROUTE_PATH as DNS_RECORDS_DETAIL_PATH } from '@/routes/api/dns-records/$id';
+import { formatDnsError } from '@/utils/helpers/dns-record.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import {
   FormProvider,
@@ -139,17 +140,22 @@ export function DnsRecordForm({
           const result = await response.json();
 
           if (!response.ok) {
-            throw new Error(result.error || `Failed to ${mode} DNS record`);
+            const errorMessage = result.error || `Failed to ${mode} DNS record`;
+            throw new Error(formatDnsError(errorMessage));
           }
 
           if (result.success) {
             onSuccess?.();
             onClose();
           } else {
-            throw new Error(result?.error || `Failed to ${mode} DNS record`);
+            const errorMessage = result?.error || `Failed to ${mode} DNS record`;
+            throw new Error(formatDnsError(errorMessage));
           }
         } catch (error: any) {
-          toast.error(error.message || `Failed to ${mode} DNS record. Please try again.`);
+          // Error message is already formatted by formatDnsError if it was a DNS error
+          // Otherwise, use the original error message
+          const displayMessage = error.message || `Failed to ${mode} DNS record. Please try again.`;
+          toast.error(displayMessage);
         } finally {
           setIsSubmitting(false);
         }

--- a/app/resources/interfaces/control-plane.interface.ts
+++ b/app/resources/interfaces/control-plane.interface.ts
@@ -30,4 +30,16 @@ export interface IExtendedControlPlaneStatus extends IControlPlaneStatus {
     reason?: string;
     message?: string;
   }>;
+
+  recordSets?: Array<{
+    name: string;
+    conditions?: Array<{
+      type: string;
+      status: 'True' | 'False' | 'Unknown';
+      reason: string;
+      message: string;
+      lastTransitionTime: string;
+      observedGeneration?: number;
+    }>;
+  }>;
 }

--- a/app/utils/helpers/dns-record.helper.ts
+++ b/app/utils/helpers/dns-record.helper.ts
@@ -63,4 +63,8 @@ export {
   type ImportDetail,
   type ImportSummary,
   type ImportResult,
+
+  // Error formatting helpers
+  formatDnsConflictError,
+  formatDnsError,
 } from './dns';

--- a/app/utils/helpers/dns/error-formatting.helper.ts
+++ b/app/utils/helpers/dns/error-formatting.helper.ts
@@ -1,0 +1,68 @@
+/**
+ * Formats a DNS conflict error message into a user-friendly explanation
+ *
+ * Handles errors like:
+ * - "RRset datum.net.test-import.com. IN CNAME: Conflicts with pre-existing RRset"
+ * - "Record "datum.net": status 422: {"error": "RRset datum.net.test-import.com. IN CNAME: Conflicts with pre-existing RRset"}"
+ * - Any error containing "Conflicts with pre-existing RRset"
+ *
+ * @param errorMessage - The raw error message from the API
+ * @returns A user-friendly error message, or the original message if it's not a conflict error
+ */
+export function formatDnsConflictError(errorMessage: string): string {
+  if (!errorMessage) {
+    return errorMessage;
+  }
+
+  // Extract the actual error message if it's wrapped in JSON format
+  // Pattern: "Record "...": status 422: {"error": "actual error message"}"
+  let actualErrorMessage = errorMessage;
+  const jsonMatch = errorMessage.match(/\{[^}]*"error"\s*:\s*"([^"]+)"/);
+  if (jsonMatch && jsonMatch[1]) {
+    actualErrorMessage = jsonMatch[1];
+  }
+
+  // Check if this is a conflict error
+  const isConflictError =
+    actualErrorMessage.toLowerCase().includes('conflicts with pre-existing rrset') ||
+    actualErrorMessage.toLowerCase().includes('conflicts with') ||
+    actualErrorMessage.toLowerCase().includes('conflict');
+
+  if (!isConflictError) {
+    return errorMessage;
+  }
+
+  // Try to extract record type from the error message
+  // Pattern: "RRset <name> IN <TYPE>: Conflicts..."
+  const typeMatch = actualErrorMessage.match(/\bIN\s+([A-Z]+):?\s*Conflicts/i);
+  const recordType = typeMatch ? typeMatch[1] : 'record';
+
+  // Special handling for CNAME conflicts (most common case)
+  if (recordType === 'CNAME') {
+    return 'CNAME records cannot coexist with other record types at the same name. Please remove the existing records before adding this CNAME, or use a different name.';
+  }
+
+  // Generic conflict message for other record types
+  return `${recordType} record conflicts with an existing record at this name. Please remove the conflicting record first, or use a different name.`;
+}
+
+/**
+ * Formats any DNS error message, applying appropriate transformations
+ *
+ * @param errorMessage - The raw error message from the API
+ * @returns A formatted, user-friendly error message
+ */
+export function formatDnsError(errorMessage: string): string {
+  if (!errorMessage) {
+    return errorMessage;
+  }
+
+  // Apply conflict formatting first
+  const conflictFormatted = formatDnsConflictError(errorMessage);
+  if (conflictFormatted !== errorMessage) {
+    return conflictFormatted;
+  }
+
+  // Add other error formatting here as needed
+  return errorMessage;
+}

--- a/app/utils/helpers/dns/index.ts
+++ b/app/utils/helpers/dns/index.ts
@@ -67,3 +67,6 @@ export {
   type ImportSummary,
   type ImportResult,
 } from './import-result.helper';
+
+// Error formatting helpers
+export { formatDnsConflictError, formatDnsError } from './error-formatting.helper';


### PR DESCRIPTION
This PR improves the error handling in DNS Zone tables. We're using new fields from the dns api to filter exactly what record the error should be shown on.