### PR TITLE
fix: use correct namespace for quota resources

### DIFF
--- a/app/resources/allowance-buckets/allowance-bucket.service.ts
+++ b/app/resources/allowance-buckets/allowance-bucket.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@/modules/control-plane/quota';
 import { logger } from '@/modules/logger';
 import type { ServiceOptions } from '@/resources/base/types';
-import { buildNamespace } from '@/utils/common';
+import { buildOrganizationNamespace } from '@/utils/common';
 import { mapApiError } from '@/utils/errors/error-mapper';
 import { getOrgScopedBase, getProjectScopedBase } from '@/utils/scoped-urls';
 
@@ -49,10 +49,12 @@ export function createAllowanceBucketService() {
     },
 
     async fetchList(namespace: 'organization' | 'project', id: string): Promise<AllowanceBucket[]> {
+      const bucketNamespace = namespace === 'organization' ? buildOrganizationNamespace(id) : 'milo-system';
+
       const response = await listQuotaMiloapisComV1Alpha1NamespacedAllowanceBucket({
         baseURL: getScopedBase(namespace, id),
         path: {
-          namespace: buildNamespace(namespace, id),
+          namespace: bucketNamespace,
         },
       });
 

--- a/app/resources/groups/group.service.ts
+++ b/app/resources/groups/group.service.ts
@@ -17,7 +17,7 @@ import {
 import { logger } from '@/modules/logger';
 import { ControlPlaneStatus } from '@/resources/base';
 import type { ServiceOptions } from '@/resources/base/types';
-import { buildNamespace } from '@/utils/common';
+import { buildOrganizationNamespace } from '@/utils/common';
 import { parseOrThrow } from '@/utils/errors/error-formatter';
 import { mapApiError } from '@/utils/errors/error-mapper';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
@@ -61,7 +61,7 @@ export function createGroupService() {
       const response = await listIamMiloapisComV1Alpha1NamespacedGroup({
         baseURL: getOrgScopedBase(organizationId),
         path: {
-          namespace: buildNamespace('organization', organizationId),
+          namespace: buildOrganizationNamespace(organizationId),
         },
       });
 
@@ -101,7 +101,7 @@ export function createGroupService() {
       const response = await readIamMiloapisComV1Alpha1NamespacedGroup({
         baseURL: getOrgScopedBase(organizationId),
         path: {
-          namespace: buildNamespace('organization', organizationId),
+          namespace: buildOrganizationNamespace(organizationId),
           name,
         },
       });
@@ -130,7 +130,7 @@ export function createGroupService() {
           message: 'Invalid group data',
         });
 
-        const namespace = buildNamespace('organization', organizationId);
+        const namespace = buildOrganizationNamespace(organizationId);
         const payload: ComMiloapisIamV1Alpha1Group = {
           apiVersion: 'iam.miloapis.com/v1alpha1',
           kind: 'Group',
@@ -179,7 +179,7 @@ export function createGroupService() {
       const startTime = Date.now();
 
       try {
-        const namespace = buildNamespace('organization', organizationId);
+        const namespace = buildOrganizationNamespace(organizationId);
         const payload: Partial<ComMiloapisIamV1Alpha1Group> = {
           metadata: {
             resourceVersion: input.resourceVersion,
@@ -221,7 +221,7 @@ export function createGroupService() {
       const startTime = Date.now();
 
       try {
-        const namespace = buildNamespace('organization', organizationId);
+        const namespace = buildOrganizationNamespace(organizationId);
 
         await deleteIamMiloapisComV1Alpha1NamespacedGroup({
           baseURL: getOrgScopedBase(organizationId),

--- a/app/resources/invitations/invitation.service.ts
+++ b/app/resources/invitations/invitation.service.ts
@@ -17,6 +17,7 @@ import {
 } from '@/modules/control-plane/iam';
 import { logger } from '@/modules/logger';
 import type { ServiceOptions } from '@/resources/base/types';
+import { buildOrganizationNamespace } from '@/utils/common';
 import { mapApiError } from '@/utils/errors/error-mapper';
 import { getOrgScopedBase, getUserScopedBase } from '@/utils/scoped-urls';
 
@@ -32,8 +33,6 @@ export const invitationKeys = {
 };
 
 const SERVICE_NAME = 'InvitationService';
-
-const buildNamespace = (organizationId: string) => `organization-${organizationId}`;
 
 export function createInvitationService() {
   return {
@@ -62,7 +61,7 @@ export function createInvitationService() {
       const response = await listIamMiloapisComV1Alpha1NamespacedUserInvitation({
         baseURL: getOrgScopedBase(organizationId),
         path: {
-          namespace: buildNamespace(organizationId),
+          namespace: buildOrganizationNamespace(organizationId),
         },
       });
 
@@ -122,7 +121,7 @@ export function createInvitationService() {
         const response = await readIamMiloapisComV1Alpha1NamespacedUserInvitation({
           baseURL: getOrgScopedBase(organizationId),
           path: {
-            namespace: buildNamespace(organizationId),
+            namespace: buildOrganizationNamespace(organizationId),
             name: invitationId,
           },
         });
@@ -158,7 +157,7 @@ export function createInvitationService() {
         const response = await createIamMiloapisComV1Alpha1NamespacedUserInvitation({
           baseURL: getOrgScopedBase(organizationId),
           path: {
-            namespace: buildNamespace(organizationId),
+            namespace: buildOrganizationNamespace(organizationId),
           },
           query: {
             dryRun: options?.dryRun ? 'All' : undefined,
@@ -197,7 +196,7 @@ export function createInvitationService() {
         await deleteIamMiloapisComV1Alpha1NamespacedUserInvitation({
           baseURL: getOrgScopedBase(organizationId),
           path: {
-            namespace: buildNamespace(organizationId),
+            namespace: buildOrganizationNamespace(organizationId),
             name: invitationId,
           },
         });
@@ -228,7 +227,7 @@ export function createInvitationService() {
         const response = await patchIamMiloapisComV1Alpha1NamespacedUserInvitation({
           baseURL: getOrgScopedBase(organizationId),
           path: {
-            namespace: buildNamespace(organizationId),
+            namespace: buildOrganizationNamespace(organizationId),
             name: invitationId,
           },
           headers: {

--- a/app/resources/members/member.service.ts
+++ b/app/resources/members/member.service.ts
@@ -9,7 +9,7 @@ import {
 } from '@/modules/control-plane/resource-manager';
 import { logger } from '@/modules/logger';
 import type { ServiceOptions } from '@/resources/base/types';
-import { buildNamespace } from '@/utils/common';
+import { buildOrganizationNamespace } from '@/utils/common';
 import { mapApiError } from '@/utils/errors/error-mapper';
 import { getOrgScopedBase } from '@/utils/scoped-urls';
 
@@ -52,7 +52,7 @@ export function createMemberService() {
         {
           baseURL: getOrgScopedBase(organizationId),
           path: {
-            namespace: buildNamespace('organization', organizationId),
+            namespace: buildOrganizationNamespace(organizationId),
           },
         }
       );
@@ -71,7 +71,7 @@ export function createMemberService() {
         await deleteResourcemanagerMiloapisComV1Alpha1NamespacedOrganizationMembership({
           baseURL: getOrgScopedBase(organizationId),
           path: {
-            namespace: buildNamespace('organization', organizationId),
+            namespace: buildOrganizationNamespace(organizationId),
             name: memberId,
           },
         });
@@ -104,7 +104,7 @@ export function createMemberService() {
           await patchResourcemanagerMiloapisComV1Alpha1NamespacedOrganizationMembership({
             baseURL: getOrgScopedBase(organizationId),
             path: {
-              namespace: buildNamespace('organization', organizationId),
+              namespace: buildOrganizationNamespace(organizationId),
               name: memberId,
             },
             query: {

--- a/app/resources/policy-bindings/policy-binding.service.ts
+++ b/app/resources/policy-bindings/policy-binding.service.ts
@@ -20,7 +20,7 @@ import {
 } from '@/modules/control-plane/iam';
 import { logger } from '@/modules/logger';
 import type { ServiceOptions } from '@/resources/base/types';
-import { buildNamespace } from '@/utils/common';
+import { buildOrganizationNamespace } from '@/utils/common';
 import { mapApiError } from '@/utils/errors/error-mapper';
 import { getOrgScopedBase } from '@/utils/scoped-urls';
 
@@ -62,7 +62,7 @@ export function createPolicyBindingService() {
       const response = await listIamMiloapisComV1Alpha1NamespacedPolicyBinding({
         baseURL: getOrgScopedBase(organizationId),
         path: {
-          namespace: buildNamespace('organization', organizationId),
+          namespace: buildOrganizationNamespace(organizationId),
         },
       });
 
@@ -99,7 +99,7 @@ export function createPolicyBindingService() {
       const response = await readIamMiloapisComV1Alpha1NamespacedPolicyBinding({
         baseURL: getOrgScopedBase(organizationId),
         path: {
-          namespace: buildNamespace('organization', organizationId),
+          namespace: buildOrganizationNamespace(organizationId),
           name: id,
         },
       });
@@ -124,7 +124,7 @@ export function createPolicyBindingService() {
         const response = await createIamMiloapisComV1Alpha1NamespacedPolicyBinding({
           baseURL: getOrgScopedBase(organizationId),
           path: {
-            namespace: buildNamespace('organization', organizationId),
+            namespace: buildOrganizationNamespace(organizationId),
           },
           query: {
             dryRun: options?.dryRun ? 'All' : undefined,
@@ -170,7 +170,7 @@ export function createPolicyBindingService() {
         const response = await patchIamMiloapisComV1Alpha1NamespacedPolicyBinding({
           baseURL: getOrgScopedBase(organizationId),
           path: {
-            namespace: buildNamespace('organization', organizationId),
+            namespace: buildOrganizationNamespace(organizationId),
             name: id,
           },
           headers: {
@@ -213,7 +213,7 @@ export function createPolicyBindingService() {
         await deleteIamMiloapisComV1Alpha1NamespacedPolicyBinding({
           baseURL: getOrgScopedBase(organizationId),
           path: {
-            namespace: buildNamespace('organization', organizationId),
+            namespace: buildOrganizationNamespace(organizationId),
             name: id,
           },
         });

--- a/app/routes/org/detail/team/index.tsx
+++ b/app/routes/org/detail/team/index.tsx
@@ -21,7 +21,7 @@ import {
   useHydrateMembers,
   useMembers,
 } from '@/resources/members';
-import { buildNamespace } from '@/utils/common';
+import { buildOrganizationNamespace } from '@/utils/common';
 import { paths } from '@/utils/config/paths.config';
 import { BadRequestError } from '@/utils/errors';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
@@ -201,7 +201,7 @@ export default function OrgTeamPage() {
     'organizationmemberships',
     'delete',
     {
-      namespace: buildNamespace('organization', orgId ?? ''),
+      namespace: buildOrganizationNamespace(orgId ?? ''),
       group: 'resourcemanager.miloapis.com',
     }
   );
@@ -210,7 +210,7 @@ export default function OrgTeamPage() {
     'userinvitations',
     'create',
     {
-      namespace: buildNamespace('organization', orgId ?? ''),
+      namespace: buildOrganizationNamespace(orgId ?? ''),
       group: 'iam.miloapis.com',
     }
   );
@@ -219,7 +219,7 @@ export default function OrgTeamPage() {
     'organizationmemberships',
     'patch',
     {
-      namespace: buildNamespace('organization', orgId ?? ''),
+      namespace: buildOrganizationNamespace(orgId ?? ''),
       group: 'resourcemanager.miloapis.com',
     }
   );

--- a/app/routes/org/detail/team/invite.tsx
+++ b/app/routes/org/detail/team/invite.tsx
@@ -5,7 +5,7 @@ import {
   type CreateInvitationInput,
   type InvitationFormSchema,
 } from '@/resources/invitations';
-import { buildNamespace } from '@/utils/common';
+import { buildOrganizationNamespace } from '@/utils/common';
 import { paths } from '@/utils/config/paths.config';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
@@ -30,7 +30,7 @@ export const loader = withMiddleware(
     resource: 'userinvitations',
     verb: 'create',
     group: 'iam.miloapis.com',
-    namespace: (params) => buildNamespace('organization', params.orgId),
+    namespace: (params) => buildOrganizationNamespace(params.orgId),
   })
 );
 

--- a/app/utils/common.ts
+++ b/app/utils/common.ts
@@ -86,8 +86,8 @@ export function removeUndefined<T extends Record<string, any>>(obj: T): Partial<
   return result;
 }
 
-export function buildNamespace(type: 'organization' | 'project', id: string): string {
-  return `${type}-${id}`;
+export function buildOrganizationNamespace(organizationId: string): string {
+  return `organization-${organizationId}`;
 }
 
 /**


### PR DESCRIPTION
Project-level quota resources exist within the `milo-system` namespace, not a namespace called `project-{id}`. I also adjusted the `buildNamespace` function to be called `buildOrganizationNamespace` to prevent confusion in how the function should be used.

---

Closes https://github.com/datum-cloud/cloud-portal/issues/941