### PR TITLE
Update DNS record discovery button text

### DIFF
--- a/app/features/edge/dns-zone/discovery-preview.tsx
+++ b/app/features/edge/dns-zone/discovery-preview.tsx
@@ -176,10 +176,12 @@ export const DnsZoneDiscoveryPreview = ({
             <CardContent className="flex min-h-[346px] flex-col items-center justify-center gap-4.5">
               <SpinnerIcon size="xl" aria-hidden="true" />
               <p className="text-sm font-semibold">Discovering DNS records...</p>
-              <Button htmlType="button" type="quaternary" theme="outline" onClick={handleSkip}>
-                Skip
-              </Button>
             </CardContent>
+            <CardFooter className="flex justify-center px-5 pb-5">
+              <Button htmlType="button" type="quaternary" theme="outline" onClick={handleSkip}>
+                Cancel DNS record discovery
+              </Button>
+            </CardFooter>
           </motion.div>
         ) : dnsRecords.length > 0 ? (
           <motion.div


### PR DESCRIPTION
- Changed button text from "Skip" to "Cancel DNS record discovery" for clarity.
- Added CardFooter component to improve layout of the discovery preview.

based on Chris’s feedback https://github.com/datum-cloud/cloud-portal/issues/944#issuecomment-3799460624

<img width="3190" height="1342" alt="image" src="https://github.com/user-attachments/assets/f4b3a8e5-0734-458e-a2d2-3876308eec85" />
