### PR TITLE
Remove some SSR from projects

### DIFF
--- a/app/components/header/header.tsx
+++ b/app/components/header/header.tsx
@@ -16,9 +16,11 @@ import { Link } from 'react-router';
 export const Header = ({
   currentProject,
   currentOrg,
+  switcherLoading = false,
 }: {
   currentProject?: Project;
   currentOrg?: Organization;
+  switcherLoading?: boolean;
 }) => {
   return (
     <header className="bg-background border-sidebar-border sticky top-0 z-50 flex h-12 w-full shrink-0 touch-none items-center justify-between gap-4 border-b px-4">
@@ -28,7 +30,11 @@ export const Header = ({
           <LogoIcon width={21} />
         </Link>
         <div className="hidden md:block">
-          <OrgProjectSwitcher currentOrg={currentOrg} currentProject={currentProject} />
+          <OrgProjectSwitcher
+            currentOrg={currentOrg}
+            currentProject={currentProject}
+            switcherLoading={switcherLoading}
+          />
         </div>
       </div>
       {/* Right Section */}

--- a/app/components/header/org-project-switcher.tsx
+++ b/app/components/header/org-project-switcher.tsx
@@ -2,44 +2,83 @@ import { OrganizationSwitcher } from './org-switcher';
 import { ProjectSwitcher } from './project-switcher';
 import type { Organization } from '@/resources/organizations';
 import type { Project } from '@/resources/projects';
+import { Skeleton } from '@datum-ui/components';
 
 export interface OrgProjectSwitcherProps {
   currentOrg?: Organization;
   currentProject?: Project;
   /** Optional class name for the project switcher trigger */
   projectSwitcherTriggerClassName?: string;
+  /** Show loading skeletons to prevent layout shift */
+  switcherLoading?: boolean;
 }
+
+const OrgSkeleton = () => (
+  <div className="flex items-center gap-2.5" aria-hidden>
+    <Skeleton className="h-4 w-3.5 shrink-0 rounded" />
+    <Skeleton className="h-4 w-40 sm:w-52" />
+    <Skeleton className="h-4 w-4 shrink-0 rounded" />
+  </div>
+);
+
+const ProjectSkeleton = () => (
+  <div className="flex items-center gap-2.5 pl-2.5" aria-hidden>
+    <Skeleton className="h-4 w-4 shrink-0 rounded" />
+    <Skeleton className="h-4 w-40" />
+    <Skeleton className="h-4 w-4 shrink-0 rounded" />
+  </div>
+);
+
+const SeparatorIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 14 14"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className="shrink-0"
+    aria-hidden>
+    <path
+      opacity="0.1"
+      className="stroke-foreground"
+      d="M9.96004 1.31641L4.04004 12.6837"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
 
 export const OrgProjectSwitcher = ({
   currentOrg,
   currentProject,
   projectSwitcherTriggerClassName = 'w-4 h-4',
+  switcherLoading = false,
 }: OrgProjectSwitcherProps) => {
+  const orgReady = currentOrg && (currentOrg.displayName || currentOrg.name);
+  const showOrg = orgReady || switcherLoading;
+  const showProject = currentProject || switcherLoading;
+  const showProjectSkeleton = !orgReady || (!currentProject && switcherLoading);
+
+  if (!showOrg && !showProject) {
+    return null;
+  }
+
   return (
     <div className="flex shrink-0 items-center gap-2">
-      {currentOrg && <OrganizationSwitcher currentOrg={currentOrg} />}
-      {currentProject && (
+      {!orgReady ? <OrgSkeleton /> : <OrganizationSwitcher currentOrg={currentOrg!} />}
+      {showProject && (
         <>
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 14 14"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            className="shrink-0"
-            aria-hidden>
-            <path
-              opacity="0.1"
-              className="stroke-foreground"
-              d="M9.96004 1.31641L4.04004 12.6837"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          <ProjectSwitcher
-            currentProject={currentProject}
-            triggerClassName={projectSwitcherTriggerClassName}
-          />
+          <SeparatorIcon />
+          {showProjectSkeleton ? (
+            <ProjectSkeleton />
+          ) : (
+            currentProject && (
+              <ProjectSwitcher
+                currentProject={currentProject}
+                triggerClassName={projectSwitcherTriggerClassName}
+              />
+            )
+          )}
         </>
       )}
     </div>

--- a/app/features/edge/proxy/proxy-basic-auth-dialog.tsx
+++ b/app/features/edge/proxy/proxy-basic-auth-dialog.tsx
@@ -13,6 +13,7 @@ import { InputWithAddons } from '@datum-ui/components/input-with-addons';
 import { Switch } from '@shadcn/ui/switch';
 import { Eye, EyeOff, PlusIcon, TrashIcon, TriangleAlert } from 'lucide-react';
 import { forwardRef, useCallback, useMemo, useImperativeHandle, useState } from 'react';
+
 const FRIENDLY_ERROR_MAP: Record<string, string> = {
   'Invalid input: expected string, received undefined':
     'Please enter a username and password for each user.',

--- a/app/features/project/dashboard.tsx
+++ b/app/features/project/dashboard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, CardContent, CardHeader } from '@datum-ui/components';
+import { Button, Card, CardContent, CardHeader, Skeleton, SpinnerIcon } from '@datum-ui/components';
 import { Icon } from '@datum-ui/components/icons/icon-wrapper';
 import { cn } from '@shadcn/lib/utils';
 import { ArrowRightIcon, CheckIcon } from 'lucide-react';
@@ -10,6 +10,7 @@ const ActionCard = ({
   onClick,
   buttonLabel,
   isCompleted,
+  isLoading,
   className,
 }: {
   image: ReactNode;
@@ -17,21 +18,26 @@ const ActionCard = ({
   onClick?: () => void;
   buttonLabel?: string;
   isCompleted?: boolean;
+  isLoading?: boolean;
   className?: string;
 }) => {
   return (
     <Card
       className={cn(
         'h-full w-full gap-0 rounded-lg bg-white p-0 shadow dark:bg-[#18273A]',
-        isCompleted && 'dark:border-card-tertiary border-primary/40',
+        isCompleted && !isLoading && 'dark:border-card-tertiary border-primary/40',
+        isLoading && 'opacity-95',
         className
       )}>
       <CardHeader
         className={cn(
           'bg-card-tertiary relative flex h-[170px] items-center justify-center gap-6 rounded-t-lg p-8',
-          isCompleted && 'dark:bg-card bg-background'
+          isCompleted && 'dark:bg-card bg-background',
+          isLoading && 'dark:bg-card bg-background'
         )}>
-        {typeof image === 'string' ? (
+        {isLoading ? (
+          <Skeleton className="h-[80px] w-[120px] rounded-lg" />
+        ) : typeof image === 'string' ? (
           <img
             src={image}
             alt={title}
@@ -41,7 +47,7 @@ const ActionCard = ({
           image
         )}
 
-        {isCompleted && (
+        {isCompleted && !isLoading && (
           <Icon
             icon={CheckIcon}
             className="text-primary absolute top-2.5 right-2.5"
@@ -51,11 +57,29 @@ const ActionCard = ({
         )}
       </CardHeader>
       <CardContent className="flex flex-1 flex-col items-center justify-between gap-4 p-8">
-        <span className="dark:text-card-foreground text-foreground text-center text-base font-semibold">
-          {title}
-        </span>
+        {isLoading ? (
+          <Skeleton className="h-6 w-32 rounded" />
+        ) : (
+          <span className="dark:text-card-foreground text-foreground text-center text-base font-semibold">
+            {title}
+          </span>
+        )}
 
-        {isCompleted ? (
+        {isLoading ? (
+          <Button
+            type={isCompleted ? 'quaternary' : 'primary'}
+            theme="outline"
+            size="xs"
+            disabled
+            className={cn(
+              isCompleted &&
+                'dark:border-card-foreground dark:hover:bg-card-foreground dark:hover:text-card dark:text-card-foreground text-foreground border-foreground hover:border-foreground hover:bg-foreground hover:text-background',
+              !isCompleted && 'size-10 rounded-full'
+            )}
+            icon={<SpinnerIcon size="sm" aria-hidden />}>
+            {isCompleted ? buttonLabel : null}
+          </Button>
+        ) : isCompleted ? (
           <Button
             type="quaternary"
             theme="outline"

--- a/app/features/project/settings/danger-card.tsx
+++ b/app/features/project/settings/danger-card.tsx
@@ -1,24 +1,32 @@
 import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
 import { DangerCard } from '@/components/danger-card/danger-card';
 import type { Project } from '@/resources/projects';
-import { useDeleteProject } from '@/resources/projects';
+import { projectKeys, useDeleteProject } from '@/resources/projects';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { toast } from '@datum-ui/components';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 
 export const ProjectDangerCard = ({ project }: { project: Project }) => {
   const navigate = useNavigate();
   const { confirm } = useConfirmationDialog();
+  const queryClient = useQueryClient();
 
   const deleteMutation = useDeleteProject({
-    onSuccess: () => {
+    onSuccess: async () => {
+      if (!project?.organizationId) {
+        throw new Error('Organization ID is required');
+      }
       toast.success('Project', {
         description: 'The project has been deleted successfully',
       });
+      const listKey = projectKeys.list(project.organizationId);
+      queryClient.invalidateQueries({ queryKey: listKey });
+      await queryClient.refetchQueries({ queryKey: listKey });
       navigate(
         getPathWithParams(paths.org.detail.projects.root, {
-          orgId: project?.organizationId ?? '',
+          orgId: project.organizationId,
         })
       );
     },
@@ -45,10 +53,10 @@ export const ProjectDangerCard = ({ project }: { project: Project }) => {
       cancelText: 'Cancel',
       variant: 'destructive',
       showConfirmInput: true,
-      confirmValue: project?.name,
-      confirmInputLabel: `Type "${project?.name}" to confirm.`,
+      confirmValue: project.name,
+      confirmInputLabel: `Type "${project.name}" to confirm.`,
       onSubmit: async () => {
-        deleteMutation.mutate(project?.name ?? '');
+        deleteMutation.mutate(project.name);
       },
     });
   };

--- a/app/features/project/settings/general-card.tsx
+++ b/app/features/project/settings/general-card.tsx
@@ -1,9 +1,10 @@
 import { useApp } from '@/providers/app.provider';
 import type { Project } from '@/resources/projects';
-import { updateProjectSchema, useUpdateProject } from '@/resources/projects';
+import { projectKeys, updateProjectSchema, useUpdateProject } from '@/resources/projects';
 import { Button, CardHeader, CardTitle, toast } from '@datum-ui/components';
 import { Card, CardContent, CardFooter } from '@datum-ui/components';
 import { Form } from '@datum-ui/components/form';
+import { useQueryClient } from '@tanstack/react-query';
 
 /**
  * Project General Settings Card Component
@@ -11,13 +12,19 @@ import { Form } from '@datum-ui/components/form';
  */
 export const ProjectGeneralCard = ({ project }: { project: Project }) => {
   const { setProject } = useApp();
+  const queryClient = useQueryClient();
 
   const updateMutation = useUpdateProject(project?.name ?? '', {
-    onSuccess: (updatedProject) => {
+    onSuccess: async (updatedProject) => {
       setProject(updatedProject);
       toast.success('Project', {
         description: 'The Project has been updated successfully',
       });
+      if (updatedProject.organizationId) {
+        const listKey = projectKeys.list(updatedProject.organizationId);
+        queryClient.invalidateQueries({ queryKey: listKey });
+        await queryClient.refetchQueries({ queryKey: listKey });
+      }
     },
     onError: (error) => {
       toast.error('Project', {

--- a/app/layouts/dashboard.layout.tsx
+++ b/app/layouts/dashboard.layout.tsx
@@ -62,6 +62,8 @@ export function DashboardLayout({
   expandBehavior = 'push',
   showBackdrop = false,
   closeOnNavigation = false,
+  sidebarLoading = false,
+  switcherLoading = false,
 }: {
   children: React.ReactNode;
   navItems: NavItem[];
@@ -74,6 +76,10 @@ export function DashboardLayout({
   expandBehavior?: 'push' | 'overlay';
   showBackdrop?: boolean;
   closeOnNavigation?: boolean;
+  /** Show skeleton in sidebar while loading */
+  sidebarLoading?: boolean;
+  /** Show skeleton in org/project switchers while loading (prevents layout shift) */
+  switcherLoading?: boolean;
 }) {
   const { pathname } = useLocation();
   const [searchParams] = useSearchParams();
@@ -81,12 +87,14 @@ export function DashboardLayout({
   return (
     <div className="flex h-svh w-full flex-col overflow-hidden">
       {/* Header at the top - outside sidebar context */}
-      <Header currentProject={currentProject} currentOrg={currentOrg} />
+      <Header
+        currentProject={currentProject}
+        currentOrg={currentOrg}
+        switcherLoading={switcherLoading}
+      />
 
       {/* Mobile menu */}
-      {navItems.length > 0 && (
-        <MobileMenu navItems={navItems} currentOrg={currentOrg} currentProject={currentProject} />
-      )}
+      <MobileMenu navItems={navItems} currentOrg={currentOrg} currentProject={currentProject} />
 
       {/* Sidebar + Content area below header - flex-1 min-h-0 so only this area scrolls on mobile */}
       <SidebarProvider
@@ -102,7 +110,7 @@ export function DashboardLayout({
             '--sidebar-width-mobile': '18.75rem', // Custom desktop width
           } as React.CSSProperties
         }>
-        {(navItems.length > 0 || sidebarHeader != null) && (
+        {(navItems.length > 0 || sidebarHeader != null || sidebarLoading) && (
           <AppSidebar
             title={sidebarHeader as any}
             navItems={navItems}
@@ -112,6 +120,7 @@ export function DashboardLayout({
             currentPath={pathname}
             linkComponent={Link}
             defaultOpen={searchParams.get('sidebar') !== 'false'}
+            loading={sidebarLoading}
           />
         )}
         <SidebarInset className="min-h-0">

--- a/app/modules/axios/request-context.ts
+++ b/app/modules/axios/request-context.ts
@@ -1,5 +1,5 @@
-import { AsyncLocalStorage } from 'async_hooks';
 import type { User } from '@/resources/users';
+import { AsyncLocalStorage } from 'async_hooks';
 
 /**
  * Request context for server-side axios/gqlts calls.

--- a/app/modules/datum-ui/components/sidebar/app-sidebar.tsx
+++ b/app/modules/datum-ui/components/sidebar/app-sidebar.tsx
@@ -3,11 +3,55 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
   SidebarHeader,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarSeparator,
   SidebarTrigger,
   useSidebar,
 } from '@datum-ui/components';
 import { useEffect } from 'react';
+
+/** Skeleton that mirrors the project nav layout: Home, separator, 6 items, separator, Project Settings */
+const ProjectNavSkeleton = () => (
+  <ul className="flex h-full w-full min-w-0 flex-col gap-0.5 py-2" data-sidebar="menu">
+    {/* Home - first item, mimics active state with subtle background */}
+    <SidebarMenu className="px-2">
+      <SidebarMenuItem>
+        <SidebarMenuSkeleton
+          showIcon
+          className="bg-sidebar-accent/60 h-8 rounded-xl **:data-[sidebar=menu-skeleton-text]:max-w-12"
+        />
+      </SidebarMenuItem>
+    </SidebarMenu>
+
+    <SidebarSeparator className="my-2" />
+
+    {/* AI Edge, Connectors, DNS, Domains, Metrics, Secrets */}
+    {[1, 2, 3, 4, 5, 6].map((i) => (
+      <SidebarMenu key={i} className="px-2">
+        <SidebarMenuItem>
+          <SidebarMenuSkeleton showIcon className="h-8 rounded-xl" />
+        </SidebarMenuItem>
+      </SidebarMenu>
+    ))}
+
+    <SidebarSeparator className="my-2" />
+
+    {/* Project Settings */}
+    <SidebarMenu className="px-2">
+      <SidebarMenuItem>
+        <SidebarMenuSkeleton
+          showIcon
+          className="h-8 rounded-xl [&_[data-sidebar=menu-skeleton-text]]:max-w-28"
+        />
+      </SidebarMenuItem>
+    </SidebarMenu>
+  </ul>
+);
 
 export function AppSidebar({
   navItems,
@@ -16,6 +60,7 @@ export function AppSidebar({
   defaultOpen,
   currentPath,
   linkComponent,
+  loading = false,
   ...props
 }: React.ComponentProps<typeof Sidebar> & {
   navItems: NavItem[];
@@ -27,6 +72,8 @@ export function AppSidebar({
   currentPath: string;
   /** Link component — passed through to NavMain (defaults to native `<a>`) */
   linkComponent?: React.ElementType;
+  /** Show skeleton instead of nav items while loading */
+  loading?: boolean;
 }) {
   const { setOpen } = useSidebar();
 
@@ -41,14 +88,22 @@ export function AppSidebar({
       <SidebarContent className="gap-0">
         {title && <SidebarHeader className="px-4 pt-4 pb-0">{title}</SidebarHeader>}
 
-        {navItems.length > 0 && (
-          <NavMain
-            className="h-fit py-2"
-            items={navItems}
-            currentPath={currentPath}
-            linkComponent={linkComponent}
-            closeOnNavigation={closeOnNavigation}
-          />
+        {loading ? (
+          <SidebarGroup className="mb-2 p-0! px-0">
+            <SidebarGroupContent className="flex flex-col gap-0 py-0">
+              <ProjectNavSkeleton />
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ) : (
+          navItems.length > 0 && (
+            <NavMain
+              className="h-fit py-2"
+              items={navItems}
+              currentPath={currentPath}
+              linkComponent={linkComponent}
+              closeOnNavigation={closeOnNavigation}
+            />
+          )
         )}
 
         {props.collapsible !== 'none' && (

--- a/app/providers/project.provider.tsx
+++ b/app/providers/project.provider.tsx
@@ -1,0 +1,30 @@
+import type { Organization } from '@/resources/organizations';
+import type { Project } from '@/resources/projects';
+import { createContext, useContext, type ReactNode } from 'react';
+
+export interface ProjectContextValue {
+  project: Project | undefined;
+  org: Organization | undefined;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const ProjectContext = createContext<ProjectContextValue | null>(null);
+
+export function ProjectProvider({
+  children,
+  value,
+}: {
+  children: ReactNode;
+  value: ProjectContextValue;
+}) {
+  return <ProjectContext.Provider value={value}>{children}</ProjectContext.Provider>;
+}
+
+export function useProjectContext() {
+  const context = useContext(ProjectContext);
+  if (!context) {
+    throw new Error('useProjectContext must be used within a ProjectProvider');
+  }
+  return context;
+}

--- a/app/resources/http-proxies/http-proxy.queries.ts
+++ b/app/resources/http-proxies/http-proxy.queries.ts
@@ -76,7 +76,12 @@ export function useCreateHttpProxy(
 export function useUpdateHttpProxy(
   projectId: string,
   name: string,
-  options?: UseMutationOptions<HttpProxy, Error, UpdateHttpProxyInput, { previous: HttpProxy | undefined }>
+  options?: UseMutationOptions<
+    HttpProxy,
+    Error,
+    UpdateHttpProxyInput,
+    { previous: HttpProxy | undefined }
+  >
 ) {
   const queryClient = useQueryClient();
 

--- a/app/resources/http-proxies/http-proxy.service.ts
+++ b/app/resources/http-proxies/http-proxy.service.ts
@@ -214,7 +214,9 @@ export function createHttpProxyService() {
       const baseURL = getProjectScopedBase(projectId);
       const htpasswd = await generateHtpasswd(users);
       const htpasswdBase64 = btoa(
-        new TextEncoder().encode(htpasswd).reduce((acc, byte) => acc + String.fromCharCode(byte), '')
+        new TextEncoder()
+          .encode(htpasswd)
+          .reduce((acc, byte) => acc + String.fromCharCode(byte), '')
       );
 
       await client.post({
@@ -254,7 +256,9 @@ export function createHttpProxyService() {
       const baseURL = getProjectScopedBase(projectId);
       const htpasswd = await generateHtpasswd(users);
       const htpasswdBase64 = btoa(
-        new TextEncoder().encode(htpasswd).reduce((acc, byte) => acc + String.fromCharCode(byte), '')
+        new TextEncoder()
+          .encode(htpasswd)
+          .reduce((acc, byte) => acc + String.fromCharCode(byte), '')
       );
 
       try {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -81,6 +81,27 @@ export async function loader({ request }: LoaderFunctionArgs) {
   );
 }
 
+/** Skip root revalidation for client-side Link navigations.
+ * Root loader only provides toast, csrf, ENV — none change per-route.
+ * Form submissions still revalidate (e.g. logout) via defaultShouldRevalidate. */
+export function shouldRevalidate({
+  currentUrl: _currentUrl,
+  nextUrl: _nextUrl,
+  defaultShouldRevalidate,
+  formData,
+}: {
+  currentUrl: URL;
+  nextUrl: URL;
+  defaultShouldRevalidate: boolean;
+  formData?: FormData;
+}) {
+  // Form submissions (logout, etc.) — revalidate to get fresh root data
+  if (formData) return defaultShouldRevalidate;
+
+  // Link navigation — skip; root data doesn't change
+  return false;
+}
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider defaultTheme="light" attribute="class">
@@ -136,6 +157,9 @@ export default function AppWithProviders() {
   const fetchers = useFetchers();
   const matches = useMatches();
 
+  /** Fetcher keys that run in the background and should not trigger the progress bar */
+  const BACKGROUND_FETCHER_KEYS = ['session-cookies'];
+
   const urqlState = useMemo<SSRData>(() => {
     return matches.reduce<SSRData>((acc, match) => {
       const state = (match.data as Record<string, unknown> | null)?.urqlState;
@@ -157,11 +181,15 @@ export default function AppWithProviders() {
    *
    * We filter fetchers to only include those that are actively submitting or loading
    * with form data, excluding stale or cancelled fetchers that may not transition cleanly.
+   * Background fetchers (e.g. session cookie sync) are excluded from progress.
    */
   const state = useMemo<'idle' | 'loading'>(
     function getGlobalState() {
       const activeFetchers = fetchers.filter(
-        (fetcher) => fetcher.state !== 'idle' && fetcher.formData
+        (fetcher) =>
+          fetcher.state !== 'idle' &&
+          fetcher.formData &&
+          !BACKGROUND_FETCHER_KEYS.includes(fetcher.key)
       );
       const states = [navigation.state, ...activeFetchers.map((fetcher) => fetcher.state)];
       if (states.every((state) => state === 'idle')) return 'idle';

--- a/app/routes/org/detail/projects/index.tsx
+++ b/app/routes/org/detail/projects/index.tsx
@@ -6,10 +6,8 @@ import { DataTable } from '@/modules/datum-ui/components/data-table';
 import { AnalyticsAction, useAnalytics } from '@/modules/fathom';
 import { Organization } from '@/resources/organizations';
 import {
-  createProjectService,
   projectFormSchema,
   useCreateProject,
-  useHydrateProjects,
   useProjects,
   type Project,
   projectKeys,
@@ -39,37 +37,12 @@ import {
 } from 'react-router';
 import z from 'zod';
 
-export const loader = async ({ params, request }: LoaderFunctionArgs) => {
-  try {
-    const { orgId } = params;
-    // Services now use global axios client with AsyncLocalStorage
-    const projectService = createProjectService();
-
-    if (!orgId) {
-      const { isClosed: alertClosed, headers: alertHeaders } = await getAlertState(
-        request,
-        'projects_understanding'
-      );
-      return data({ projects: [], alertClosed }, { headers: alertHeaders });
-    }
-
-    // Fetch fresh data from API
-    const projectList = await projectService.list(orgId);
-
-    // Get alert state from server-side cookie
-    const { isClosed: alertClosed, headers: alertHeaders } = await getAlertState(
-      request,
-      'projects_understanding'
-    );
-
-    return data({ projects: projectList.items, alertClosed }, { headers: alertHeaders });
-  } catch {
-    const { isClosed: alertClosed, headers: alertHeaders } = await getAlertState(
-      request,
-      'projects_understanding'
-    );
-    return data({ projects: [], alertClosed }, { headers: alertHeaders });
-  }
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { isClosed: alertClosed, headers: alertHeaders } = await getAlertState(
+    request,
+    'projects_understanding'
+  );
+  return data({ alertClosed }, { headers: alertHeaders });
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {
@@ -79,20 +52,17 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
 export default function OrgProjectsPage() {
   const { orgId } = useParams();
-  const { projects: initialProjects, alertClosed } = useLoaderData<typeof loader>();
+  const { alertClosed } = useLoaderData<typeof loader>();
   const organization = useRouteLoaderData<Organization>('org-detail');
 
-  // Hydrate cache with SSR data (runs once on mount)
-  useHydrateProjects(orgId ?? '', initialProjects ?? []);
+  if (!orgId) {
+    throw new Error('Organization ID is required');
+  }
 
-  // Read from React Query cache
-  const { data: queryData } = useProjects(orgId ?? '', undefined, {
-    refetchOnMount: false,
+  const { data: queryData, isLoading: projectsLoading } = useProjects(orgId, undefined, {
     staleTime: 5 * 60 * 1000,
   });
-
-  // Use React Query data, fallback to SSR data
-  const projects = queryData?.items ?? initialProjects ?? [];
+  const projects = queryData?.items ?? [];
 
   const navigate = useNavigate();
   const revalidator = useRevalidator();
@@ -101,7 +71,6 @@ export default function OrgProjectsPage() {
   const { enqueue, showSummary } = useTaskQueue();
   const queryClient = useQueryClient();
 
-  // Alert close fetcher - native useFetcher with effect-based callback
   const alertFetcher = useFetcher<{ success: boolean }>({ key: 'alert-closed' });
   const alertSubmittedRef = useRef(false);
 
@@ -172,7 +141,6 @@ export default function OrgProjectsPage() {
   );
 
   const handleAlertClose = () => {
-    // Save the close state via server-side cookie
     alertSubmittedRef.current = true;
     alertFetcher.submit({}, { method: 'POST' });
   };
@@ -189,7 +157,7 @@ export default function OrgProjectsPage() {
       cancelable: false,
       metadata: {
         scope: 'org',
-        orgId,
+        orgId: orgId as string,
         orgName: organization?.displayName,
       },
       processor: async (ctx) => {
@@ -218,6 +186,11 @@ export default function OrgProjectsPage() {
       onComplete: (outcome) => {
         if (outcome.status === 'completed') {
           trackAction(AnalyticsAction.CreateProject);
+          // Update project detail cache with ready project so nav items become enabled when user clicks "View Project"
+          if (outcome.result) {
+            const readyProject = outcome.result as Project;
+            queryClient.setQueryData(projectKeys.detail(readyProject.name), readyProject);
+          }
         }
         queryClient.invalidateQueries({ queryKey: projectKeys.list(orgId ?? '') });
       },
@@ -262,6 +235,7 @@ export default function OrgProjectsPage() {
       <Row gutter={[0, 24]}>
         <Col span={24}>
           <DataTable
+            isLoading={projectsLoading}
             hideHeader
             mode="card"
             hidePagination
@@ -312,7 +286,7 @@ export default function OrgProjectsPage() {
             defaultSorting={[{ id: 'name', desc: true }]}
           />
         </Col>
-        {showAlert && (
+        {showAlert && !projectsLoading && (
           <Col span={24}>
             <NoteCard
               closable

--- a/app/routes/org/detail/team/index.tsx
+++ b/app/routes/org/detail/team/index.tsx
@@ -7,23 +7,10 @@ import {
 import { DataTable } from '@/modules/datum-ui/components/data-table';
 import { useHasPermission } from '@/modules/rbac';
 import { useApp } from '@/providers/app.provider';
-import {
-  createInvitationService,
-  useCancelInvitation,
-  useResendInvitation,
-  useHydrateInvitations,
-  useInvitations,
-} from '@/resources/invitations';
-import {
-  createMemberService,
-  useRemoveMember,
-  useLeaveOrganization,
-  useHydrateMembers,
-  useMembers,
-} from '@/resources/members';
+import { useCancelInvitation, useResendInvitation, useInvitations } from '@/resources/invitations';
+import { useRemoveMember, useLeaveOrganization, useMembers } from '@/resources/members';
 import { buildOrganizationNamespace } from '@/utils/common';
 import { paths } from '@/utils/config/paths.config';
-import { BadRequestError } from '@/utils/errors';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Tooltip } from '@datum-ui/components';
 import { Badge } from '@datum-ui/components';
@@ -39,14 +26,7 @@ import {
   UserPlusIcon,
 } from 'lucide-react';
 import { useMemo, useRef } from 'react';
-import {
-  Link,
-  LoaderFunctionArgs,
-  data,
-  useLoaderData,
-  useNavigate,
-  useParams,
-} from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 
 // Generic interface for combined team data
 interface ITeamMember {
@@ -65,50 +45,23 @@ interface ITeamMember {
   avatarUrl?: string;
 }
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
-  const { orgId } = params;
-
-  if (!orgId) {
-    throw new BadRequestError('Organization ID is required');
-  }
-
-  // Services now use global axios client with AsyncLocalStorage
-  const invitationService = createInvitationService();
-  const memberService = createMemberService();
-
-  // Fetch raw data - transformation happens in component
-  const [invitations, members] = await Promise.all([
-    invitationService.list(orgId),
-    memberService.list(orgId),
-  ]);
-
-  return data({ members, invitations });
-};
-
 export default function OrgTeamPage() {
-  const { members: initialMembers, invitations: initialInvitations } =
-    useLoaderData<typeof loader>();
   const { orgId } = useParams();
   const { user } = useApp();
   const navigate = useNavigate();
 
-  // Hydrate React Query cache with SSR data (runs once on mount)
-  useHydrateMembers(orgId ?? '', initialMembers);
-  useHydrateInvitations(orgId ?? '', initialInvitations);
+  if (!orgId) {
+    throw new Error('Organization ID is required');
+  }
 
-  // Read from React Query cache (gets updates from mutations)
-  const { data: liveMembers } = useMembers(orgId ?? '', {
-    refetchOnMount: false,
+  const { data: members = [], isLoading: membersLoading } = useMembers(orgId, {
     staleTime: 5 * 60 * 1000,
   });
-  const { data: liveInvitations } = useInvitations(orgId ?? '', {
-    refetchOnMount: false,
+  const { data: invitations = [], isLoading: invitationsLoading } = useInvitations(orgId, {
     staleTime: 5 * 60 * 1000,
   });
 
-  // Use live data, fallback to SSR data
-  const members = liveMembers ?? initialMembers;
-  const invitations = liveInvitations ?? initialInvitations;
+  const isLoading = membersLoading || invitationsLoading;
 
   // Transform members to team members format
   const memberTeamMembers: ITeamMember[] = useMemo(() => {
@@ -528,6 +481,7 @@ export default function OrgTeamPage() {
         }}
       />
       <DataTable
+        isLoading={isLoading}
         columns={columns}
         data={orderedTeamMembers ?? []}
         tableTitle={{

--- a/app/routes/org/detail/team/invite.tsx
+++ b/app/routes/org/detail/team/invite.tsx
@@ -2,16 +2,19 @@ import { InvitationForm } from '@/features/organization/team/invitation-form';
 import { AnalyticsAction, useAnalytics } from '@/modules/fathom';
 import { createRbacMiddleware } from '@/modules/rbac';
 import {
+  invitationKeys,
   useCreateInvitation,
   type CreateInvitationInput,
   type InvitationFormSchema,
 } from '@/resources/invitations';
+import { memberKeys } from '@/resources/members';
 import { buildOrganizationNamespace } from '@/utils/common';
 import { paths } from '@/utils/config/paths.config';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { withMiddleware } from '@/utils/middlewares';
 import { toast } from '@datum-ui/components';
+import { useQueryClient } from '@tanstack/react-query';
 import { useState, useCallback } from 'react';
 import { data, MetaFunction, useNavigate, useParams } from 'react-router';
 
@@ -47,6 +50,7 @@ export default function OrgTeamInvitePage() {
   const navigate = useNavigate();
   const { trackAction } = useAnalytics();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const queryClient = useQueryClient();
 
   const createInvitation = useCreateInvitation(orgId ?? '');
 
@@ -158,8 +162,10 @@ export default function OrgTeamInvitePage() {
           description: ErrorList(failedResults),
         });
       }
+      queryClient.refetchQueries({ queryKey: invitationKeys.list(orgId) });
+      queryClient.refetchQueries({ queryKey: memberKeys.list(orgId) });
     },
-    [orgId, createInvitation, navigate, trackAction]
+    [orgId, createInvitation, navigate, trackAction, queryClient]
   );
 
   return (

--- a/app/routes/project/detail/config/layout.tsx
+++ b/app/routes/project/detail/config/layout.tsx
@@ -7,7 +7,7 @@ export const handle = {
   breadcrumb: () => <span>Assets</span>,
   path: (data: ProjectLayoutLoaderData) => {
     return getPathWithParams(paths.project.detail.domains.root, {
-      projectId: data?.project?.name,
+      projectId: data?.project?.name ?? data?.projectId,
     });
   },
 };

--- a/app/routes/project/detail/home.tsx
+++ b/app/routes/project/detail/home.tsx
@@ -8,23 +8,18 @@ import { DomainIllustration } from '@/features/project/illustrations/domain';
 import { MetricsIllustration } from '@/features/project/illustrations/metrics';
 import { AnalyticsAction, useAnalytics } from '@/modules/fathom';
 import { useApp } from '@/providers/app.provider';
-import { createDnsZoneService } from '@/resources/dns-zones';
-import { createDomainService } from '@/resources/domains';
-import { createExportPolicyService } from '@/resources/export-policies';
-import { createHttpProxyService } from '@/resources/http-proxies';
+import { useProjectContext } from '@/providers/project.provider';
+import { useDnsZones } from '@/resources/dns-zones';
+import { useDomains } from '@/resources/domains';
+import { useExportPolicies } from '@/resources/export-policies';
+import { useHttpProxies } from '@/resources/http-proxies';
 import NotFound from '@/routes/not-found';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Col, Icon, Row } from '@datum-ui/components';
 import { CalendarFold } from 'lucide-react';
 import type { ReactNode } from 'react';
-import {
-  data,
-  type LoaderFunctionArgs,
-  useLoaderData,
-  useRouteLoaderData,
-  useNavigate,
-} from 'react-router';
+import { useNavigate } from 'react-router';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,6 +28,7 @@ import {
 type DashboardCardConfig = {
   key: string;
   isCompleted: boolean;
+  isLoading: boolean;
   illustration: ReactNode;
   completedTitle: string;
   pendingTitle: string;
@@ -63,43 +59,45 @@ export const handle = {
   hideBreadcrumb: true,
 };
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
-  const { projectId } = params;
-  if (!projectId) {
-    return data({ hasAiEdge: false, hasDomains: false, hasDnsZones: false, hasMetrics: false });
-  }
-
-  const [httpProxiesResult, domainsResult, dnsZonesResult, exportPoliciesResult] =
-    await Promise.allSettled([
-      createHttpProxyService().list(projectId, { limit: 1 }),
-      createDomainService().list(projectId, { limit: 1 }),
-      createDnsZoneService().list(projectId, { limit: 1 }),
-      createExportPolicyService().list(projectId, { limit: 1 }),
-    ]);
-
-  return data({
-    hasAiEdge: httpProxiesResult.status === 'fulfilled' && httpProxiesResult.value.length > 0,
-    hasDomains: domainsResult.status === 'fulfilled' && domainsResult.value.length > 0,
-    hasDnsZones: dnsZonesResult.status === 'fulfilled' && dnsZonesResult.value.length > 0,
-    hasMetrics:
-      exportPoliciesResult.status === 'fulfilled' && exportPoliciesResult.value.length > 0,
-  });
-};
-
 // ---------------------------------------------------------------------------
 // Page component
 // ---------------------------------------------------------------------------
 
 export default function ProjectHomePage() {
-  const { project } = useRouteLoaderData('project-detail');
-  const { hasAiEdge, hasDomains, hasDnsZones, hasMetrics } = useLoaderData<typeof loader>();
+  const { project, isLoading } = useProjectContext();
   const { trackAction } = useAnalytics();
   const navigate = useNavigate();
   const { user } = useApp();
 
+  const { data: httpProxies = [], isLoading: httpProxiesLoading } = useHttpProxies(
+    project?.name ?? '',
+    { staleTime: 5 * 60 * 1000 }
+  );
+  const { data: domains = [], isLoading: domainsLoading } = useDomains(project?.name ?? '', {
+    staleTime: 5 * 60 * 1000,
+  });
+  const { data: dnsZones = [], isLoading: dnsZonesLoading } = useDnsZones(
+    project?.name ?? '',
+    undefined,
+    { staleTime: 5 * 60 * 1000 }
+  );
+  const { data: exportPolicies = [], isLoading: exportPoliciesLoading } = useExportPolicies(
+    project?.name ?? '',
+    { staleTime: 5 * 60 * 1000 }
+  );
+
+  const hasAiEdge = httpProxies.length > 0;
+  const hasDomains = domains.length > 0;
+  const hasDnsZones = dnsZones.length > 0;
+  const hasMetrics = exportPolicies.length > 0;
+
   const isNewUser = Boolean(
     user?.createdAt && Date.now() - new Date(user.createdAt).getTime() < NEW_USER_THRESHOLD_MS
   );
+
+  if (isLoading) {
+    return null;
+  }
 
   if (!project) {
     return <NotFound />;
@@ -111,6 +109,7 @@ export default function ProjectHomePage() {
     {
       key: 'ai-edge',
       isCompleted: hasAiEdge,
+      isLoading: httpProxiesLoading,
       illustration: <AIEdgeIllustration variant={hasAiEdge ? 'completed' : 'default'} />,
       completedTitle: 'AI Edge deployed',
       pendingTitle: 'Deploy an AI Edge',
@@ -126,6 +125,7 @@ export default function ProjectHomePage() {
     {
       key: 'domains',
       isCompleted: hasDomains,
+      isLoading: domainsLoading,
       illustration: <DomainIllustration variant={hasDomains ? 'completed' : 'default'} />,
       completedTitle: 'Domains added',
       pendingTitle: 'Add a Domain',
@@ -141,6 +141,7 @@ export default function ProjectHomePage() {
     {
       key: 'dns',
       isCompleted: hasDnsZones,
+      isLoading: dnsZonesLoading,
       illustration: <DnsIllustration variant={hasDnsZones ? 'completed' : 'default'} />,
       completedTitle: 'DNS migrated',
       pendingTitle: 'Migrate DNS to Datum',
@@ -156,6 +157,7 @@ export default function ProjectHomePage() {
     {
       key: 'metrics',
       isCompleted: hasMetrics,
+      isLoading: exportPoliciesLoading,
       illustration: <MetricsIllustration variant={hasMetrics ? 'completed' : 'default'} />,
       completedTitle: 'Metrics sent to Grafana',
       pendingTitle: 'Send metrics to Grafana',
@@ -232,14 +234,22 @@ export default function ProjectHomePage() {
 
       {/* Action cards */}
       <Row
+        className="overflow-hidden"
         gutter={[
           { xs: 8, sm: 16, md: 24, xl: 32 },
           { xs: 8, sm: 16, md: 24, xl: 32 },
         ]}>
         {cards.map((card) => (
-          <Col key={card.key} xs={24} sm={12} md={12} xl={6} className="h-full max-h-[380px]">
+          <Col
+            key={card.key}
+            xs={24}
+            sm={12}
+            md={12}
+            xl={6}
+            className="h-[350px] min-h-[380px] overflow-hidden">
             <ActionCard
               isCompleted={card.isCompleted}
+              isLoading={card.isLoading}
               image={card.illustration}
               className="h-full"
               title={card.isCompleted ? card.completedTitle : card.pendingTitle}
@@ -251,11 +261,11 @@ export default function ProjectHomePage() {
       </Row>
 
       {/* Community */}
-      <Row>
+      <Row className="shrink-0">
         <Col span={24}>
           <div className="dark:border-card relative flex h-auto min-h-[300px] w-full flex-col items-center justify-center rounded-lg bg-white/50 p-9 pb-8 shadow dark:bg-[#18273A]">
             <h2 className="mb-2 text-lg font-medium">Datum community</h2>
-            <p className="dark:text-card-quaternary text-foreground/60 text-sm font-normal">
+            <p className="dark:text-card-quaternary text-foreground/60 text-center text-sm font-normal">
               Looking for some help or share some knowledge? We&apos;d love to see you!
             </p>
 

--- a/app/routes/project/detail/layout.tsx
+++ b/app/routes/project/detail/layout.tsx
@@ -1,30 +1,21 @@
 import { DashboardLayout } from '@/layouts/dashboard.layout';
 import { setSentryOrgContext, setSentryProjectContext } from '@/modules/sentry';
 import { useApp } from '@/providers/app.provider';
+import { ProjectProvider } from '@/providers/project.provider';
 import { ControlPlaneStatus } from '@/resources/base';
 import { connectorKeys, createConnectorService } from '@/resources/connectors';
 import { createDnsZoneService, dnsZoneKeys } from '@/resources/dns-zones';
 import { createDomainService, domainKeys } from '@/resources/domains';
 import { createExportPolicyService, exportPolicyKeys } from '@/resources/export-policies';
 import { createHttpProxyService, httpProxyKeys } from '@/resources/http-proxies';
-import { createOrganizationService, type Organization } from '@/resources/organizations';
-import {
-  createProjectService,
-  useHydrateProject,
-  useProject,
-  type Project,
-} from '@/resources/projects';
+import { useOrganization, type Organization } from '@/resources/organizations';
+import { useProject, type Project } from '@/resources/projects';
 import { createSecretService, secretKeys } from '@/resources/secrets';
 import { paths } from '@/utils/config/paths.config';
-import {
-  getOrgSession,
-  redirectWithToast,
-  setOrgSession,
-  setProjectSession,
-} from '@/utils/cookies';
-import { ValidationError } from '@/utils/errors';
+import { setOrgSession, setProjectSession } from '@/utils/cookies';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
 import { combineHeaders, getPathWithParams } from '@/utils/helpers/path.helper';
+import { toast } from '@datum-ui/components';
 import { NavItem } from '@datum-ui/components/sidebar/nav-main';
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -37,61 +28,47 @@ import {
   SettingsIcon,
   SignpostIcon,
 } from 'lucide-react';
-import { useEffect, useMemo } from 'react';
-import { LoaderFunctionArgs, Outlet, data, useLoaderData } from 'react-router';
+import { useEffect, useMemo, useRef } from 'react';
+import {
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+  Outlet,
+  data,
+  useFetcher,
+  useNavigate,
+  useParams,
+} from 'react-router';
 
-export interface ProjectLayoutLoaderData {
-  project: Project;
-  org: Organization;
-}
-
-export const loader = async ({ params, request }: LoaderFunctionArgs) => {
-  const { projectId } = params;
-
-  // Services now use global axios client with AsyncLocalStorage
-  const projectService = createProjectService();
-  const orgService = createOrganizationService();
-
-  try {
-    if (!projectId) {
-      throw new ValidationError('Project ID is required');
-    }
-
-    const project = await projectService.get(projectId);
-
-    if (!project.name) {
-      throw new ValidationError('Project not found');
-    }
-
-    const orgId = project.organizationId;
-    if (!orgId) {
-      throw new ValidationError('Organization ID not found for project');
-    }
-    const org = await orgService.get(orgId);
-
-    // Set both org and project cookies
-    const orgSession = await setOrgSession(request, org.name);
-    const projectSession = await setProjectSession(request, project.name);
-
-    // Combine headers from both cookie operations
-    const headers = combineHeaders(orgSession.headers, projectSession.headers);
-
-    return data({ project, org }, { headers });
-  } catch (error: any) {
-    const orgSession = await getOrgSession(request);
-
-    return redirectWithToast(
-      orgSession.orgId
-        ? getPathWithParams(paths.org.detail.projects.root, { orgId: orgSession.orgId })
-        : paths.account.organizations.root,
-      {
-        title: 'Project unavailable',
-        description: error.message,
-        type: 'error',
-      }
-    );
-  }
+/** Minimal loader - returns projectId for breadcrumbs only. No blocking fetch. */
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  return data({ projectId: params.projectId });
 };
+
+/** Sets org and project session cookies when user enters a project. Used for "return to last project" on next visit. */
+export const action = async ({ request }: ActionFunctionArgs) => {
+  if (request.method !== 'POST') return new Response(null, { status: 405 });
+
+  const formData = await request.formData();
+  const projectId = formData.get('projectId') as string | null;
+  const orgId = formData.get('orgId') as string | null;
+
+  if (!projectId || !orgId) {
+    return new Response(null, { status: 400 });
+  }
+
+  const orgSession = await setOrgSession(request, orgId);
+  const projectSession = await setProjectSession(request, projectId);
+  const headers = combineHeaders(orgSession.headers, projectSession.headers);
+
+  return new Response(null, { status: 204, headers });
+};
+
+/** @deprecated Use useProjectContext for project/org. Kept for breadcrumb handle.path compatibility. */
+export interface ProjectLayoutLoaderData {
+  project?: Project;
+  org?: Organization;
+  projectId?: string;
+}
 
 /** Skip re-running the loader when navigating within the same project (e.g. Home → AI Edge → Connectors). */
 export function shouldRevalidate({
@@ -107,150 +84,171 @@ export function shouldRevalidate({
   return defaultShouldRevalidate;
 }
 
-export default function ProjectLayout() {
-  const { project: initialProject, org } = useLoaderData<ProjectLayoutLoaderData>();
+function ProjectLayoutContent() {
+  const { projectId } = useParams();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const sessionFetcher = useFetcher({ key: 'session-cookies' });
+  const lastSessionProjectRef = useRef<string | null>(null);
+  const { organization: appOrg, setOrganization, setProject } = useApp();
 
-  // Hydrate cache with SSR data (runs once on mount)
-  useHydrateProject(initialProject.name, initialProject);
-
-  // Read from React Query cache
-  const { data: queryData } = useProject(initialProject.name, {
+  const {
+    data: project,
+    isLoading: projectLoading,
+    isError: projectError,
+    error: projectErrorDetail,
+  } = useProject(projectId ?? '', {
+    staleTime: 5 * 60 * 1000,
     refetchOnMount: false,
+  });
+
+  const { data: org } = useOrganization(project?.organizationId ?? '', {
+    enabled: !!project?.organizationId,
     staleTime: 5 * 60 * 1000,
   });
 
-  // Use React Query data, fallback to SSR data
-  const project = queryData ?? initialProject;
+  // Redirect on error (invalid project, not found, etc.)
+  useEffect(() => {
+    if (projectError && projectId) {
+      toast.error('Project unavailable', {
+        description: projectErrorDetail?.message ?? 'Project not found',
+      });
+      const redirectPath = appOrg?.name
+        ? getPathWithParams(paths.org.detail.projects.root, { orgId: appOrg.name })
+        : paths.account.organizations.root;
+      navigate(redirectPath);
+    }
+  }, [projectError, projectErrorDetail, projectId, appOrg?.name, navigate]);
 
-  const { setOrganization, setProject } = useApp();
+  const projectContextValue = useMemo(
+    () => ({
+      project,
+      org: org ?? undefined,
+      isLoading: projectLoading,
+      error: projectError ? (projectErrorDetail ?? new Error('Project unavailable')) : null,
+    }),
+    [project, org, projectLoading, projectError, projectErrorDetail]
+  );
 
   const navItems: NavItem[] = useMemo(() => {
+    if (!project?.name) return [];
+
     const currentStatus = transformControlPlaneStatus(project.status);
     const isReady = currentStatus.status === ControlPlaneStatus.Success;
-    const projectId = project.name;
+    const pid = project.name;
 
     const settingsGeneral = getPathWithParams(paths.project.detail.settings.general, {
-      projectId,
+      projectId: pid,
     });
     const settingsActivity = getPathWithParams(paths.project.detail.settings.activity, {
-      projectId,
+      projectId: pid,
     });
     const settingsNotifications = getPathWithParams(paths.project.detail.settings.notifications, {
-      projectId,
+      projectId: pid,
     });
-    const settingsQuotas = getPathWithParams(paths.project.detail.settings.quotas, { projectId });
+    const settingsQuotas = getPathWithParams(paths.project.detail.settings.quotas, {
+      projectId: pid,
+    });
 
     return [
       {
         title: 'Home',
-        href: getPathWithParams(paths.project.detail.home, { projectId }),
+        href: getPathWithParams(paths.project.detail.home, { projectId: pid }),
         type: 'link',
         icon: HomeIcon,
         onPrefetch: () => {
           void queryClient.prefetchQuery({
-            queryKey: domainKeys.list(projectId),
-            queryFn: () => createDomainService().list(projectId),
+            queryKey: domainKeys.list(pid),
+            queryFn: () => createDomainService().list(pid),
           });
           void queryClient.prefetchQuery({
-            queryKey: exportPolicyKeys.list(projectId),
-            queryFn: () => createExportPolicyService().list(projectId),
+            queryKey: exportPolicyKeys.list(pid),
+            queryFn: () => createExportPolicyService().list(pid),
           });
         },
       },
       {
         title: 'AI Edge',
-        href: getPathWithParams(paths.project.detail.proxy.root, {
-          projectId,
-        }),
+        href: getPathWithParams(paths.project.detail.proxy.root, { projectId: pid }),
         icon: GaugeIcon,
         disabled: !isReady,
         type: 'link',
         showSeparatorAbove: true,
         onPrefetch: () => {
           void queryClient.prefetchQuery({
-            queryKey: httpProxyKeys.list(projectId),
-            queryFn: () => createHttpProxyService().list(projectId),
+            queryKey: httpProxyKeys.list(pid),
+            queryFn: () => createHttpProxyService().list(pid),
           });
         },
       },
       {
         title: 'Connectors',
-        href: getPathWithParams(paths.project.detail.connectors.root, {
-          projectId,
-        }),
+        href: getPathWithParams(paths.project.detail.connectors.root, { projectId: pid }),
         type: 'link',
         icon: CableIcon,
         disabled: !isReady,
         onPrefetch: () => {
           void queryClient.prefetchQuery({
-            queryKey: connectorKeys.list(projectId),
-            queryFn: () => createConnectorService().list(projectId),
+            queryKey: connectorKeys.list(pid),
+            queryFn: () => createConnectorService().list(pid),
           });
         },
       },
       {
         title: 'DNS',
-        href: getPathWithParams(paths.project.detail.dnsZones.root, {
-          projectId,
-        }),
+        href: getPathWithParams(paths.project.detail.dnsZones.root, { projectId: pid }),
         icon: SignpostIcon,
         disabled: !isReady,
         type: 'link',
         onPrefetch: () => {
           void queryClient.prefetchQuery({
-            queryKey: dnsZoneKeys.list(projectId),
-            queryFn: () => createDnsZoneService().list(projectId),
+            queryKey: dnsZoneKeys.list(pid),
+            queryFn: () => createDnsZoneService().list(pid),
           });
         },
       },
       {
         title: 'Domains',
-        href: getPathWithParams(paths.project.detail.domains.root, {
-          projectId,
-        }),
+        href: getPathWithParams(paths.project.detail.domains.root, { projectId: pid }),
         type: 'link',
         icon: LayersIcon,
         disabled: !isReady,
         onPrefetch: () => {
           void queryClient.prefetchQuery({
-            queryKey: domainKeys.list(projectId),
-            queryFn: () => createDomainService().list(projectId),
+            queryKey: domainKeys.list(pid),
+            queryFn: () => createDomainService().list(pid),
           });
         },
       },
       {
         title: 'Metrics',
-        href: getPathWithParams(paths.project.detail.metrics.root, { projectId }),
+        href: getPathWithParams(paths.project.detail.metrics.root, { projectId: pid }),
         type: 'link',
         icon: ChartSplineIcon,
         disabled: !isReady,
         onPrefetch: () => {
           void queryClient.prefetchQuery({
-            queryKey: exportPolicyKeys.list(projectId),
-            queryFn: () => createExportPolicyService().list(projectId),
+            queryKey: exportPolicyKeys.list(pid),
+            queryFn: () => createExportPolicyService().list(pid),
           });
         },
       },
-
       {
         title: 'Secrets',
-        href: getPathWithParams(paths.project.detail.config.secrets.root, {
-          projectId,
-        }),
+        href: getPathWithParams(paths.project.detail.config.secrets.root, { projectId: pid }),
         type: 'link',
         icon: FileLockIcon,
         disabled: !isReady,
         onPrefetch: () => {
           void queryClient.prefetchQuery({
-            queryKey: secretKeys.list(projectId),
-            queryFn: () => createSecretService().list(projectId),
+            queryKey: secretKeys.list(pid),
+            queryFn: () => createSecretService().list(pid),
           });
         },
       },
       {
         title: 'Project Settings',
-        href: getPathWithParams(paths.project.detail.settings.general, { projectId }),
+        href: getPathWithParams(paths.project.detail.settings.general, { projectId: pid }),
         type: 'link',
         disabled: !isReady,
         icon: SettingsIcon,
@@ -262,28 +260,54 @@ export default function ProjectLayout() {
   }, [project, queryClient]);
 
   useEffect(() => {
-    if (org) {
-      setOrganization(org);
-      setSentryOrgContext(org);
+    const currentOrg = org ?? appOrg;
+    if (currentOrg) {
+      setOrganization(currentOrg);
+      setSentryOrgContext(currentOrg);
     }
-  }, [org]);
+  }, [org, appOrg, setOrganization]);
 
   useEffect(() => {
     if (project) {
       setProject(project);
       setSentryProjectContext(project);
     }
-  }, [project]);
+  }, [project, setProject]);
+
+  // Set org/project session cookies when project loads - enables "return to last project" on next visit
+  useEffect(() => {
+    const orgId = org?.name ?? appOrg?.name;
+    if (project?.name && orgId && lastSessionProjectRef.current !== project.name) {
+      lastSessionProjectRef.current = project.name;
+      sessionFetcher.submit({ projectId: project.name, orgId }, { method: 'POST' });
+    }
+  }, [project?.name, org?.name, appOrg?.name, sessionFetcher]);
+
+  // Don't render content while redirecting on error
+  if (projectError && projectId) {
+    return null;
+  }
+
+  const currentOrg = org ?? appOrg;
+  const currentProject = project ?? undefined;
 
   return (
-    <DashboardLayout
-      navItems={navItems}
-      sidebarCollapsible="icon"
-      currentProject={project}
-      currentOrg={org}
-      expandBehavior="push"
-      showBackdrop={false}>
-      <Outlet />
-    </DashboardLayout>
+    <ProjectProvider value={projectContextValue}>
+      <DashboardLayout
+        navItems={navItems}
+        sidebarCollapsible="icon"
+        currentProject={currentProject}
+        currentOrg={currentOrg}
+        expandBehavior="push"
+        showBackdrop={false}
+        sidebarLoading={projectLoading}
+        switcherLoading={projectLoading}>
+        <Outlet />
+      </DashboardLayout>
+    </ProjectProvider>
   );
+}
+
+export default function ProjectLayout() {
+  return <ProjectLayoutContent />;
 }

--- a/app/routes/project/detail/metrics/layout.tsx
+++ b/app/routes/project/detail/metrics/layout.tsx
@@ -10,7 +10,7 @@ export const handle = {
   breadcrumb: () => <span>Metrics</span>,
   path: (data: ProjectLayoutLoaderData) => {
     return getPathWithParams(paths.project.detail.metrics.root, {
-      projectId: data?.project?.name,
+      projectId: data?.project?.name ?? data?.projectId,
     });
   },
 };

--- a/app/routes/project/detail/settings/general.tsx
+++ b/app/routes/project/detail/settings/general.tsx
@@ -1,15 +1,20 @@
 import { ProjectDangerCard } from '@/features/project/settings/danger-card';
 import { ProjectGeneralCard } from '@/features/project/settings/general-card';
+import { useProjectContext } from '@/providers/project.provider';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Col, Row } from '@datum-ui/components';
-import { MetaFunction, useRouteLoaderData } from 'react-router';
+import { MetaFunction } from 'react-router';
 
 export const meta: MetaFunction = mergeMeta(() => {
   return metaObject('General');
 });
 
 export default function ProjectGeneralSettingsPage() {
-  const { project } = useRouteLoaderData('project-detail');
+  const { project } = useProjectContext();
+
+  if (!project) {
+    return null;
+  }
 
   return (
     <div className="flex w-full flex-col gap-8">

--- a/app/routes/project/detail/settings/layout.tsx
+++ b/app/routes/project/detail/settings/layout.tsx
@@ -1,12 +1,13 @@
 import TabsLayout from '@/layouts/tabs/tabs.layout';
 import { TabsNavProps } from '@/layouts/tabs/tabs.types';
+import { useProjectContext } from '@/providers/project.provider';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { useMemo } from 'react';
-import { Outlet, useRouteLoaderData } from 'react-router';
+import { Outlet } from 'react-router';
 
-export default function OrgSettingsLayout() {
-  const { project } = useRouteLoaderData('project-detail');
+export default function ProjectSettingsLayout() {
+  const { project } = useProjectContext();
 
   const navItems: TabsNavProps[] = useMemo(() => {
     const projectId = project?.name;
@@ -33,6 +34,7 @@ export default function OrgSettingsLayout() {
       },
     ];
   }, [project]);
+
   return (
     <TabsLayout tabsTitle={{ title: 'Project Settings' }} navItems={navItems}>
       <Outlet />

--- a/app/routes/project/detail/settings/quotas.tsx
+++ b/app/routes/project/detail/settings/quotas.tsx
@@ -1,6 +1,7 @@
 import { QuotasTable } from '@/features/quotas/quotas-table';
+import { useProjectContext } from '@/providers/project.provider';
 import { createAllowanceBucketService, type AllowanceBucket } from '@/resources/allowance-buckets';
-import { LoaderFunctionArgs, useLoaderData, useRouteLoaderData } from 'react-router';
+import { LoaderFunctionArgs, useLoaderData } from 'react-router';
 
 export const handle = {
   breadcrumb: () => <span>Quotas</span>,
@@ -20,8 +21,12 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 };
 
 export default function ProjectQuotasPage() {
-  const { project } = useRouteLoaderData('project-detail');
+  const { project } = useProjectContext();
   const allowanceBuckets = useLoaderData<typeof loader>() as AllowanceBucket[];
 
-  return <QuotasTable data={allowanceBuckets} resourceType="project" resource={project!} />;
+  if (!project) {
+    return null;
+  }
+
+  return <QuotasTable data={allowanceBuckets} resourceType="project" resource={project} />;
 }

--- a/app/utils/middlewares/registration-approval.middleware.ts
+++ b/app/utils/middlewares/registration-approval.middleware.ts
@@ -1,6 +1,6 @@
 import { MiddlewareContext, NextFunction } from './middleware';
-import { createUserService, RegistrationApproval } from '@/resources/users';
 import { getRequestContext } from '@/modules/axios/request-context';
+import { createUserService, RegistrationApproval } from '@/resources/users';
 import { paths } from '@/utils/config/paths.config';
 import { getSession } from '@/utils/cookies';
 import { redirect } from 'react-router';


### PR DESCRIPTION
## Overview

This PR shifts project and org-scoped data fetching from server-side loaders to client-side React Query, reducing blocking SSR and improving perceived performance with skeletons and loading states.

---

## Project dashboard refactor

### Layout & data flow

- **Project layout** now uses a minimal loader (returns `projectId` only for breadcrumbs). Project and org data are fetched client-side via `useProject` and `useOrganization`.
- **ProjectProvider** (`app/providers/project.provider.tsx`) provides `{ project, org, isLoading, error }` to child routes via `useProjectContext()`.
- **Session cookies** are set via a background fetcher when project/org load; this fetcher is excluded from the progress bar.

### Child routes

- **Project home** – Uses `useProjectContext()` and React Query for http proxies, domains, DNS zones, export policies. Action cards show skeletons while loading.
- **Project settings** (general, quotas, layout) – Switched from `useRouteLoaderData('project-detail')` to `useProjectContext()`.
- **Config layout** – Breadcrumb path fallback updated for minimal loader data.

### Nav & header

- **Sidebar** – `ProjectNavSkeleton` shows while project loads (mirrors Home, AI Edge, Connectors, DNS, Domains, Metrics, Secrets, Project Settings).
- **Org/project switcher** – `OrgSkeleton` and `ProjectSkeleton` prevent layout shift while loading.
- **DashboardLayout** – New `sidebarLoading` and `switcherLoading` props.

---

## Org pages refactor

### Projects list (`/org/:orgId/projects`)

- **Loader** – Only fetches alert state (cookie). Projects are loaded client-side with `useProjects`.
- **Create project** – On task completion, the ready project is written to the project detail cache so nav items enable correctly when the user clicks "View Project".
- **Alert card** – Hidden until projects finish loading to avoid layout jump.

### Team page (`/org/:orgId/team`)

- **Loader removed** – Members and invitations fetched client-side with `useMembers` and `useInvitations`.
- **Team invite** – Refetches members and invitations after creating invitations.

---

## Progress bar & root loader

- **Root `shouldRevalidate`** – Skips revalidation for Link navigations (root data is toast, CSRF, ENV; unchanged per route). Form submissions still revalidate.
- **Background fetchers** – Session cookie fetcher excluded from progress bar via `BACKGROUND_FETCHER_KEYS`.

---

## Other changes

- **Project danger card** – Invalidates and refetches projects list after delete before navigating.
- **Project general card** – Invalidates and refetches projects list after update.
- **Mobile menu** – Renders even when `navItems` is empty (for loading states).
- **AsyncLocalStorage import** – Moved in `request-context.ts` for Node compatibility.
- **HTTP proxy service** – Minor formatting in htpasswd encoding.

https://github.com/user-attachments/assets/2e328f11-2712-40ff-ac28-c8a19f6e76cd

Ref: https://github.com/datum-cloud/enhancements/issues/656