### PR TITLE
Copy Nameservers is buggy

### DIFF
--- a/app/components/badge/badge-copy.tsx
+++ b/app/components/badge/badge-copy.tsx
@@ -47,42 +47,34 @@ export const BadgeCopy = ({
 
   const copyButton = (
     <span
-      onClick={(event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        copyToClipboard();
-      }}
-      className={cn(
-        'flex items-center justify-center transition-colors',
-        'hover:bg-black/5 dark:hover:bg-white/5',
-        'focus-visible:ring-ring focus-visible:ring-1 focus-visible:outline-hidden',
-        'cursor-pointer disabled:pointer-events-none disabled:opacity-50',
-        copyButtonClassName
-      )}
+      className={cn('flex items-center justify-center', copyButtonClassName)}
       aria-label={copied ? 'Copied!' : 'Copy to clipboard'}>
       <Icon icon={CopyIcon} className="size-3" />
     </span>
   );
 
-  const badgeContent = (
+  const badge = (
     <Badge
       type={badgeType}
       theme={badgeTheme}
       className={cn(
-        'flex cursor-default items-center gap-2.5 rounded-md px-1.5 py-[5px] font-mono text-xs font-normal',
+        'flex cursor-pointer items-center gap-2.5 rounded-md px-1.5 py-[5px] font-mono text-xs font-normal',
         className
       )}
       onClick={(event) => {
         event.preventDefault();
         event.stopPropagation();
+        copyToClipboard();
       }}>
       <span className={textClassName}>{displayText}</span>
-      {showTooltip ? (
-        <Tooltip message={copied ? 'Copied!' : 'Copy'}>{copyButton}</Tooltip>
-      ) : (
-        copyButton
-      )}
+      {copyButton}
     </Badge>
+  );
+
+  const badgeContent = showTooltip ? (
+    <Tooltip message={copied ? 'Copied!' : 'Copy'}>{badge}</Tooltip>
+  ) : (
+    badge
   );
 
   return <div className={cn('w-fit', containerClassName)}>{badgeContent}</div>;

--- a/app/components/demo/badge.tsx
+++ b/app/components/demo/badge.tsx
@@ -1,3 +1,4 @@
+import { BadgeCopy } from '@/components/badge/badge-copy';
 import { Badge } from '@datum-ui/components';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@datum-ui/components';
 import { AlertCircle, CheckCircle, XCircle, Star, Info } from 'lucide-react';
@@ -9,6 +10,7 @@ export const badgeDemoSections = [
   { id: 'status-indicators', label: 'Status Indicators' },
   { id: 'custom-styling', label: 'Custom Styling' },
   { id: 'interactive-badges', label: 'Interactive Badges' },
+  { id: 'badge-copy', label: 'Copyable Badges' },
   { id: 'use-cases', label: 'Common Use Cases' },
 ];
 
@@ -177,6 +179,44 @@ export default function BadgeDemo() {
               Hover Effect
             </Badge>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Copyable Badges */}
+      <Card id="badge-copy">
+        <CardHeader>
+          <CardTitle>Copyable Badges</CardTitle>
+          <CardDescription>
+            Use `BadgeCopy` for quickly copying values like IDs, hostnames, or tokens.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {['solid', 'outline', 'light'].map((theme) => (
+            <div key={theme} className="space-y-2">
+              <h4 className="text-sm font-medium capitalize">{theme} theme</h4>
+              <div className="flex flex-wrap gap-3">
+                {[
+                  'primary',
+                  'secondary',
+                  'tertiary',
+                  'quaternary',
+                  'info',
+                  'warning',
+                  'danger',
+                  'success',
+                ].map((type) => (
+                  <BadgeCopy
+                    key={`${type}-${theme}`}
+                    value={`${type}-${theme}`}
+                    text={`${type} • ${theme}`}
+                    badgeType={type as any}
+                    badgeTheme={theme as any}
+                    showTooltip
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
- Update BadgeCopy so the entire badge (not just the icon) acts as the copy trigger, with the tooltip attached to the whole badge.
- Simplify cursor/hover behavior to avoid flicker while keeping clear affordance that the badge is clickable.
- Extend the Badge demo to include a “Copyable Badges” section that showcases BadgeCopy across all type × theme combinations.

<img width="1642" height="1032" alt="image" src="https://github.com/user-attachments/assets/4d81a1ef-2643-4e77-bf28-47c34d3d9d60" />
