### PR TITLE
fix: add TCP keepalive to prevent upstream connection timeouts

### DIFF
--- a/config/base/backend-traffic-policy.yaml
+++ b/config/base/backend-traffic-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: cloud-portal-tcp-keepalive
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: cloud-portal
+  tcpKeepalive:
+    idleTime: 60s
+    interval: 15s
+    probes: 3

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
   - service.yaml
   - http-route.yaml
   - service-monitor.yaml
+  - backend-traffic-policy.yaml


### PR DESCRIPTION
## Summary
- Add BackendTrafficPolicy to configure TCP keepalives on upstream connections
- Prevents intermittent 503 errors caused by idle connections being terminated by intermediate infrastructure (GCP load balancers, firewalls) before Envoy detects they are dead

## Configuration
| Setting | Value | Description |
|---------|-------|-------------|
| `idleTime` | 60s | Start probing after 60 seconds idle |
| `interval` | 15s | Probe every 15 seconds |
| `probes` | 3 | Consider connection dead after 3 failed probes |

## Test plan
- [ ] Verify BackendTrafficPolicy is deployed to staging after merge
- [ ] Monitor for 503 upstream connection timeout errors
- [ ] Confirm TCP keepalive settings are applied via Envoy admin interface

Fixes: datum-cloud/infra#115