### PR TITLE
chore: configure Claude Code datum plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "datum-claude-code-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "datum-cloud/claude-code-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "datum-platform@datum-claude-code-plugins": true,
+    "datum-gtm@datum-claude-code-plugins": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 .cursor/
 .windsurf/
 .claude/
+!.claude/settings.json
 CLAUDE.MD
 
 cypress/screenshots


### PR DESCRIPTION
This PR configures Claude Code to automatically include the datum-cloud plugins from the shared plugin marketplace.

## Changes
- Adds `.claude/settings.json` with the datum-cloud plugin marketplace configuration
- Enables both `datum-platform` and `datum-gtm` plugins by default
- Updates `.gitignore` to allow `.claude/settings.json` while still ignoring other `.claude/` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)