### PR TITLE
fix(auth): harden session token refresh against multi-pod rotation races

### DIFF
--- a/app/server/entry.ts
+++ b/app/server/entry.ts
@@ -13,6 +13,7 @@ import { Logger } from '@/modules/logger';
 import { checkRedisHealth } from '@/modules/redis';
 import { sentryTracingMiddleware } from '@/modules/sentry';
 import { watchHub } from '@/server/watch';
+import { sessionManager } from '@/utils/auth';
 import { env } from '@/utils/env/env.server';
 import { prometheus } from '@hono/prometheus';
 import { Hono } from 'hono';
@@ -28,6 +29,13 @@ const beginShutdown = () => {
 
 process.once('SIGTERM', beginShutdown);
 process.once('SIGINT', beginShutdown);
+
+// Sync refreshed tokens to WatchHub SSE connections.
+// When sessionMiddleware refreshes a token, all SSE clients for that user
+// get the new token so upstream reconnections use fresh credentials.
+sessionManager.registerRefreshHook(({ userId, accessToken }) => {
+  watchHub.updateTokensByUserId(userId, accessToken);
+});
 
 // Initialize observability (OTEL + Sentry + error handlers)
 initializeObservability().catch((error: unknown) => {

--- a/app/server/middleware/auth.ts
+++ b/app/server/middleware/auth.ts
@@ -1,5 +1,5 @@
 import type { Variables } from '@/server/types';
-import { AuthService } from '@/utils/auth/auth.service';
+import { sessionManager } from '@/utils/auth';
 import { AuthenticationError } from '@/utils/errors/app-error';
 import * as Sentry from '@sentry/react-router';
 import { createMiddleware } from 'hono/factory';
@@ -13,7 +13,7 @@ export function sessionMiddleware() {
   return createMiddleware<{ Variables: Variables }>(async (c, next) => {
     const cookieHeader = c.req.header('Cookie') ?? null;
 
-    const { session, headers, refreshed } = await AuthService.getValidSession(cookieHeader);
+    const { session, headers, refreshed } = await sessionManager.getValidSession(cookieHeader);
 
     if (session) {
       c.set('session', session);
@@ -27,6 +27,10 @@ export function sessionMiddleware() {
       }
 
       Sentry.setUser({ id: session.sub });
+    } else {
+      // Reset Sentry user to prevent scope leaking from a previous request
+      // on the same server instance into this unauthenticated request.
+      Sentry.setUser(null);
     }
 
     await next();

--- a/app/server/watch/watch-hub.ts
+++ b/app/server/watch/watch-hub.ts
@@ -105,6 +105,19 @@ class WatchHub {
     if (client) client.token = token;
   }
 
+  /**
+   * Update the auth token for all SSE clients owned by a specific user.
+   * Called after a successful token refresh so that upstream reconnections
+   * use the newly rotated access token instead of the stale one.
+   */
+  updateTokensByUserId(userId: string, accessToken: string): void {
+    for (const client of this.clients.values()) {
+      if (client.userId === userId) {
+        client.token = accessToken;
+      }
+    }
+  }
+
   /** Check whether a client belongs to the given user (for ownership validation). */
   isClientOwnedBy(clientId: string, userId: string): boolean {
     const client = this.clients.get(clientId);

--- a/app/utils/auth/auth.config.ts
+++ b/app/utils/auth/auth.config.ts
@@ -8,9 +8,9 @@ import { env } from '@/utils/env';
 export const AUTH_CONFIG = {
   /**
    * Refresh token when access token expires within this window
-   * Default: 1 hour before expiry
+   * Default: 10 minutes before expiry
    */
-  REFRESH_WINDOW_MS: 60 * 60 * 1000,
+  REFRESH_WINDOW_MS: 10 * 60 * 1000,
 
   /**
    * Session cookie lifetime (slightly longer than access token)

--- a/app/utils/auth/auth.service.ts
+++ b/app/utils/auth/auth.service.ts
@@ -292,6 +292,13 @@ export class AuthService {
         } catch (error) {
           debugLog('Failed to restore session', { error: String(error) });
 
+          console.warn(
+            '[AuthService] Session restore failed — refresh token rejected. Clearing refresh cookie.',
+            {
+              error: String(error),
+            }
+          );
+
           // Clean up invalid refresh token
           const destroyHeader = await refreshTokenStorage.destroySession(refreshRaw);
           const headers = new Headers();
@@ -335,10 +342,11 @@ export class AuthService {
             minutesUntilExpiry,
           });
 
-          // If token has enough time left (> 5 minutes), continue with current session
-          // This handles both network errors and other transient failures gracefully
-          const MIN_BUFFER_MS = 5 * 60 * 1000; // 5 minutes minimum buffer
-          if (!isExpired && timeUntilExpiry > MIN_BUFFER_MS) {
+          // If token is not yet expired, return the current session.
+          // Covers multi-pod refresh races (Zitadel rotation): another pod may have already
+          // rotated the refresh token (REFRESH_TOKEN_REVOKED / invalid_grant), but our
+          // access token is still valid — no reason to log the user out.
+          if (!isExpired) {
             return { session, headers: defaultHeaders, refreshed: false };
           }
 
@@ -346,6 +354,14 @@ export class AuthService {
           if (refreshError instanceof RefreshError && refreshError.type === 'NETWORK_ERROR') {
             debugLog('Network error during refresh of expired token');
           }
+
+          console.warn(
+            '[AuthService] Token refresh failed and access token is expired. User will be logged out.',
+            {
+              type: refreshError instanceof RefreshError ? refreshError.type : 'UNKNOWN',
+              error: String(error),
+            }
+          );
 
           // Clean up invalid refresh token and return null session
           const destroyHeader = await refreshTokenStorage.destroySession(refreshRaw);
@@ -360,6 +376,9 @@ export class AuthService {
       // Token expired and no refresh token
       if (isExpired) {
         debugLog('Token expired and no refresh token available');
+        console.warn('[AuthService] Access token expired with no refresh token available.', {
+          expiredAt: session.expiredAt,
+        });
         return { session: null, headers: defaultHeaders, refreshed: false };
       }
     }

--- a/app/utils/auth/index.ts
+++ b/app/utils/auth/index.ts
@@ -13,3 +13,5 @@ export {
   clearUserPermissionCache,
 } from './auth.service';
 export { destroyLocalSessions } from './auth.utils';
+export { sessionManager } from './session-manager';
+export type { TokenRefreshEvent } from './session-manager';

--- a/app/utils/auth/session-manager.ts
+++ b/app/utils/auth/session-manager.ts
@@ -1,0 +1,59 @@
+import { AuthService } from './auth.service';
+import type { SessionValidationResult } from './auth.types';
+
+export interface TokenRefreshEvent {
+  userId: string;
+  accessToken: string;
+}
+
+type RefreshHook = (event: TokenRefreshEvent) => void;
+
+/**
+ * SessionManager wraps AuthService.getValidSession() and notifies
+ * a single registered hook whenever a token is successfully refreshed.
+ *
+ * Only one hook may be registered (enforced at runtime) to prevent
+ * uncontrolled access to raw access tokens by arbitrary subscribers.
+ *
+ * Usage:
+ * ```ts
+ * sessionManager.registerRefreshHook(({ userId, accessToken }) => {
+ *   watchHub.updateTokensByUserId(userId, accessToken);
+ * });
+ * ```
+ */
+class SessionManager {
+  private refreshHook: RefreshHook | undefined;
+
+  /**
+   * Register a callback to be called after every successful token refresh.
+   * Throws if a hook is already registered to prevent multiple token consumers.
+   */
+  registerRefreshHook(callback: RefreshHook): void {
+    if (this.refreshHook !== undefined) {
+      throw new Error(
+        '[SessionManager] Refresh hook already registered. Only one hook is allowed.'
+      );
+    }
+    this.refreshHook = callback;
+  }
+
+  async getValidSession(cookieHeader: string | null): Promise<SessionValidationResult> {
+    const result = await AuthService.getValidSession(cookieHeader);
+
+    if (result.refreshed && result.session) {
+      this.refreshHook?.({
+        userId: result.session.sub,
+        accessToken: result.session.accessToken,
+      });
+    }
+
+    return result;
+  }
+}
+
+/**
+ * Singleton SessionManager instance.
+ * Initialized once at server start; wired to WatchHub in `app/server/entry.ts`.
+ */
+export const sessionManager = new SessionManager();

--- a/app/utils/errors/auth.ts
+++ b/app/utils/errors/auth.ts
@@ -69,11 +69,21 @@ export function categorizeRefreshError(error: unknown): RefreshError {
   const errorMessage = error instanceof Error ? error.message : String(error);
   const errorString = errorMessage.toLowerCase();
 
+  // Also check OAuth2 structured fields (.code / .description) that Zitadel returns
+  const oauthCode =
+    error instanceof Error && 'code' in error ? String((error as any).code).toLowerCase() : '';
+  const oauthDesc =
+    error instanceof Error && 'description' in error
+      ? String((error as any).description).toLowerCase()
+      : '';
+
   // Token revoked or invalid
   if (
     errorString.includes('invalid_grant') ||
     errorString.includes('token has been revoked') ||
-    errorString.includes('refresh token is invalid')
+    errorString.includes('refresh token is invalid') ||
+    oauthDesc.includes('refreshtokeninvalid') || // Zitadel: Errors.OIDCSession.RefreshTokenInvalid
+    oauthCode === 'invalid_grant'
   ) {
     return new RefreshError(
       RefreshErrorType.REFRESH_TOKEN_REVOKED,

--- a/cypress/component/categorize-refresh-error.cy.ts
+++ b/cypress/component/categorize-refresh-error.cy.ts
@@ -1,0 +1,108 @@
+import { categorizeRefreshError, RefreshErrorType } from '@/utils/errors/auth';
+
+describe('categorizeRefreshError', () => {
+  describe('REFRESH_TOKEN_REVOKED', () => {
+    it('recognizes invalid_grant in the error message', () => {
+      const error = new Error('invalid_grant');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.REFRESH_TOKEN_REVOKED);
+    });
+
+    it('recognizes token has been revoked', () => {
+      const error = new Error('token has been revoked by the user');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.REFRESH_TOKEN_REVOKED);
+    });
+
+    it('recognizes refresh token is invalid', () => {
+      const error = new Error('refresh token is invalid');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.REFRESH_TOKEN_REVOKED);
+    });
+
+    it('recognizes Zitadel invalid_grant via oauth .code field', () => {
+      // Zitadel sometimes returns the OAuth error code in a structured field
+      // rather than the message string
+      const error = Object.assign(new Error('invalid_request'), { code: 'invalid_grant' });
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.REFRESH_TOKEN_REVOKED);
+    });
+
+    it('recognizes Zitadel Errors.OIDCSession.RefreshTokenInvalid via oauth .description field', () => {
+      // Zitadel sends: error=invalid_request, description=Errors.OIDCSession.RefreshTokenInvalid
+      // This was the multi-pod rotation race error that was previously logged as UNKNOWN_ERROR
+      const error = Object.assign(new Error('invalid_request'), {
+        code: 'invalid_request',
+        description: 'Errors.OIDCSession.RefreshTokenInvalid',
+      });
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.REFRESH_TOKEN_REVOKED);
+    });
+
+    it('is case-insensitive for oauth .description matching', () => {
+      const error = Object.assign(new Error('invalid_request'), {
+        description: 'errors.oidcsession.refreshtokeninvalid',
+      });
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.REFRESH_TOKEN_REVOKED);
+    });
+
+    it('preserves the original error on the RefreshError', () => {
+      const original = new Error('invalid_grant');
+      const result = categorizeRefreshError(original);
+      expect(result.originalError).to.equal(original);
+    });
+  });
+
+  describe('REFRESH_TOKEN_EXPIRED', () => {
+    it('recognizes expired in the error message', () => {
+      const error = new Error('token is expired');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.REFRESH_TOKEN_EXPIRED);
+    });
+
+    it('recognizes token is no longer valid', () => {
+      const error = new Error('token is no longer valid');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.REFRESH_TOKEN_EXPIRED);
+    });
+  });
+
+  describe('NETWORK_ERROR', () => {
+    it('recognizes network error', () => {
+      const error = new Error('network error');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.NETWORK_ERROR);
+    });
+
+    it('recognizes fetch failure', () => {
+      const error = new Error('fetch failed');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.NETWORK_ERROR);
+    });
+
+    it('recognizes ECONNREFUSED', () => {
+      const error = new Error('ECONNREFUSED 127.0.0.1:3000');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.NETWORK_ERROR);
+    });
+
+    it('recognizes timeout', () => {
+      const error = new Error('request timeout');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.NETWORK_ERROR);
+    });
+  });
+
+  describe('UNKNOWN_ERROR', () => {
+    it('falls back to UNKNOWN_ERROR for unrecognized messages', () => {
+      const error = new Error('something completely unexpected');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.UNKNOWN_ERROR);
+    });
+
+    it('handles non-Error input (string)', () => {
+      const result = categorizeRefreshError('some string error');
+      expect(result.type).to.equal(RefreshErrorType.UNKNOWN_ERROR);
+    });
+
+    it('handles non-Error input (object)', () => {
+      const result = categorizeRefreshError({ status: 500 });
+      expect(result.type).to.equal(RefreshErrorType.UNKNOWN_ERROR);
+    });
+  });
+
+  describe('REVOKED takes precedence over EXPIRED', () => {
+    it('matches REVOKED before EXPIRED when both keywords present', () => {
+      const error = new Error('invalid_grant: token is expired');
+      expect(categorizeRefreshError(error).type).to.equal(RefreshErrorType.REFRESH_TOKEN_REVOKED);
+    });
+  });
+});

