### PR TITLE
chore: Remove DNS zone Overview route and links

### DIFF
--- a/app/features/edge/domain/overview/general-card.tsx
+++ b/app/features/edge/domain/overview/general-card.tsx
@@ -62,7 +62,7 @@ export const DomainGeneralCard = ({
             theme="link"
             size="link"
             className="font-semibold"
-            to={getPathWithParams(paths.project.detail.dnsZones.detail.overview, {
+            to={getPathWithParams(paths.project.detail.dnsZones.detail.root, {
               projectId: projectId ?? '',
               dnsZoneId: dnsZone?.name,
             })}>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -112,7 +112,7 @@ export default [
               { id: 'dns-zone-detail' },
               [
                 index('routes/project/detail/edge/dns-zones/detail/index.tsx'),
-                route('overview', 'routes/project/detail/edge/dns-zones/detail/overview.tsx'),
+                // route('overview', 'routes/project/detail/edge/dns-zones/detail/overview.tsx'),
                 route('dns-records', 'routes/project/detail/edge/dns-zones/detail/dns-records.tsx'),
                 route('nameservers', 'routes/project/detail/edge/dns-zones/detail/nameservers.tsx'),
                 route('settings', 'routes/project/detail/edge/dns-zones/detail/settings.tsx'),

--- a/app/routes/project/detail/config/domains/index.tsx
+++ b/app/routes/project/detail/config/domains/index.tsx
@@ -205,7 +205,7 @@ export default function DomainsPage() {
   const handleManageDnsZone = async (domain: FormattedDomain) => {
     if (domain.dnsZone) {
       navigate(
-        getPathWithParams(paths.project.detail.dnsZones.detail.overview, {
+        getPathWithParams(paths.project.detail.dnsZones.detail.root, {
           projectId,
           dnsZoneId: domain.dnsZone.name ?? '',
         })

--- a/app/routes/project/detail/edge/dns-zones/detail/index.tsx
+++ b/app/routes/project/detail/edge/dns-zones/detail/index.tsx
@@ -6,7 +6,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   const { projectId, dnsZoneId } = params;
 
   return redirect(
-    getPathWithParams(paths.project.detail.dnsZones.detail.overview, {
+    getPathWithParams(paths.project.detail.dnsZones.detail.dnsRecords, {
       projectId,
       dnsZoneId,
     })

--- a/app/routes/project/detail/edge/dns-zones/detail/layout.tsx
+++ b/app/routes/project/detail/edge/dns-zones/detail/layout.tsx
@@ -84,14 +84,14 @@ export default function DnsZoneDetailLayout() {
 
   const navItems: NavItem[] = useMemo(() => {
     return [
-      {
+      /* {
         title: 'Overview',
         href: getPathWithParams(paths.project.detail.dnsZones.detail.overview, {
           projectId,
           dnsZoneId: dnsZone?.name ?? '',
         }),
         type: 'link',
-      },
+      }, */
       {
         title: 'DNS Records',
         href: getPathWithParams(paths.project.detail.dnsZones.detail.dnsRecords, {

--- a/app/routes/project/detail/edge/dns-zones/index.tsx
+++ b/app/routes/project/detail/edge/dns-zones/index.tsx
@@ -286,7 +286,7 @@ export default function DnsZonesPage() {
       },
       {
         key: 'refresh',
-        label: 'Refresh',
+        label: 'Refresh nameservers',
         variant: 'default',
         hidden: (row) => !row.status?.domainRef?.name,
         action: (row) => refreshDomain(row),

--- a/app/utils/config/paths.config.ts
+++ b/app/utils/config/paths.config.ts
@@ -85,7 +85,7 @@ export const paths = {
         new: '/project/[projectId]/dns-zones/new',
         detail: {
           root: '/project/[projectId]/dns-zones/[dnsZoneId]',
-          overview: '/project/[projectId]/dns-zones/[dnsZoneId]/overview',
+          // overview: '/project/[projectId]/dns-zones/[dnsZoneId]/overview',
           dnsRecords: '/project/[projectId]/dns-zones/[dnsZoneId]/dns-records',
           nameservers: '/project/[projectId]/dns-zones/[dnsZoneId]/nameservers',
           settings: '/project/[projectId]/dns-zones/[dnsZoneId]/settings',


### PR DESCRIPTION
Disable the DNS Zone "Overview" page: remove/comment out the overview path and route, hide the Overview nav item, and update redirects/links to use the zone root or DNS Records. Also adjust the DNS zones list action label to "Refresh nameservers". Affected files: paths.config.ts, routes.ts, detail layout/index, domain general card, project domains navigator, and DNS zones index.

Ref: https://github.com/datum-cloud/cloud-portal/issues/1000