### PR TITLE
feat(activity): default to modification events

### DIFF
--- a/app/features/activity-log/activity-log-table.tsx
+++ b/app/features/activity-log/activity-log-table.tsx
@@ -96,6 +96,20 @@ export interface ActivityLogTableProps {
    * ```
    */
   defaultResource?: string | string[];
+  /**
+   * Initial action filter(s) for the filter UI.
+   * Sets a default action filter that users can change.
+   *
+   * @example
+   * ```tsx
+   * // Default to modify operations but allow users to change
+   * <ActivityLogTable
+   *   scope={{ type: 'project', projectId }}
+   *   initialActions={['Added', 'Modified', 'Deleted']}
+   * />
+   * ```
+   */
+  initialActions?: string | string[];
 }
 
 // ============================================
@@ -136,6 +150,7 @@ export function ActivityLogTable({
   hidePagination = false,
   hideFilters = false,
   defaultResource,
+  initialActions,
 }: ActivityLogTableProps) {
   const { user, organization } = useApp();
 
@@ -144,6 +159,7 @@ export function ActivityLogTable({
     scope,
     defaultPageSize,
     defaultResource,
+    initialActions,
     hideFilters,
   });
 
@@ -227,6 +243,7 @@ export function ActivityLogTable({
       }}
       // Server-side filtering
       serverSideFiltering={!hideFilters}
+      defaultFilters={hideFilters ? undefined : table.filters}
       onFiltersChange={hideFilters ? undefined : table.setFilters}
       // Server-side pagination
       serverSidePagination={!hidePagination}

--- a/app/features/activity-log/use-activity-log-table.ts
+++ b/app/features/activity-log/use-activity-log-table.ts
@@ -32,6 +32,11 @@ export interface UseActivityLogTableOptions {
    * When set, only these resources are shown.
    */
   defaultResource?: string | string[];
+  /**
+   * Initial action filter(s) for the filter UI.
+   * Sets a default action filter that users can change.
+   */
+  initialActions?: string | string[];
   /** Whether filters are hidden (disables filter state management) */
   hideFilters?: boolean;
 }
@@ -162,7 +167,13 @@ function getInitialFiltersFromUrl(timezone: string): FilterState {
 export function useActivityLogTable(
   options: UseActivityLogTableOptions
 ): UseActivityLogTableReturn {
-  const { scope, defaultPageSize = 20, defaultResource, hideFilters = false } = options;
+  const {
+    scope,
+    defaultPageSize = 20,
+    defaultResource,
+    initialActions,
+    hideFilters = false,
+  } = options;
 
   // ----------------------------------------
   // Time range handling
@@ -171,9 +182,19 @@ export function useActivityLogTable(
   const timezone = userPreferences?.timezone ?? getBrowserTimezone();
 
   // ----------------------------------------
-  // Filter state - initialize from URL params
+  // Filter state - initialize from URL params, then initialActions
   // ----------------------------------------
-  const [filters, setFilters] = useState<FilterState>(() => getInitialFiltersFromUrl(timezone));
+  const [filters, setFilters] = useState<FilterState>(() => {
+    const urlFilters = getInitialFiltersFromUrl(timezone);
+
+    // If no URL params, use initialActions
+    if (!urlFilters.actions && initialActions) {
+      const actionsArray = Array.isArray(initialActions) ? initialActions : [initialActions];
+      return { ...urlFilters, actions: actionsArray };
+    }
+
+    return urlFilters;
+  });
 
   // Normalize defaultResource to array
   const effectiveResources = useMemo(() => {

--- a/app/routes/org/detail/settings/activity.tsx
+++ b/app/routes/org/detail/settings/activity.tsx
@@ -9,5 +9,10 @@ export const meta: MetaFunction = mergeMeta(() => {
 export default function OrgActivityPage() {
   const { orgId } = useParams();
   if (!orgId) return null;
-  return <ActivityLogTable scope={{ type: 'organization', organizationId: orgId }} />;
+  return (
+    <ActivityLogTable
+      scope={{ type: 'organization', organizationId: orgId }}
+      initialActions={['Added', 'Modified', 'Deleted']}
+    />
+  );
 }

--- a/app/routes/project/detail/home.tsx
+++ b/app/routes/project/detail/home.tsx
@@ -283,6 +283,7 @@ export default function ProjectHomePage() {
                 defaultPageSize={5}
                 hidePagination
                 hideFilters
+                initialActions={['Added', 'Modified', 'Deleted']}
               />
             </CardContent>
           </Card>

--- a/app/routes/project/detail/settings/activity.tsx
+++ b/app/routes/project/detail/settings/activity.tsx
@@ -8,5 +8,10 @@ export const handle = {
 export default function ProjectActivityLogsPage() {
   const { projectId } = useParams();
 
-  return <ActivityLogTable scope={{ type: 'project', projectId: projectId! }} />;
+  return (
+    <ActivityLogTable
+      scope={{ type: 'project', projectId: projectId! }}
+      initialActions={['Added', 'Modified', 'Deleted']}
+    />
+  );
 }


### PR DESCRIPTION
This change adjusts the activity log viewer to only show modifcation events by default to help focus on critical activity. Users still have the ability to select `read` events if they'd like to.

I also consolidated "Updated" and "Modified" into just "Modified" since there's not much difference to end-users.

---

Relates to https://github.com/datum-cloud/enhancements/issues/469