--- a/cypress/component/session-manager.cy.ts
+++ b/cypress/component/session-manager.cy.ts
@@ -1,0 +1,253 @@
+/**
+ * Behavior contract tests for SessionManager and WatchHub.updateTokensByUserId.
+ *
+ * NOTE: The real modules (session-manager.ts, watch-hub.ts) transitively import
+ * server-only code (env.server, zitadel.server OAuth discovery) which cannot
+ * run in a browser/Cypress context. These tests use inline test doubles that
+ * mirror the exact same logic to verify the behavior contract and catch regressions.
+ *
+ * If the logic in session-manager.ts or watch-hub.ts changes, update these
+ * doubles accordingly so the tests remain a faithful specification.
+ */
+
+// ─── Test doubles ─────────────────────────────────────────────────────────────
+
+interface TokenRefreshEvent {
+  userId: string;
+  accessToken: string;
+}
+
+type RefreshHook = (event: TokenRefreshEvent) => void;
+
+interface SessionResult {
+  refreshed: boolean;
+  session: { sub: string; accessToken: string } | null;
+}
+
+/** Mirrors app/utils/auth/session-manager.ts */
+class TestSessionManager {
+  private refreshHook: RefreshHook | undefined;
+
+  registerRefreshHook(callback: RefreshHook): void {
+    if (this.refreshHook !== undefined) {
+      throw new Error(
+        '[SessionManager] Refresh hook already registered. Only one hook is allowed.'
+      );
+    }
+    this.refreshHook = callback;
+  }
+
+  // Simulates the notification logic inside getValidSession()
+  simulateSessionResult(result: SessionResult): void {
+    if (result.refreshed && result.session) {
+      this.refreshHook?.({
+        userId: result.session.sub,
+        accessToken: result.session.accessToken,
+      });
+    }
+  }
+}
+
+interface WatchClient {
+  userId: string;
+  token: string;
+}
+
+/** Mirrors the client token update logic in app/server/watch/watch-hub.ts */
+class TestWatchClientPool {
+  private clients = new Map<string, WatchClient>();
+
+  add(id: string, userId: string, token: string): void {
+    this.clients.set(id, { userId, token });
+  }
+
+  updateTokensByUserId(userId: string, accessToken: string): void {
+    for (const client of this.clients.values()) {
+      if (client.userId === userId) {
+        client.token = accessToken;
+      }
+    }
+  }
+
+  getToken(id: string): string | undefined {
+    return this.clients.get(id)?.token;
+  }
+}
+
+// ─── SessionManager contract ───────────────────────────────────────────────────
+
+describe('SessionManager — registerRefreshHook contract', () => {
+  it('calls the registered hook when session is refreshed', () => {
+    const manager = new TestSessionManager();
+    const received: TokenRefreshEvent[] = [];
+    manager.registerRefreshHook((event) => received.push(event));
+
+    manager.simulateSessionResult({
+      refreshed: true,
+      session: { sub: 'user-123', accessToken: 'new-token' },
+    });
+
+    expect(received).to.have.length(1);
+    expect(received[0]).to.deep.equal({ userId: 'user-123', accessToken: 'new-token' });
+  });
+
+  it('does NOT call the hook when refreshed is false', () => {
+    const manager = new TestSessionManager();
+    const received: TokenRefreshEvent[] = [];
+    manager.registerRefreshHook((event) => received.push(event));
+
+    manager.simulateSessionResult({
+      refreshed: false,
+      session: { sub: 'user-123', accessToken: 'same-token' },
+    });
+
+    expect(received).to.have.length(0);
+  });
+
+  it('does NOT call the hook when session is null (refresh failed)', () => {
+    const manager = new TestSessionManager();
+    const received: TokenRefreshEvent[] = [];
+    manager.registerRefreshHook((event) => received.push(event));
+
+    manager.simulateSessionResult({ refreshed: true, session: null });
+
+    expect(received).to.have.length(0);
+  });
+
+  it('works with no hook registered (safe no-op)', () => {
+    const manager = new TestSessionManager();
+
+    // Should not throw when no hook is registered
+    expect(() => {
+      manager.simulateSessionResult({
+        refreshed: true,
+        session: { sub: 'user-123', accessToken: 'new-token' },
+      });
+    }).not.to.throw();
+  });
+
+  it('throws when a second hook is registered', () => {
+    const manager = new TestSessionManager();
+    manager.registerRefreshHook(() => {});
+
+    expect(() => {
+      manager.registerRefreshHook(() => {});
+    }).to.throw('[SessionManager] Refresh hook already registered. Only one hook is allowed.');
+  });
+
+  it('calls the hook multiple times across successive refreshes', () => {
+    const manager = new TestSessionManager();
+    const tokens: string[] = [];
+    manager.registerRefreshHook(({ accessToken }) => tokens.push(accessToken));
+
+    manager.simulateSessionResult({
+      refreshed: true,
+      session: { sub: 'user-1', accessToken: 'token-v1' },
+    });
+    manager.simulateSessionResult({
+      refreshed: true,
+      session: { sub: 'user-1', accessToken: 'token-v2' },
+    });
+
+    expect(tokens).to.deep.equal(['token-v1', 'token-v2']);
+  });
+});
+
+// ─── WatchHub.updateTokensByUserId contract ────────────────────────────────────
+
+describe('WatchHub.updateTokensByUserId — token propagation contract', () => {
+  it('updates tokens for all clients belonging to the user', () => {
+    const pool = new TestWatchClientPool();
+    pool.add('client-a', 'user-1', 'old-token');
+    pool.add('client-b', 'user-1', 'old-token');
+    pool.add('client-c', 'user-2', 'other-token');
+
+    pool.updateTokensByUserId('user-1', 'new-token');
+
+    expect(pool.getToken('client-a')).to.equal('new-token');
+    expect(pool.getToken('client-b')).to.equal('new-token');
+    // Different user — untouched
+    expect(pool.getToken('client-c')).to.equal('other-token');
+  });
+
+  it('does not affect clients belonging to a different user', () => {
+    const pool = new TestWatchClientPool();
+    pool.add('client-x', 'user-2', 'user2-token');
+
+    pool.updateTokensByUserId('user-1', 'refreshed-token');
+
+    expect(pool.getToken('client-x')).to.equal('user2-token');
+  });
+
+  it('is a no-op when no clients match the userId', () => {
+    const pool = new TestWatchClientPool();
+    pool.add('client-a', 'user-99', 'some-token');
+
+    expect(() => {
+      pool.updateTokensByUserId('user-1', 'new-token');
+    }).not.to.throw();
+
+    expect(pool.getToken('client-a')).to.equal('some-token');
+  });
+
+  it('is a no-op when the pool is empty', () => {
+    const pool = new TestWatchClientPool();
+
+    expect(() => {
+      pool.updateTokensByUserId('user-1', 'new-token');
+    }).not.to.throw();
+  });
+
+  it('updates a single client when only one matches', () => {
+    const pool = new TestWatchClientPool();
+    pool.add('client-a', 'user-1', 'stale');
+    pool.add('client-b', 'user-2', 'untouched');
+
+    pool.updateTokensByUserId('user-1', 'fresh');
+
+    expect(pool.getToken('client-a')).to.equal('fresh');
+    expect(pool.getToken('client-b')).to.equal('untouched');
+  });
+});
+
+// ─── Integration: SessionManager → WatchHub wiring ────────────────────────────
+
+describe('SessionManager + WatchHub integration — token sync', () => {
+  it('propagates a refreshed token to all SSE clients for that user', () => {
+    const pool = new TestWatchClientPool();
+    pool.add('tab-1', 'user-abc', 'stale-token');
+    pool.add('tab-2', 'user-abc', 'stale-token');
+    pool.add('tab-3', 'user-xyz', 'other-token');
+
+    const manager = new TestSessionManager();
+    manager.registerRefreshHook(({ userId, accessToken }) => {
+      pool.updateTokensByUserId(userId, accessToken);
+    });
+
+    // Simulate a successful token refresh for user-abc
+    manager.simulateSessionResult({
+      refreshed: true,
+      session: { sub: 'user-abc', accessToken: 'fresh-token' },
+    });
+
+    expect(pool.getToken('tab-1')).to.equal('fresh-token');
+    expect(pool.getToken('tab-2')).to.equal('fresh-token');
+    // Different user — should not be touched
+    expect(pool.getToken('tab-3')).to.equal('other-token');
+  });
+
+  it('does not update SSE clients when token refresh failed', () => {
+    const pool = new TestWatchClientPool();
+    pool.add('tab-1', 'user-abc', 'valid-token');
+
+    const manager = new TestSessionManager();
+    manager.registerRefreshHook(({ userId, accessToken }) => {
+      pool.updateTokensByUserId(userId, accessToken);
+    });
+
+    // Refresh failed — session is null, hook must NOT fire
+    manager.simulateSessionResult({ refreshed: true, session: null });
+
+    expect(pool.getToken('tab-1')).to.equal('valid-token');
+  });
+});

