### PR TITLE
feat(errors): centralize error message resolution in Axios interceptor

### DIFF
--- a/app/modules/axios/axios.client.ts
+++ b/app/modules/axios/axios.client.ts
@@ -1,9 +1,11 @@
+import { type K8sStatus, isK8sStatus, parseK8sStatusError } from './k8s-error';
 import {
   isKubernetesResource,
   setSentryResourceContext,
   clearSentryResourceContext,
   captureApiError,
 } from '@/modules/sentry';
+import { AppError } from '@/utils/errors/app-error';
 import * as Sentry from '@sentry/react-router';
 import Axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
@@ -13,7 +15,7 @@ export const PROXY_URL = '/api/proxy';
  * Client-side axios instance for React Query hooks.
  * - Routes through /api/proxy (session cookie auth)
  * - Handles 401 → redirect to logout
- * - Shows toast on errors
+ * - Transforms errors into AppError objects with user-friendly messages
  * - Captures errors to Sentry
  */
 export const httpClient = Axios.create({
@@ -96,7 +98,63 @@ function getErrorMessage(error: AxiosError): { message: string; requestId?: stri
   };
 }
 
-const onResponseError = (error: AxiosError): Promise<AxiosError> => {
+/** Serialized AppError shape (from Hono error handler) */
+interface SerializedAppError {
+  code: string;
+  message: string;
+  status: number;
+  details?: Array<{ path: string[]; message: string; code?: string }>;
+  requestId?: string;
+}
+
+function isSerializedAppError(data: unknown): data is SerializedAppError {
+  if (typeof data !== 'object' || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return (
+    typeof obj.code === 'string' &&
+    typeof obj.status === 'number' &&
+    typeof obj.message === 'string' &&
+    !('kind' in obj) // Exclude K8s resources (they have 'kind' field)
+  );
+}
+
+function appErrorFromK8sStatus(data: K8sStatus, httpStatus: number, cause: AxiosError): AppError {
+  const parsed = parseK8sStatusError(data, httpStatus);
+  return new AppError(parsed.message, {
+    code: parsed.code,
+    status: httpStatus,
+    originalMessage: parsed.originalMessage,
+    k8sReason: parsed.k8sReason,
+    k8sDetails: parsed.k8sDetails,
+    details: parsed.details,
+    cause,
+    captureToSentry: false,
+  });
+}
+
+function appErrorFromSerialized(data: SerializedAppError, cause: AxiosError): AppError {
+  return new AppError(data.message, {
+    code: data.code,
+    status: data.status,
+    details: data.details,
+    requestId: data.requestId,
+    cause,
+    captureToSentry: false,
+  });
+}
+
+function appErrorFromRaw(error: AxiosError, httpStatus: number): AppError {
+  const { message, requestId } = getErrorMessage(error);
+  return new AppError(message, {
+    code: 'API_ERROR',
+    status: httpStatus,
+    requestId,
+    cause: error,
+    captureToSentry: false,
+  });
+}
+
+const onResponseError = (error: AxiosError): Promise<never> => {
   // Handle 401 AUTH_ERROR → redirect to logout
   if (error.response?.status === 401) {
     const data = error.response?.data as { code?: string } | undefined;
@@ -106,23 +164,26 @@ const onResponseError = (error: AxiosError): Promise<AxiosError> => {
     }
   }
 
-  const errorInfo = getErrorMessage(error);
+  const responseData = error.response?.data;
+  const httpStatus = error.response?.status ?? 500;
 
-  // Capture API error to Sentry with resource context and fingerprinting
+  const appError = isK8sStatus(responseData)
+    ? appErrorFromK8sStatus(responseData, httpStatus, error)
+    : isSerializedAppError(responseData)
+      ? appErrorFromSerialized(responseData, error)
+      : appErrorFromRaw(error, httpStatus);
+
+  // Capture to Sentry
   captureApiError({
     error,
     method: error.config?.method,
     url: error.config?.url,
     status: error.response?.status ?? 'network',
-    message: errorInfo.message,
-    requestId: errorInfo.requestId,
+    message: appError.originalMessage ?? appError.message,
+    requestId: appError.requestId,
   });
 
-  // Show toast with error message
-  // const title = errorInfo.requestId ? `Request ID: ${errorInfo.requestId}` : 'Error';
-  // toast.error(title, { description: errorInfo.message });
-
-  return Promise.reject(error);
+  return Promise.reject(appError);
 };
 
 httpClient.interceptors.request.use(onRequest, onRequestError);

--- a/app/modules/axios/k8s-error.ts
+++ b/app/modules/axios/k8s-error.ts
@@ -1,0 +1,97 @@
+import { type K8sErrorDetails } from '@/utils/errors/app-error';
+import { parseK8sMessage } from '@/utils/errors/error-parser';
+
+/** K8s Status object shape (from API error responses) */
+export interface K8sStatus {
+  kind: 'Status';
+  apiVersion: string;
+  status: 'Failure' | 'Success';
+  message: string;
+  reason?: string;
+  code: number;
+  details?: {
+    name?: string;
+    group?: string;
+    kind?: string;
+    causes?: Array<{ field?: string; message?: string; reason?: string }>;
+  };
+}
+
+export function isK8sStatus(data: unknown): data is K8sStatus {
+  if (typeof data !== 'object' || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return obj.kind === 'Status' && typeof obj.message === 'string' && typeof obj.code === 'number';
+}
+
+export function mapK8sReasonToCode(reason: string | undefined, httpStatus: number): string {
+  switch (reason) {
+    case 'AlreadyExists':
+      return 'CONFLICT';
+    case 'NotFound':
+      return 'NOT_FOUND';
+    case 'Conflict':
+      return 'CONFLICT';
+    case 'Forbidden':
+      return 'AUTHORIZATION_ERROR';
+    case 'Unauthorized':
+      return 'AUTHENTICATION_ERROR';
+    case 'Invalid':
+    case 'BadRequest':
+      return 'VALIDATION_ERROR';
+    case 'TooManyRequests':
+      return 'RATE_LIMIT_EXCEEDED';
+    default: {
+      switch (httpStatus) {
+        case 400:
+          return 'VALIDATION_ERROR';
+        case 401:
+          return 'AUTHENTICATION_ERROR';
+        case 403:
+          return 'AUTHORIZATION_ERROR';
+        case 404:
+          return 'NOT_FOUND';
+        case 409:
+          return 'CONFLICT';
+        case 429:
+          return 'RATE_LIMIT_EXCEEDED';
+        default:
+          return 'API_ERROR';
+      }
+    }
+  }
+}
+
+/** Parsed result from a K8s Status object */
+export interface ParsedK8sError {
+  message: string;
+  originalMessage: string;
+  code: string;
+  k8sReason?: string;
+  k8sDetails?: K8sErrorDetails;
+  details?: Array<{ path: string[]; message: string; code?: string }>;
+}
+
+/**
+ * Parse a K8s Status response into a structured error with user-friendly message.
+ * Shared between client-side and server-side Axios interceptors.
+ */
+export function parseK8sStatusError(data: K8sStatus, httpStatus: number): ParsedK8sError {
+  const parsedMessage = parseK8sMessage(data.message);
+  const k8sDetails: K8sErrorDetails | undefined = data.details
+    ? { kind: data.details.kind, name: data.details.name, group: data.details.group }
+    : undefined;
+  const details = data.details?.causes?.map((k8sCause) => ({
+    path: k8sCause.field ? k8sCause.field.split('.') : [],
+    message: k8sCause.message ?? '',
+    code: k8sCause.reason,
+  }));
+
+  return {
+    message: parsedMessage,
+    originalMessage: data.message,
+    code: mapK8sReasonToCode(data.reason, httpStatus),
+    k8sReason: data.reason,
+    k8sDetails,
+    details: details?.length ? details : undefined,
+  };
+}

--- a/app/modules/tanstack/query.ts
+++ b/app/modules/tanstack/query.ts
@@ -1,9 +1,3 @@
 import { QueryClient } from '@tanstack/react-query';
 
-export const queryClient = new QueryClient({
-  // defaultOptions: {
-  //   queries: {
-  //     retry: 1,
-  //   },
-  // },
-});
+export const queryClient = new QueryClient();

--- a/app/utils/errors/app-error.ts
+++ b/app/utils/errors/app-error.ts
@@ -6,6 +6,12 @@ export interface ErrorDetail {
   code?: string;
 }
 
+export interface K8sErrorDetails {
+  kind?: string;
+  name?: string;
+  group?: string;
+}
+
 export interface SerializedError {
   code: string;
   message: string;
@@ -13,6 +19,9 @@ export interface SerializedError {
   details?: ErrorDetail[];
   requestId?: string;
   sentryEventId?: string;
+  originalMessage?: string;
+  k8sReason?: string;
+  k8sDetails?: K8sErrorDetails;
 }
 
 export class AppError extends Error {
@@ -21,6 +30,9 @@ export class AppError extends Error {
   public readonly details?: ErrorDetail[];
   public readonly requestId?: string;
   public readonly sentryEventId?: string;
+  public readonly originalMessage?: string;
+  public readonly k8sReason?: string;
+  public readonly k8sDetails?: K8sErrorDetails;
 
   constructor(
     message: string,
@@ -31,6 +43,9 @@ export class AppError extends Error {
       requestId?: string;
       cause?: unknown;
       captureToSentry?: boolean;
+      originalMessage?: string;
+      k8sReason?: string;
+      k8sDetails?: K8sErrorDetails;
     } = {}
   ) {
     super(message, { cause: options.cause });
@@ -39,6 +54,9 @@ export class AppError extends Error {
     this.status = options.status ?? 500;
     this.details = options.details;
     this.requestId = options.requestId;
+    this.originalMessage = options.originalMessage;
+    this.k8sReason = options.k8sReason;
+    this.k8sDetails = options.k8sDetails;
 
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
@@ -71,6 +89,9 @@ export class AppError extends Error {
       details: this.details,
       requestId: this.requestId,
       sentryEventId: this.sentryEventId,
+      originalMessage: this.originalMessage,
+      k8sReason: this.k8sReason,
+      k8sDetails: this.k8sDetails,
     };
   }
 

--- a/app/utils/errors/error-parser.ts
+++ b/app/utils/errors/error-parser.ts
@@ -1,0 +1,81 @@
+import { getResourceLabel } from '@/utils/helpers/resource-labels';
+
+/**
+ * K8s resource path pattern: `group.api.com "name" is reason`
+ * Examples:
+ *   - projects.resourcemanager.miloapis.com "jinja-otoke-tkr5rh" is forbidden
+ *   - domains.networking.datumapis.com "hiyahya-dev" is forbidden
+ *   - dnszones.dns.networking.miloapis.com "example" not found
+ */
+const K8S_RESOURCE_PATH_PATTERN = /^[\w.-]+\.[\w.-]+\.\w+ "[^"]+" (?:is \w+|not found)$/;
+
+/**
+ * Admission webhook prefix pattern
+ * Example: admission webhook "vdomain-v1alpha.kb.io" denied the request
+ */
+const ADMISSION_WEBHOOK_PATTERN = /^admission webhook "[^"]+" denied the request$/;
+
+/**
+ * K8s "not found" single-segment pattern: `resource.group.api.com "name" not found`
+ * Captures the resource kind (e.g., "dnszones") and the quoted resource name.
+ * The resource kind is the first dot-separated segment before the API group.
+ */
+const K8S_NOT_FOUND_PATTERN = /^(\w+)\.[\w.-]+ "([^"]+)" not found$/;
+
+function capitalize(str: string): string {
+  if (!str) return str;
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * Parse a raw K8s Status message to extract the user-friendly portion.
+ *
+ * K8s messages are often nested with colons:
+ *   admission webhook "x" denied the request: resource.group.com "name" is reason: actual message
+ *
+ * This parser walks backwards through colon-separated segments, skipping
+ * admission webhook prefixes and K8s resource path segments, and returns
+ * the deepest meaningful segment.
+ *
+ * Uses shared resource labels from `resource-labels` for
+ * humanizing "not found" messages.
+ */
+export function parseK8sMessage(raw: string): string {
+  if (!raw) return raw;
+
+  // Split on ": " to handle nested K8s messages
+  const segments = raw.split(': ');
+
+  // Single segment — check for K8s not-found pattern
+  if (segments.length === 1) {
+    const notFoundMatch = raw.match(K8S_NOT_FOUND_PATTERN);
+    if (notFoundMatch) {
+      const label = getResourceLabel(notFoundMatch[1]);
+      return `${label} "${notFoundMatch[2]}" not found`;
+    }
+    return raw;
+  }
+
+  // Walk backwards to find the first meaningful segment
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const segment = segments[i].trim();
+
+    // Humanize K8s "not found" resource path before skipping
+    const notFoundMatch = segment.match(K8S_NOT_FOUND_PATTERN);
+    if (notFoundMatch) {
+      const label = getResourceLabel(notFoundMatch[1]);
+      return `${label} "${notFoundMatch[2]}" not found`;
+    }
+
+    // Skip other K8s resource path segments (e.g., "is forbidden")
+    if (K8S_RESOURCE_PATH_PATTERN.test(segment)) continue;
+
+    // Skip admission webhook prefixes
+    if (ADMISSION_WEBHOOK_PATTERN.test(segment)) continue;
+
+    return capitalize(segment);
+  }
+
+  // Fallback: return the last segment capitalized
+  return capitalize(segments[segments.length - 1].trim());
+}

--- a/app/utils/errors/index.ts
+++ b/app/utils/errors/index.ts
@@ -8,6 +8,7 @@ export {
   RateLimitError,
   type ErrorDetail,
   type SerializedError,
+  type K8sErrorDetails,
 } from './app-error';
 
 export {
@@ -32,3 +33,5 @@ export {
 export { formatZodError, fromZodError, parseOrThrow } from './error-formatter';
 
 export { mapApiError } from './error-mapper';
+
+export { parseK8sMessage } from './error-parser';

--- a/app/utils/helpers/resource-labels.ts
+++ b/app/utils/helpers/resource-labels.ts
@@ -1,0 +1,32 @@
+/**
+ * Central registry of K8s resource kind → human-readable label.
+ * Single source of truth used by:
+ * - Error message parser (K8s Status messages)
+ * - Activity log humanization
+ * - Any UI that displays resource types
+ */
+const RESOURCE_LABELS: Readonly<Record<string, string>> = Object.freeze({
+  // Organization-level resources
+  organizations: 'Organization',
+  users: 'User',
+  groups: 'Group',
+  roles: 'Role',
+  projects: 'Project',
+  invitations: 'Invitation',
+  members: 'Member',
+
+  // Project-level resources
+  domains: 'Domain',
+  dnszones: 'DNS Zone',
+  dnsrecords: 'DNS Record',
+  dnsrecordsets: 'DNS Record Set',
+  dnszonediscoveries: 'DNS Zone Discovery',
+  httpproxies: 'HTTP Proxy',
+  secrets: 'Secret',
+  policybindings: 'Policy Binding',
+  exportpolicies: 'Export Policy',
+});
+
+export function getResourceLabel(resource: string): string {
+  return RESOURCE_LABELS[resource] ?? resource;
+}

--- a/cypress/component/error-parser.cy.ts
+++ b/cypress/component/error-parser.cy.ts
@@ -1,0 +1,54 @@
+import { parseK8sMessage } from '@/utils/errors/error-parser';
+
+describe('parseK8sMessage', () => {
+  it('extracts message after single colon in resource path pattern', () => {
+    const raw =
+      'projects.resourcemanager.miloapis.com "jinja-otoke-tkr5rh" is forbidden: Insufficient quota resources available.';
+    const result = parseK8sMessage(raw);
+    expect(result).to.equal('Insufficient quota resources available.');
+  });
+
+  it('extracts deepest segment from admission webhook nested message', () => {
+    const raw =
+      'admission webhook "vdomain-v1alpha.kb.io" denied the request: domains.networking.datumapis.com "hiyahya-dev" is forbidden: cannot delete Domain while in use by an HTTPProxy';
+    const result = parseK8sMessage(raw);
+    expect(result).to.equal('Cannot delete Domain while in use by an HTTPProxy');
+  });
+
+  it('returns full message when no colon-separated nesting', () => {
+    const raw = 'Something went wrong';
+    const result = parseK8sMessage(raw);
+    expect(result).to.equal('Something went wrong');
+  });
+
+  it('handles simple K8s not found message', () => {
+    const raw = 'dnszones.dns.networking.miloapis.com "example" not found';
+    const result = parseK8sMessage(raw);
+    expect(result).to.equal('DNS Zone "example" not found');
+  });
+
+  it('capitalizes the first letter of the result', () => {
+    const raw =
+      'admission webhook "foo.kb.io" denied the request: resources.api.com "bar" is invalid: must be at least 3 characters';
+    const result = parseK8sMessage(raw);
+    expect(result).to.equal('Must be at least 3 characters');
+  });
+
+  it('handles empty string gracefully', () => {
+    const result = parseK8sMessage('');
+    expect(result).to.equal('');
+  });
+
+  it('handles message with only webhook prefix and resource path', () => {
+    const raw = 'admission webhook "test.kb.io" denied the request: something unexpected happened';
+    const result = parseK8sMessage(raw);
+    expect(result).to.equal('Something unexpected happened');
+  });
+
+  it('humanizes not-found in multi-segment webhook message', () => {
+    const raw =
+      'admission webhook "foo.kb.io" denied the request: dnszones.dns.networking.miloapis.com "example" not found';
+    const result = parseK8sMessage(raw);
+    expect(result).to.equal('DNS Zone "example" not found');
+  });
+});

--- a/cypress/component/k8s-error.cy.ts
+++ b/cypress/component/k8s-error.cy.ts
@@ -1,0 +1,220 @@
+import { isK8sStatus, mapK8sReasonToCode, parseK8sStatusError } from '@/modules/axios/k8s-error';
+
+describe('isK8sStatus', () => {
+  it('returns true for valid K8s Status object', () => {
+    expect(
+      isK8sStatus({
+        kind: 'Status',
+        apiVersion: 'v1',
+        status: 'Failure',
+        message: 'not found',
+        code: 404,
+      })
+    ).to.equal(true);
+  });
+
+  it('returns false when kind is not Status', () => {
+    expect(isK8sStatus({ kind: 'Project', apiVersion: 'v1', message: 'test', code: 200 })).to.equal(
+      false
+    );
+  });
+
+  it('returns false when message is missing', () => {
+    expect(isK8sStatus({ kind: 'Status', code: 404 })).to.equal(false);
+  });
+
+  it('returns false when code is missing', () => {
+    expect(isK8sStatus({ kind: 'Status', message: 'not found' })).to.equal(false);
+  });
+
+  it('returns false when code is not a number', () => {
+    expect(isK8sStatus({ kind: 'Status', message: 'test', code: '404' })).to.equal(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isK8sStatus(null)).to.equal(false);
+  });
+
+  it('returns false for non-object', () => {
+    expect(isK8sStatus('Status')).to.equal(false);
+  });
+});
+
+describe('mapK8sReasonToCode', () => {
+  it('maps AlreadyExists to CONFLICT', () => {
+    expect(mapK8sReasonToCode('AlreadyExists', 409)).to.equal('CONFLICT');
+  });
+
+  it('maps NotFound to NOT_FOUND', () => {
+    expect(mapK8sReasonToCode('NotFound', 404)).to.equal('NOT_FOUND');
+  });
+
+  it('maps Conflict to CONFLICT', () => {
+    expect(mapK8sReasonToCode('Conflict', 409)).to.equal('CONFLICT');
+  });
+
+  it('maps Forbidden to AUTHORIZATION_ERROR', () => {
+    expect(mapK8sReasonToCode('Forbidden', 403)).to.equal('AUTHORIZATION_ERROR');
+  });
+
+  it('maps Unauthorized to AUTHENTICATION_ERROR', () => {
+    expect(mapK8sReasonToCode('Unauthorized', 401)).to.equal('AUTHENTICATION_ERROR');
+  });
+
+  it('maps Invalid to VALIDATION_ERROR', () => {
+    expect(mapK8sReasonToCode('Invalid', 422)).to.equal('VALIDATION_ERROR');
+  });
+
+  it('maps BadRequest to VALIDATION_ERROR', () => {
+    expect(mapK8sReasonToCode('BadRequest', 400)).to.equal('VALIDATION_ERROR');
+  });
+
+  it('maps TooManyRequests to RATE_LIMIT_EXCEEDED', () => {
+    expect(mapK8sReasonToCode('TooManyRequests', 429)).to.equal('RATE_LIMIT_EXCEEDED');
+  });
+
+  it('falls back to HTTP 400 as VALIDATION_ERROR', () => {
+    expect(mapK8sReasonToCode(undefined, 400)).to.equal('VALIDATION_ERROR');
+  });
+
+  it('falls back to HTTP 401 as AUTHENTICATION_ERROR', () => {
+    expect(mapK8sReasonToCode(undefined, 401)).to.equal('AUTHENTICATION_ERROR');
+  });
+
+  it('falls back to HTTP 403 as AUTHORIZATION_ERROR', () => {
+    expect(mapK8sReasonToCode(undefined, 403)).to.equal('AUTHORIZATION_ERROR');
+  });
+
+  it('falls back to HTTP 404 as NOT_FOUND', () => {
+    expect(mapK8sReasonToCode(undefined, 404)).to.equal('NOT_FOUND');
+  });
+
+  it('falls back to HTTP 409 as CONFLICT', () => {
+    expect(mapK8sReasonToCode(undefined, 409)).to.equal('CONFLICT');
+  });
+
+  it('falls back to HTTP 429 as RATE_LIMIT_EXCEEDED', () => {
+    expect(mapK8sReasonToCode(undefined, 429)).to.equal('RATE_LIMIT_EXCEEDED');
+  });
+
+  it('falls back to API_ERROR for unknown status', () => {
+    expect(mapK8sReasonToCode(undefined, 500)).to.equal('API_ERROR');
+  });
+});
+
+describe('parseK8sStatusError', () => {
+  it('parses K8s Status with message and reason', () => {
+    const result = parseK8sStatusError(
+      {
+        kind: 'Status',
+        apiVersion: 'v1',
+        status: 'Failure',
+        message:
+          'admission webhook "vdomain-v1alpha.kb.io" denied the request: domains.networking.datumapis.com "test" is forbidden: cannot delete Domain while in use',
+        reason: 'Forbidden',
+        code: 403,
+      },
+      403
+    );
+
+    expect(result.message).to.equal('Cannot delete Domain while in use');
+    expect(result.code).to.equal('AUTHORIZATION_ERROR');
+    expect(result.k8sReason).to.equal('Forbidden');
+    expect(result.originalMessage).to.include('admission webhook');
+  });
+
+  it('parses K8s Status with details and causes', () => {
+    const result = parseK8sStatusError(
+      {
+        kind: 'Status',
+        apiVersion: 'v1',
+        status: 'Failure',
+        message: 'Invalid resource',
+        reason: 'Invalid',
+        code: 422,
+        details: {
+          kind: 'DNSZone',
+          name: 'example',
+          group: 'dns.networking.miloapis.com',
+          causes: [
+            {
+              field: 'spec.domain',
+              message: 'must be a valid domain',
+              reason: 'FieldValueInvalid',
+            },
+          ],
+        },
+      },
+      422
+    );
+
+    expect(result.code).to.equal('VALIDATION_ERROR');
+    expect(result.k8sDetails).to.deep.equal({
+      kind: 'DNSZone',
+      name: 'example',
+      group: 'dns.networking.miloapis.com',
+    });
+    expect(result.details).to.have.length(1);
+    expect(result.details?.[0].path).to.deep.equal(['spec', 'domain']);
+    expect(result.details?.[0].message).to.equal('must be a valid domain');
+    expect(result.details?.[0].code).to.equal('FieldValueInvalid');
+  });
+
+  it('handles K8s Status without details', () => {
+    const result = parseK8sStatusError(
+      {
+        kind: 'Status',
+        apiVersion: 'v1',
+        status: 'Failure',
+        message: 'Something went wrong',
+        code: 500,
+      },
+      500
+    );
+
+    expect(result.message).to.equal('Something went wrong');
+    expect(result.code).to.equal('API_ERROR');
+    expect(result.k8sReason).to.equal(undefined);
+    expect(result.k8sDetails).to.equal(undefined);
+    expect(result.details).to.equal(undefined);
+  });
+
+  it('handles K8s Status with empty causes array', () => {
+    const result = parseK8sStatusError(
+      {
+        kind: 'Status',
+        apiVersion: 'v1',
+        status: 'Failure',
+        message: 'Not found',
+        reason: 'NotFound',
+        code: 404,
+        details: { kind: 'Project', causes: [] },
+      },
+      404
+    );
+
+    expect(result.code).to.equal('NOT_FOUND');
+    expect(result.details).to.equal(undefined);
+    expect(result.k8sDetails).to.deep.equal({ kind: 'Project', name: undefined, group: undefined });
+  });
+
+  it('handles cause without field', () => {
+    const result = parseK8sStatusError(
+      {
+        kind: 'Status',
+        apiVersion: 'v1',
+        status: 'Failure',
+        message: 'Invalid',
+        reason: 'Invalid',
+        code: 422,
+        details: {
+          causes: [{ message: 'something wrong' }],
+        },
+      },
+      422
+    );
+
+    expect(result.details?.[0].path).to.deep.equal([]);
+    expect(result.details?.[0].message).to.equal('something wrong');
+  });
+});

--- a/cypress/component/resource-labels.cy.ts
+++ b/cypress/component/resource-labels.cy.ts
@@ -1,0 +1,27 @@
+import { getResourceLabel } from '@/utils/helpers/resource-labels';
+
+describe('getResourceLabel', () => {
+  it('returns label for known resource', () => {
+    expect(getResourceLabel('projects')).to.equal('Project');
+  });
+
+  it('returns label for DNS zone resource', () => {
+    expect(getResourceLabel('dnszones')).to.equal('DNS Zone');
+  });
+
+  it('returns label for HTTP proxies', () => {
+    expect(getResourceLabel('httpproxies')).to.equal('HTTP Proxy');
+  });
+
+  it('returns label for domains', () => {
+    expect(getResourceLabel('domains')).to.equal('Domain');
+  });
+
+  it('returns raw key for unknown resource', () => {
+    expect(getResourceLabel('unknownresource')).to.equal('unknownresource');
+  });
+
+  it('returns label for organizations', () => {
+    expect(getResourceLabel('organizations')).to.equal('Organization');
+  });
+});


### PR DESCRIPTION
## Summary

Previously, the client-side Axios interceptor re-threw raw `AxiosError` objects, leaving each consumer to manually parse K8s Status messages and extract user-friendly text. This PR centralizes error message resolution at the Axios transport layer so that every consumer receives an `AppError` with a clean, human-readable `message`.

### Concept

**Axios interceptor (transport layer)** does the heavy lifting:
- Detects error shape: K8s Status, serialized AppError from Hono, or raw response
- Parses nested K8s messages using a backwards-walking segment extractor (strips webhook prefixes and resource paths)
- Builds `AppError` with parsed `message`, plus `originalMessage`, `k8sReason`, and `k8sDetails` for debugging

**Consumers own the toast** with context-aware titles:
```typescript
// error.message is already user-friendly thanks to the interceptor
toast.error('Domain', { description: error.message });
```

This keeps presentation decisions where they belong — consumers know their resource context ("Domain", "DNS Zone", "Project") and provide appropriate titles.

### Implementation

- **`app/utils/errors/app-error.ts`** — Extended with `originalMessage`, `k8sReason`, `k8sDetails` fields
- **`app/utils/errors/error-parser.ts`** — K8s message parser that walks backwards through `": "`-delimited segments, skipping admission webhook prefixes and resource path patterns to extract the meaningful message
- **`app/utils/helpers/resource-labels.ts`** — Shared registry of K8s resource kind → human-readable label (used by parser and activity logs)
- **`app/modules/axios/axios.client.ts`** — Response error interceptor now transforms all errors to `AppError` with three factory functions (`appErrorFromK8sStatus`, `appErrorFromSerialized`, `appErrorFromRaw`)
- **`app/modules/tanstack/query.ts`** — Simplified to plain `QueryClient` (no auto-toast)
- **`app/resources/activity-logs/activity-log.helpers.ts`** — Refactored to use shared resource labels instead of duplicated registry

### Examples

**Before** (raw K8s message in toast):
> `admission webhook "vdomain-v1alpha.kb.io" denied the request: domains.networking.datumapis.com "hiyahya-dev" is forbidden: cannot delete Domain while in use by an HTTPProxy`

**After** (parsed by interceptor):
> `Cannot delete Domain while in use by an HTTPProxy`

### Screenshot
<img width="2408" height="1277" alt="Screenshot 2026-02-21 at 04 23 17" src="https://github.com/user-attachments/assets/77c3da14-5776-44c6-afd9-30480bf5d93f" />




Ref: https://github.com/datum-cloud/cloud-portal/issues/997