### PR TITLE
AI edge task errors

### DIFF
--- a/app/modules/datum-ui/components/task-queue/core/task-panel-actions.tsx
+++ b/app/modules/datum-ui/components/task-queue/core/task-panel-actions.tsx
@@ -1,3 +1,4 @@
+import { useTaskQueue } from '../hooks/use-task-queue';
 import type { Task } from '../types';
 import { extractItemId } from '../utils';
 import { Button, type ButtonProps } from '@datum-ui/components/button/button';
@@ -7,7 +8,36 @@ interface TaskPanelActionsProps {
 }
 
 export function TaskPanelActions({ task }: TaskPanelActionsProps) {
+  const { showSummary } = useTaskQueue();
   const actions = resolveActions(task);
+
+  const hasBatch = task.total != null;
+  const hasFailedMessages = task.failedItems.length > 0 && task.failedItems.some((f) => f.message);
+
+  if (!hasBatch && task.status === 'failed' && hasFailedMessages && actions.length === 0) {
+    return (
+      <div className="flex items-center justify-end gap-1.5">
+        <Button
+          htmlType="button"
+          type="quaternary"
+          theme="outline"
+          size="xs"
+          onClick={() =>
+            showSummary(
+              task.title,
+              task.failedItems.map((item, i) => ({
+                id: item.id ?? `error-${i}`,
+                label: item.id ?? 'Error',
+                status: 'failed',
+                message: item.message,
+              }))
+            )
+          }>
+          Details
+        </Button>
+      </div>
+    );
+  }
 
   if (actions.length === 0) return null;
 

--- a/app/modules/datum-ui/components/task-queue/core/task-panel-item.tsx
+++ b/app/modules/datum-ui/components/task-queue/core/task-panel-item.tsx
@@ -48,7 +48,7 @@ export function TaskPanelItem({ task, contextLabel, onCancel }: TaskPanelItemPro
             <TaskPanelCounter total={task.total} completed={task.completed} failed={task.failed} />
           )}
 
-          {hasBatch && isTerminal && (
+          {isTerminal && (
             <TaskPanelCounter
               total={task.total}
               completed={task.completed}

--- a/app/modules/datum-ui/components/task-queue/core/task-queue-dropdown.tsx
+++ b/app/modules/datum-ui/components/task-queue/core/task-queue-dropdown.tsx
@@ -45,8 +45,6 @@ export function TaskQueueDropdown() {
   // If there are any tasks that are not running or pending, show the dismiss button.
   const hasDismissable = tasks.some((t) => t.status !== 'running' && t.status !== 'pending');
 
-  // if (tasks.length === 0) return null;
-
   return (
     <>
       <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -54,7 +52,10 @@ export function TaskQueueDropdown() {
           <TaskQueueTrigger tasks={tasks} />
         </DropdownMenuTrigger>
 
-        <DropdownMenuContent align="end" className="w-96 rounded-lg p-0">
+        <DropdownMenuContent
+          align="end"
+          className="w-96 rounded-lg p-0"
+          onCloseAutoFocus={(e) => e.preventDefault()}>
           <TaskPanelHeader />
           <div className="max-h-[350px] overflow-y-auto">
             {tasks.length === 0 && !activeSummary ? (


### PR DESCRIPTION
### Problem

When a single-process task (e.g. creating an AI Edge) failed, the task panel showed the red failure icon but **no error message or summary** — unlike batch tasks which display a "Summary" button with a detailed breakdown. There was no way to see _why_ the task failed.

Additionally, dismissing the task dropdown caused the trigger button to receive focus, which unintentionally highlighted it and opened its tooltip.

### Changes

#### 1. Show status label and error message for single-process tasks (`task-panel-item.tsx`)

- The `TaskPanelCounter` (which renders "Failed" / "Completed" / "Cancelled" text) was previously gated behind `hasBatch`, meaning it never rendered for single-process tasks. Removed that gate so all terminal tasks show their status label.

#### 2. Auto-show "Details" button for failed single-process tasks (`task-panel-actions.tsx`)

- For any non-batch task that fails with error messages in `failedItems`, a "Details" button is now automatically rendered — no need for individual tasks to define `completionActions`.
- Clicking "Details" opens the existing `TaskSummaryDialog` with the error details, matching the UX of batch task summaries.

#### 3. Prevent focus return on dropdown close (`task-queue-dropdown.tsx`)

- Added `onCloseAutoFocus={(e) => e.preventDefault()}` to `DropdownMenuContent` to stop Radix from returning focus to the trigger button when the dropdown closes. This fixes the unwanted button highlight and tooltip flash.

<img width="1512" height="829" alt="Screenshot 2026-02-27 at 10 58 17" src="https://github.com/user-attachments/assets/d77d5b9a-ac5a-499c-8719-bce19e337fef" />
<img width="1512" height="829" alt="Screenshot 2026-02-27 at 10 58 28" src="https://github.com/user-attachments/assets/0dbb0e87-ebcd-4179-ac12-b2bd626fa28a" />