--- a/observability/providers/sentry.ts
+++ b/observability/providers/sentry.ts
@@ -158,7 +158,7 @@ export class SentryProvider extends BaseProvider {
   }
 
   private createBeforeSendHandler() {
-    return (event: any, hint: any) => {
+    return (event: any, _hint: any) => {
       if (this.circuitBreakerOpen) {
         console.warn('⚠️ Sentry circuit breaker open, skipping event');
         return null;


### PR DESCRIPTION
## Problem

We found two root causes for `system:anonymous` API errors appearing in Sentry — errors that indicated the portal server was making unauthenticated API calls:

### 1. Sentry scope leak 
`Sentry.setUser()` was never cleared for unauthenticated requests. If a previous request on the same server instance was authenticated, the user context leaked into the next unauthenticated request, incorrectly attributing API errors.

### 2. Multi-pod refresh token rotation race 
In a Kubernetes multi-pod deployment, when multiple pods attempt a token refresh simultaneously:
- Zitadel rotates the refresh token on first use — the winning pod gets a new token pair, all other pods receive `Errors.OIDCSession.RefreshTokenInvalid`
- `REFRESH_WINDOW_MS` was set to **1 hour**, meaning nearly every request across all pods triggered a refresh attempt for the entire last hour of token life — dramatically increasing the frequency of race collisions
- When refresh failed, the code unnecessarily **destroyed the refresh cookie** and returned `null` — even though the access token was still valid. The next request had no session, made an unauthenticated API call, and generated a `system:anonymous` error in Sentry
- `categorizeRefreshError()` did not recognize Zitadel's `Errors.OIDCSession.RefreshTokenInvalid` (sent as `invalid_request`), so it logged as `UNKNOWN_ERROR` instead of being handled gracefully
- WatchHub SSE connections stored tokens at subscription time and never received updated tokens after a successful rotation on any pod

## Fixes

| Fix | Change |
|-----|--------|
| Narrow refresh window | `REFRESH_WINDOW_MS`: 1 hour → **10 minutes** |
| Graceful rotation race fallback | Return current (unexpired) session when refresh fails instead of destroying it |
| Zitadel error recognition | Add `Errors.OIDCSession.RefreshTokenInvalid` to `categorizeRefreshError()` |
| SessionManager + WatchHub sync | New `SessionManager` EventEmitter emits `tokenRefresh` on success; WatchHub propagates new tokens to all SSE clients for that user |
| Production visibility | `console.warn` at all null-session return paths in `AuthService` |

Ref #998