### PR TITLE
fix: ensure we match ns on optional trailing dot

### DIFF
--- a/app/utils/helpers/dns/__tests__/nameserver.helper.test.ts
+++ b/app/utils/helpers/dns/__tests__/nameserver.helper.test.ts
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getNameserverSetupStatus } from '../nameserver.helper';
+import type { IDnsZoneControlResponse, IDnsNameserver } from '@/resources/interfaces/dns.interface';
+
+const makeZone = (params: {
+  datumNs: string[];
+  zoneNs: Array<Pick<IDnsNameserver, 'hostname'>>;
+}): IDnsZoneControlResponse => {
+  return {
+    apiVersion: 'v1',
+    kind: 'DNSZone',
+    name: 'example-zone',
+    namespace: 'default',
+    domainName: 'example.com',
+    status: {
+      nameservers: params.datumNs,
+      domainRef: {
+        name: 'example.com',
+        status: {
+          nameservers: params.zoneNs as IDnsNameserver[],
+        },
+      },
+    },
+  } as unknown as IDnsZoneControlResponse;
+};
+
+test('getNameserverSetupStatus: fully setup when trailing dots and case differ', () => {
+  const zone = makeZone({
+    datumNs: ['ns1.datum.com.', 'ns2.datum.com'],
+    zoneNs: [
+      { hostname: 'NS1.DATUM.COM' },
+      { hostname: 'ns2.datum.com.' },
+    ],
+  });
+
+  const result = getNameserverSetupStatus(zone);
+
+  assert.equal(result.totalCount, 2);
+  assert.equal(result.setupCount, 2);
+  assert.equal(result.isFullySetup, true);
+  assert.equal(result.isPartiallySetup, false);
+  assert.equal(result.hasAnySetup, true);
+});
+
+test('getNameserverSetupStatus: partial setup when only some nameservers match', () => {
+  const zone = makeZone({
+    datumNs: ['ns1.datum.com', 'ns2.datum.com'],
+    zoneNs: [{ hostname: 'ns1.datum.com.' }],
+  });
+
+  const result = getNameserverSetupStatus(zone);
+
+  assert.equal(result.totalCount, 2);
+  assert.equal(result.setupCount, 1);
+  assert.equal(result.isFullySetup, false);
+  assert.equal(result.isPartiallySetup, true);
+  assert.equal(result.hasAnySetup, true);
+});
+
+test('getNameserverSetupStatus: no setup when none match', () => {
+  const zone = makeZone({
+    datumNs: ['ns1.datum.com', 'ns2.datum.com'],
+    zoneNs: [{ hostname: 'ns3.other.com.' }],
+  });
+
+  const result = getNameserverSetupStatus(zone);
+
+  assert.equal(result.totalCount, 2);
+  assert.equal(result.setupCount, 0);
+  assert.equal(result.isFullySetup, false);
+  assert.equal(result.isPartiallySetup, false);
+  assert.equal(result.hasAnySetup, false);
+});
+
+test('getNameserverSetupStatus: trims whitespace and ignores single trailing dot', () => {
+  const zone = makeZone({
+    datumNs: ['ns1.datum.com. '],
+    zoneNs: [{ hostname: ' ns1.datum.com' }],
+  });
+
+  const result = getNameserverSetupStatus(zone);
+
+  assert.equal(result.totalCount, 1);
+  assert.equal(result.setupCount, 1);
+  assert.equal(result.isFullySetup, true);
+  assert.equal(result.isPartiallySetup, false);
+  assert.equal(result.hasAnySetup, true);
+});
+
+

--- a/app/utils/helpers/dns/nameserver.helper.ts
+++ b/app/utils/helpers/dns/nameserver.helper.ts
@@ -25,9 +25,17 @@ export function getNameserverSetupStatus(
   const zoneNs =
     dnsZone?.status?.domainRef?.status?.nameservers?.map((ns: IDnsNameserver) => ns.hostname) ?? [];
 
-  // Normalize to lowercase for case-insensitive comparison (DNS is case-insensitive per RFC 1035)
-  const zoneNsLower = zoneNs.map((ns) => ns?.toLowerCase());
-  const setupCount = datumNs.filter((ns: string) => zoneNsLower.includes(ns?.toLowerCase())).length;
+  // Normalize for comparison:
+  // - case-insensitive (DNS is case-insensitive per RFC 1035)
+  // - ignore a single trailing dot on FQDNs
+  const normalizeNs = (ns?: string) =>
+    (ns ?? '')
+      .trim()
+      .toLowerCase()
+      .replace(/\.$/, '');
+  const zoneNsNormalized = zoneNs.map(normalizeNs);
+  const datumNsNormalized = datumNs.map(normalizeNs);
+  const setupCount = datumNsNormalized.filter((ns: string) => zoneNsNormalized.includes(ns)).length;
   const totalCount = datumNs.length;
 
   return {


### PR DESCRIPTION
This pull request adds tests for the `getNameserverSetupStatus` helper and improves its normalization logic to make nameserver comparison more robust. The changes ensure that nameserver matching is case-insensitive, trims whitespace, and ignores a single trailing dot, which aligns with DNS conventions.

**Testing improvements:**

* Added a new test suite `nameserver.helper.test.ts` to cover various scenarios for `getNameserverSetupStatus`, including handling of case differences, trailing dots, whitespace, partial matches, and no matches.

**Comparison logic improvements:**

* Updated `getNameserverSetupStatus` in `nameserver.helper.ts` to normalize nameserver hostnames by trimming whitespace, converting to lowercase, and removing a single trailing dot before comparison, making the function more accurate and resilient.

Ref: https://github.com/datum-cloud/enhancements/issues/516