### PR TITLE
bugfix: change notification namespace as prod uses milo-system

### DIFF
--- a/app/resources/notifications/notification-scope.ts
+++ b/app/resources/notifications/notification-scope.ts
@@ -14,7 +14,7 @@ export type NotificationScope =
       projectId: string;
     };
 
-export const DEFAULT_NOTIFICATION_NAMESPACE = 'default';
+export const DEFAULT_NOTIFICATION_NAMESPACE = 'milo-system';
 
 export function getNotificationScopedBase(scope: NotificationScope): string {
   switch (scope.type) {


### PR DESCRIPTION
Change the notification contact namespace to `milo-system` to fix contact issue for notifications.