### PR TITLE
remove use of react-dom server

### DIFF
--- a/app/features/edge/proxy/overview/active-pops-card.tsx
+++ b/app/features/edge/proxy/overview/active-pops-card.tsx
@@ -1,5 +1,4 @@
 import { getRegionCoordinates } from './region-coordinates';
-import { ClientOnly } from '@/modules/datum-themes';
 import { usePrometheusLabels } from '@/modules/metrics';
 import { buildPrometheusLabelSelector } from '@/modules/metrics/utils/query-builders';
 import { SpinnerIcon } from '@datum-ui/components';
@@ -74,13 +73,10 @@ export const ActivePopsCard = ({ projectId, proxyId }: { projectId: string; prox
         {!isLoading && !error && regionOptions.length > 0 && (
           <div className="flex flex-col gap-4">
             {regionsWithCoords.length > 0 && (
-              <ClientOnly
+              <Suspense
                 fallback={<div className="bg-muted h-64 animate-pulse rounded-lg border" />}>
-                <Suspense
-                  fallback={<div className="bg-muted h-64 animate-pulse rounded-lg border" />}>
-                  <ActivePopsMap regionsWithCoords={regionsWithCoords} />
-                </Suspense>
-              </ClientOnly>
+                <ActivePopsMap regionsWithCoords={regionsWithCoords} />
+              </Suspense>
             )}
             {regionsWithCoords.length === 0 && (
               <div className="bg-muted flex h-64 w-full items-center justify-center rounded-lg border">

--- a/app/features/edge/proxy/overview/active-pops-map.tsx
+++ b/app/features/edge/proxy/overview/active-pops-map.tsx
@@ -1,16 +1,10 @@
-import {
-  Map,
-  MapFullscreenControl,
-  MapMarker,
-  MapTileLayer,
-  MapTooltip,
-  MapZoomControl,
-} from '@shadcn/ui/map';
+import { Map, MapMarker, MapTileLayer, MapTooltip, MapZoomControl } from '@shadcn/ui/map';
+import type { LatLngExpression } from 'leaflet';
 
 interface RegionWithCoords {
   value: string;
   label: string;
-  coords: [number, number];
+  coords: LatLngExpression;
 }
 
 const GreenPulseDot = () => (
@@ -26,7 +20,6 @@ export const ActivePopsMap = ({ regionsWithCoords }: { regionsWithCoords: Region
       <Map center={[20, 0]} zoom={2} minZoom={2} maxZoom={10} className="h-full w-full">
         <MapTileLayer />
         <MapZoomControl />
-        <MapFullscreenControl />
         {regionsWithCoords.map(({ value, label, coords }) => (
           <MapMarker key={value} position={coords} icon={<GreenPulseDot />} iconAnchor={[12, 12]}>
             <MapTooltip permanent={false}>{label}</MapTooltip>

--- a/app/modules/shadcn/ui/map.tsx
+++ b/app/modules/shadcn/ui/map.tsx
@@ -77,7 +77,7 @@ import React, {
   type ReactNode,
   type Ref,
 } from 'react';
-import { renderToString } from 'react-dom/server';
+import { renderToString } from 'react-dom/server.browser';
 import {
   useMap,
   useMapEvents,


### PR DESCRIPTION
The new AI Edge overview page errors in a build due to the use of a node api. This replaces it with the browser version.