### PR TITLE
Enhance header with HelpScout integration and update HelpScoutBeacon config

### DIFF
--- a/app/components/header/header.tsx
+++ b/app/components/header/header.tsx
@@ -3,13 +3,14 @@ import { ProjectSwitcher } from './project-switcher';
 import { UserDropdown } from './user-dropdown';
 import { LogoIcon } from '@/components/logo/logo-icon';
 import { NotificationDropdown } from '@/components/notification';
+import { helpScoutAPI } from '@/modules/helpscout';
 import type { Organization } from '@/resources/organizations';
 import type { Project } from '@/resources/projects';
 import { paths } from '@/utils/config/paths.config';
 import { Button } from '@datum-ui/components';
 import { Tooltip } from '@datum-ui/components';
 import { Icon } from '@datum-ui/components/icons/icon-wrapper';
-import { BookOpen } from 'lucide-react';
+import { BookOpen, LifeBuoy } from 'lucide-react';
 import { Link } from 'react-router';
 
 export const Header = ({
@@ -51,6 +52,17 @@ export const Header = ({
       {/* Right Section */}
       <div className="flex items-center justify-end">
         <div className="flex h-full items-center gap-1.5">
+          <Tooltip message="Get in touch">
+            <Button
+              type="quaternary"
+              theme="outline"
+              size="small"
+              className="h-7 w-7 rounded-lg p-0"
+              onClick={() => helpScoutAPI.toggle()}>
+              <Icon icon={LifeBuoy} className="text-icon-primary size-3.5" />
+            </Button>
+          </Tooltip>
+
           <Tooltip message="Docs">
             <Link to="https://datum.net/docs/" target="_blank" rel="noreferrer">
               <Button

--- a/app/layouts/private.layout.tsx
+++ b/app/layouts/private.layout.tsx
@@ -61,7 +61,7 @@ export default function PrivateLayout() {
     userSignature: '',
   });
 
-  const { resolvedTheme, setTheme } = useTheme();
+  const { setTheme } = useTheme();
 
   useEffect(() => {
     if (data?.user) {
@@ -91,6 +91,7 @@ export default function PrivateLayout() {
         {helpscoutEnv.HELPSCOUT_BEACON_ID && helpscoutEnv.isProd && (
           <HelpScoutBeacon
             beaconId={helpscoutEnv.HELPSCOUT_BEACON_ID}
+            displayStyle="manual"
             user={{
               name: `${data?.user?.givenName} ${data?.user?.familyName}`,
               email: data?.user?.email,

--- a/app/modules/helpscout/helpscout.tsx
+++ b/app/modules/helpscout/helpscout.tsx
@@ -20,6 +20,7 @@ export interface HelpScoutBeaconComponentProps {
   poweredBy?: boolean;
   attachment?: boolean;
   labels?: string[];
+  displayStyle?: 'icon' | 'text' | 'iconAndText' | 'manual';
 }
 
 export const HelpScoutBeacon = ({
@@ -36,6 +37,7 @@ export const HelpScoutBeacon = ({
   poweredBy,
   attachment,
   labels,
+  displayStyle,
 }: HelpScoutBeaconComponentProps) => {
   const location = useLocation();
   const isLoadedRef = useRef(false);
@@ -129,14 +131,15 @@ export const HelpScoutBeacon = ({
       !isValidBeacon ||
       typeof window === 'undefined' ||
       !window.Beacon ||
-      configAppliedRef.current ||
-      !window.BeaconLoaded
+      configAppliedRef.current
     ) {
       return;
     }
 
     // Apply configuration options directly (no 'ready' callback needed in v2)
-    const config: Record<string, any> = {};
+    const config: Record<string, any> = {
+      display: {},
+    };
 
     if (color) config.color = color;
     if (icon) config.icon = icon;
@@ -149,6 +152,7 @@ export const HelpScoutBeacon = ({
     if (poweredBy !== undefined) config.poweredBy = poweredBy;
     if (attachment !== undefined) config.attachment = attachment;
     if (labels) config.labels = labels;
+    if (displayStyle) config.display.style = displayStyle;
 
     if (Object.keys(config).length > 0) {
       window.Beacon?.('config', config);


### PR DESCRIPTION
- Added HelpScout button in the header for user support access.
- Introduced LifeBuoy icon for the HelpScout button with a tooltip.
- Updated HelpScoutBeacon to accept a new displayStyle prop for manual display configuration.
- Removed unused resolvedTheme from PrivateLayout for cleaner code.


https://github.com/user-attachments/assets/f62499d9-b6e2-45e9-956c-f09f83037942

Ref: #962 