### PR TITLE
feat: add "Show All" option and row count display to DataTable

### DIFF
--- a/app/modules/datum-ui/components/data-table/core/data-table.tsx
+++ b/app/modules/datum-ui/components/data-table/core/data-table.tsx
@@ -92,6 +92,7 @@ function DataTableInternal<TData, TValue>(
     defaultColumnFilters = [],
     defaultSorting = [],
     pageSize = 50,
+    enableShowAll = false,
     filterComponent,
     filters,
     defaultFilters,
@@ -314,6 +315,7 @@ function DataTableInternal<TData, TValue>(
         enableInlineContent={enableInlineContent}
         inlineContent={inlineContent}
         inlineContentClassName={inlineContentClassName}
+        enableShowAll={enableShowAll}
       />
     </DataTableProvider>
   );
@@ -349,6 +351,7 @@ interface DataTableContentProps<TData, TValue> {
   enableInlineContent: boolean;
   inlineContent?: any;
   inlineContentClassName?: string;
+  enableShowAll?: boolean;
 }
 
 const DataTableContent = forwardRef(function DataTableContent<TData, TValue>(
@@ -381,6 +384,7 @@ const DataTableContent = forwardRef(function DataTableContent<TData, TValue>(
     enableInlineContent,
     inlineContent,
     inlineContentClassName,
+    enableShowAll = false,
   }: DataTableContentProps<TData, TValue>,
   ref: Ref<DataTableRef<TData>>
 ) {
@@ -467,7 +471,10 @@ const DataTableContent = forwardRef(function DataTableContent<TData, TValue>(
           </div>
 
           {/* Pagination Section */}
-          {!hidePagination && table.getPageCount() > 1 && <DataTablePagination table={table} />}
+          {/* Show pagination if: more than 1 page, OR enableShowAll is true (to allow changing page size) */}
+          {!hidePagination && (table.getPageCount() > 1 || enableShowAll) && (
+            <DataTablePagination table={table} enableShowAll={enableShowAll} />
+          )}
         </div>
       ) : (
         <EmptyContent {...emptyContent} />

--- a/app/modules/datum-ui/components/data-table/core/data-table.types.ts
+++ b/app/modules/datum-ui/components/data-table/core/data-table.types.ts
@@ -19,6 +19,7 @@ export interface DataTableProps<TData, TValue> {
   defaultColumnFilters?: ColumnFiltersState;
   defaultSorting?: SortingState;
   pageSize?: number; // Custom page size (default: 20)
+  enableShowAll?: boolean; // Enable "All" option in page size selector (default: false)
 
   // Filter system (compound components)
   /**
@@ -194,6 +195,9 @@ export interface DataTableToolbarConfig {
 
   /** Show filter count badge on dropdown button */
   showFilterCount?: boolean;
+
+  /** Show row count before filters (e.g., "Showing 5 records") */
+  showRowCount?: boolean;
 
   /** Enable responsive behavior (auto-collapse on mobile) */
   responsive?: boolean;

--- a/app/modules/datum-ui/components/data-table/features/pagination/data-table-pagination.tsx
+++ b/app/modules/datum-ui/components/data-table/features/pagination/data-table-pagination.tsx
@@ -9,20 +9,38 @@ import {
 import { Icon } from '@datum-ui/components/icons/icon-wrapper';
 import { Table as TTable } from '@tanstack/react-table';
 import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { useState } from 'react';
 
-export const DataTablePagination = <TData,>({ table }: { table: TTable<TData> }) => {
+export const DataTablePagination = <TData,>({
+  table,
+  enableShowAll = false,
+}: {
+  table: TTable<TData>;
+  enableShowAll?: boolean;
+}) => {
+  const totalRows = table.getFilteredRowModel().rows.length;
+  const currentPageSize = table.getState().pagination.pageSize;
+
+  const [isShowingAll, setIsShowingAll] = useState(false);
+
   return (
     <div className="flex items-center justify-between space-x-4 md:space-x-6 lg:space-x-8">
       <div className="flex items-center space-x-4">
         <div className="flex items-center space-x-2">
           <p className="text-sm font-medium">Rows per page</p>
           <Select
-            value={`${table.getState().pagination.pageSize}`}
+            value={isShowingAll ? 'all' : `${currentPageSize}`}
             onValueChange={(value) => {
-              table.setPageSize(Number(value));
+              if (value === 'all') {
+                table.setPageSize(totalRows);
+                setIsShowingAll(true);
+              } else {
+                table.setPageSize(Number(value));
+                setIsShowingAll(false);
+              }
             }}>
             <SelectTrigger className="border-secondary/20 hover:border-secondary w-[70px] transition-all">
-              <SelectValue placeholder={table.getState().pagination.pageSize} />
+              <SelectValue placeholder={isShowingAll ? 'All' : currentPageSize} />
             </SelectTrigger>
             <SelectContent side="top">
               {[10, 20, 30, 40, 50].map((pageSize) => (
@@ -30,37 +48,44 @@ export const DataTablePagination = <TData,>({ table }: { table: TTable<TData> })
                   {pageSize}
                 </SelectItem>
               ))}
+              {enableShowAll && (
+                <SelectItem key="all" value="all">
+                  All
+                </SelectItem>
+              )}
             </SelectContent>
           </Select>
         </div>
       </div>
-      <div className="flex items-center space-x-2">
-        <div className="mr-5 flex items-center justify-center text-sm font-medium">
-          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+      {!isShowingAll && (
+        <div className="flex items-center space-x-2">
+          <div className="mr-5 flex items-center justify-center text-sm font-medium">
+            Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+          </div>
+          <Button
+            type="secondary"
+            theme="outline"
+            className="disabled:cursor-not-allowed disabled:opacity-20"
+            onClick={() => {
+              table.previousPage();
+            }}
+            disabled={!table.getCanPreviousPage()}>
+            <span className="sr-only">Go to previous page</span>
+            <Icon icon={ArrowLeft} className="size-4" />
+          </Button>
+          <Button
+            type="secondary"
+            theme="outline"
+            className="disabled:cursor-not-allowed disabled:opacity-20"
+            onClick={() => {
+              table.nextPage();
+            }}
+            disabled={!table.getCanNextPage()}>
+            <span className="sr-only">Go to next page</span>
+            <Icon icon={ArrowRight} className="size-4" />
+          </Button>
         </div>
-        <Button
-          type="secondary"
-          theme="outline"
-          className="disabled:cursor-not-allowed disabled:opacity-20"
-          onClick={() => {
-            table.previousPage();
-          }}
-          disabled={!table.getCanPreviousPage()}>
-          <span className="sr-only">Go to previous page</span>
-          <Icon icon={ArrowLeft} className="size-4" />
-        </Button>
-        <Button
-          type="secondary"
-          theme="outline"
-          className="disabled:cursor-not-allowed disabled:opacity-20"
-          onClick={() => {
-            table.nextPage();
-          }}
-          disabled={!table.getCanNextPage()}>
-          <span className="sr-only">Go to next page</span>
-          <Icon icon={ArrowRight} className="size-4" />
-        </Button>
-      </div>
+      )}
     </div>
   );
 };

--- a/app/modules/datum-ui/components/data-table/features/toolbar/data-table-toolbar-row-count.tsx
+++ b/app/modules/datum-ui/components/data-table/features/toolbar/data-table-toolbar-row-count.tsx
@@ -1,0 +1,42 @@
+import { useDataTable } from '../../core/data-table.context';
+
+/**
+ * Component to display the filtered row count with pagination information
+ * Shows "Showing X-Y of Z records" when paginated, or "Showing X records" when all are shown
+ */
+export function DataTableToolbarRowCount() {
+  const { table } = useDataTable();
+  const totalFiltered = table.getFilteredRowModel().rows.length;
+
+  // Hide if no records
+  if (totalFiltered === 0) {
+    return null;
+  }
+
+  const currentPageRows = table.getRowModel().rows.length;
+  const pagination = table.getState().pagination;
+  const pageIndex = pagination.pageIndex;
+  const pageSize = pagination.pageSize;
+
+  // Check if pagination is enabled (if pageSize is less than total, we're paginating)
+  const isPaginated = pageSize < totalFiltered && currentPageRows > 0;
+
+  let displayText: string;
+
+  if (isPaginated) {
+    // Calculate the range being shown
+    const start = pageIndex * pageSize + 1;
+    const end = Math.min((pageIndex + 1) * pageSize, totalFiltered);
+
+    displayText = `Showing ${start}-${end} of ${totalFiltered} ${totalFiltered === 1 ? 'record' : 'records'}`;
+  } else {
+    // All records are shown (no pagination or all fit on one page)
+    displayText = `Showing ${totalFiltered} ${totalFiltered === 1 ? 'record' : 'records'}`;
+  }
+
+  return (
+    <span className="text-muted-foreground text-sm font-medium whitespace-nowrap">
+      {displayText}
+    </span>
+  );
+}

--- a/app/modules/datum-ui/components/data-table/features/toolbar/data-table-toolbar.tsx
+++ b/app/modules/datum-ui/components/data-table/features/toolbar/data-table-toolbar.tsx
@@ -5,6 +5,7 @@ import {
 } from '../../core/data-table.types';
 import { DataTableFilter } from '../filter/data-table-filter';
 import { DataTableToolbarFilterDropdown } from './data-table-toolbar-filter-dropdown';
+import { DataTableToolbarRowCount } from './data-table-toolbar-row-count';
 import { DataTableToolbarSearch } from './data-table-toolbar-search';
 import { PageTitle } from '@/components/page-title/page-title';
 import { cn } from '@shadcn/lib/utils';
@@ -148,6 +149,7 @@ export const DataTableToolbar = ({
       maxInlineFilters: config?.maxInlineFilters || 3,
       primaryFilters: config?.primaryFilters,
       showFilterCount: config?.showFilterCount ?? true,
+      showRowCount: config?.showRowCount ?? false, // Default to false, must be explicitly enabled
       responsive: config?.responsive ?? true,
     }),
     [config]
@@ -253,8 +255,11 @@ export const DataTableToolbar = ({
           )}
         </div>
 
-        {/* Right Section: Dropdown Filters + Actions */}
+        {/* Right Section: Row Count + Dropdown Filters + Actions */}
         <div className={cn('flex items-center justify-end gap-3', rightSectionClassName)}>
+          {/* Row count appears before dropdown filters */}
+          {toolbarConfig.showRowCount && <DataTableToolbarRowCount />}
+
           {dropdownFilters && dropdownFilters.length > 0 && (
             <DataTableToolbarFilterDropdown
               showFilterCount={toolbarConfig.showFilterCount}

--- a/app/routes/project/detail/edge/dns-zones/detail/dns-records.tsx
+++ b/app/routes/project/detail/edge/dns-zones/detail/dns-records.tsx
@@ -116,6 +116,7 @@ export default function DnsRecordsPage() {
       <DnsRecordTable
         ref={tableRef}
         mode="full"
+        enableShowAll={true}
         data={dnsRecords}
         projectId={projectId!}
         emptyContent={{
@@ -186,6 +187,7 @@ export default function DnsRecordsPage() {
             placeholder: 'Search DNS records',
           },
           filtersDisplay: 'dropdown',
+          showRowCount: true,
         }}
         filters={
           <>


### PR DESCRIPTION
This PR adds row count display to the DataTable toolbar and introduces an "All" option for pagination, while simplifying the DNS records page implementation.

#### 1. Row Count Display in Toolbar
- Added `showRowCount` option to `DataTableToolbarConfig` to enable/disable row count display
- Displays pagination-aware count:
  - **Paginated**: "Showing 1-10 of 20 records"
  - **All shown**: "Showing 20 records"
- Automatically hides when there are no records
- Positioned in the right section of the toolbar, before dropdown filters

#### 2. "All" Option in Pagination
- Added `enableShowAll` prop to `DataTableProps` to enable "All" option in page size selector
- Uses local state to track "All" selection (cleaner than sentinel values)
- When "All" is selected, shows all rows and hides page navigation buttons
- Works seamlessly with existing pagination logic

Ref: #880 