### PR TITLE
Fix small fetching issues and excessive toast usage

### DIFF
--- a/app/features/edge/dns-zone/dns-zone-form-dialog.tsx
+++ b/app/features/edge/dns-zone/dns-zone-form-dialog.tsx
@@ -30,9 +30,6 @@ export const DnsZoneFormDialog = forwardRef<DnsZoneFormDialogRef, DnsZoneFormDia
     const createZone = useCreateDnsZone(projectId, {
       onSuccess: (dnsZone) => {
         trackAction(AnalyticsAction.AddDnsZone);
-        toast.success('DNS', {
-          description: 'DNS zone has been created successfully',
-        });
         setOpen(false);
         // Navigate to discovery page — it creates the discovery on mount
         navigate(

--- a/app/features/edge/domain/domain-form-dialog.tsx
+++ b/app/features/edge/domain/domain-form-dialog.tsx
@@ -37,9 +37,6 @@ export const DomainFormDialog = forwardRef<DomainFormDialogRef, DomainFormDialog
     const handleSubmit = async (formData: DomainSchema) => {
       try {
         const domain = await createDomainMutation.mutateAsync({ domainName: formData.domain });
-        toast.success('Domain', {
-          description: 'The domain has been added to your project',
-        });
         trackAction(AnalyticsAction.AddDomain);
         setOpen(false);
 

--- a/app/features/metric/export-policies/form/update-form.tsx
+++ b/app/features/metric/export-policies/form/update-form.tsx
@@ -70,9 +70,6 @@ export const ExportPolicyUpdateForm = ({
 
   const updateMutation = useUpdateExportPolicy(projectId ?? '', defaultValue?.name ?? '', {
     onSuccess: () => {
-      toast.success('Export policy updated successfully', {
-        description: 'You have successfully updated an export policy.',
-      });
       navigate(
         getPathWithParams(paths.project.detail.metrics.root, {
           projectId,
@@ -88,9 +85,6 @@ export const ExportPolicyUpdateForm = ({
 
   const deleteMutation = useDeleteExportPolicy(projectId ?? '', {
     onSuccess: () => {
-      toast.success('Export policy deleted successfully', {
-        description: 'You have successfully deleted an export policy.',
-      });
       navigate(
         getPathWithParams(paths.project.detail.metrics.root, {
           projectId,

--- a/app/features/organization/settings/danger-card.tsx
+++ b/app/features/organization/settings/danger-card.tsx
@@ -1,20 +1,14 @@
 import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
 import { DangerCard } from '@/components/danger-card/danger-card';
-import {
-  type Organization,
-  useDeleteOrganization,
-  useOrganizationsGql,
-} from '@/resources/organizations';
+import { type Organization, useDeleteOrganization } from '@/resources/organizations';
 import { paths } from '@/utils/config/paths.config';
 import { toast } from '@datum-ui/components';
 import { useNavigate } from 'react-router';
 
 export const OrganizationDangerCard = ({ organization }: { organization: Organization }) => {
   const navigate = useNavigate();
-  const { refetch: refetchOrgs } = useOrganizationsGql();
   const deleteOrganization = useDeleteOrganization({
     onSuccess: () => {
-      refetchOrgs();
       navigate(paths.account.organizations.root);
     },
     onError: (error) => {

--- a/app/features/project/settings/danger-card.tsx
+++ b/app/features/project/settings/danger-card.tsx
@@ -13,9 +13,6 @@ export const ProjectDangerCard = ({ project }: { project: Project }) => {
 
   const deleteMutation = useDeleteProject({
     onSuccess: () => {
-      toast.success('Project', {
-        description: 'The project has been deleted successfully',
-      });
       navigate(
         getPathWithParams(paths.org.detail.projects.root, {
           orgId: project.organizationId,

--- a/app/features/secret/form/secret-form-dialog.tsx
+++ b/app/features/secret/form/secret-form-dialog.tsx
@@ -29,9 +29,6 @@ export const SecretFormDialog = forwardRef<SecretFormDialogRef>((_props, ref) =>
   const createSecret = useCreateSecret(projectId ?? '', {
     onSuccess: (secret) => {
       trackAction(AnalyticsAction.AddSecret);
-      toast.success('Secret', {
-        description: 'The secret has been created successfully',
-      });
       setOpen(false);
       navigate(
         getPathWithParams(paths.project.detail.secrets.detail.root, {

--- a/app/resources/invitations/invitation.queries.ts
+++ b/app/resources/invitations/invitation.queries.ts
@@ -78,10 +78,8 @@ export function useCreateInvitation(
       options?.onSuccess?.(...args);
     },
     onSettled: (...args) => {
-      // Force refetch active queries (works even with staleTime)
-      queryClient.refetchQueries({
+      queryClient.invalidateQueries({
         queryKey: invitationKeys.list(orgId),
-        type: 'active',
       });
       queryClient.refetchQueries({
         queryKey: invitationKeys.userLists(),

--- a/app/resources/organizations/organization.gql-queries.ts
+++ b/app/resources/organizations/organization.gql-queries.ts
@@ -59,7 +59,7 @@ export function useOrganizationsGql(_params?: undefined, options?: { enabled?: b
   const [result, reexecute] = useQuery({
     query: orgListOp.query,
     variables: orgListOp.variables,
-    requestPolicy: 'cache-first',
+    requestPolicy: 'cache-and-network',
     pause,
   });
 

--- a/app/routes/account/settings/active-sessions.tsx
+++ b/app/routes/account/settings/active-sessions.tsx
@@ -69,9 +69,6 @@ export default function AccountActiveSessionsPage() {
       if (selectedSession?.name === currentSession) {
         return navigate(paths.auth.logOut, { replace: true });
       }
-      toast.success('Session', {
-        description: 'The session has been revoked successfully',
-      });
       setSelectedSession(null);
     },
     onError: (error) => {

--- a/app/routes/org/detail/settings/policy-bindings.tsx
+++ b/app/routes/org/detail/settings/policy-bindings.tsx
@@ -43,11 +43,6 @@ export default function OrgPolicyBindingsPage() {
   const { confirm } = useConfirmationDialog();
 
   const deleteMutation = useDeletePolicyBinding(orgId ?? '', {
-    onSuccess: () => {
-      toast.success('Policy binding', {
-        description: 'The policy binding has been deleted successfully',
-      });
-    },
     onError: (error) => {
       toast.error('Error', { description: error.message });
     },

--- a/app/routes/org/detail/team/create-group.tsx
+++ b/app/routes/org/detail/team/create-group.tsx
@@ -42,7 +42,6 @@ export default function CreateGroupPage() {
     setIsSubmitting(true);
     try {
       await createGroup.mutateAsync(formData);
-      toast.success('Group created successfully');
       navigate(getPathWithParams(paths.org.detail.team.groups, { orgId }));
     } catch (error: unknown) {
       toast.error(error instanceof Error ? error.message : 'Failed to create group');

--- a/app/routes/org/detail/team/groups.tsx
+++ b/app/routes/org/detail/team/groups.tsx
@@ -72,7 +72,6 @@ export default function GroupsPage() {
   });
 
   const { mutateAsync: deleteGroupAsync } = useDeleteGroup(orgId, {
-    onSuccess: () => toast.success('Group deleted successfully'),
     onError: (error) => toast.error(error.message || 'Failed to delete group'),
   });
 

--- a/app/routes/org/detail/team/index.tsx
+++ b/app/routes/org/detail/team/index.tsx
@@ -91,9 +91,6 @@ export default function OrgTeamPage() {
 
   // Mutation hooks
   const cancelInvitationMutation = useCancelInvitation(orgId, {
-    onSuccess: () => {
-      toast.success('Invitation cancelled successfully');
-    },
     onError: (error) => {
       toast.error(error.message || 'Failed to cancel invitation');
     },
@@ -109,9 +106,6 @@ export default function OrgTeamPage() {
   });
 
   const removeMemberMutation = useRemoveMember(orgId, {
-    onSuccess: () => {
-      toast.success('Member removed successfully');
-    },
     onError: (error) => {
       toast.error(error.message || 'Failed to remove member');
     },

--- a/app/routes/org/detail/team/invite.tsx
+++ b/app/routes/org/detail/team/invite.tsx
@@ -130,11 +130,6 @@ export default function OrgTeamInvitePage() {
       if (hasSuccess && !hasFailed) {
         // All invitations succeeded
         trackAction(AnalyticsAction.InviteCollaborator);
-        const message =
-          successCount === 1
-            ? 'Invitation sent successfully!'
-            : `${formatCount(successCount)} sent successfully!`;
-        toast.success(message);
         navigate(getPathWithParams(paths.org.detail.team.root, { orgId }));
       } else if (hasSuccess && hasFailed) {
         // Partial success - some succeeded, some failed

--- a/app/routes/project/detail/dns-zones/detail/dns-records.tsx
+++ b/app/routes/project/detail/dns-zones/detail/dns-records.tsx
@@ -115,11 +115,6 @@ export default function DnsRecordsPage() {
 
   const { confirm } = useConfirmationDialog();
   const deleteMutation = useDeleteDnsRecord(projectId!, dnsZoneId!, {
-    onSuccess: () => {
-      toast.success('DNS record', {
-        description: 'The DNS record has been deleted successfully',
-      });
-    },
     onError: (error) => {
       toast.error(error.message || 'Failed to delete DNS record');
     },

--- a/app/routes/project/detail/dns-zones/detail/settings.tsx
+++ b/app/routes/project/detail/dns-zones/detail/settings.tsx
@@ -5,7 +5,7 @@ import { DescriptionFormCard } from '@/features/edge/dns-zone/overview/descripti
 import { useDeleteDnsZone } from '@/resources/dns-zones';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { Col, Row, toast } from '@datum-ui/components';
+import { Col, Row } from '@datum-ui/components';
 import { PageTitle } from '@datum-ui/components/page-title';
 import { useNavigate, useParams, useRouteLoaderData } from 'react-router';
 
@@ -20,9 +20,6 @@ export default function DnsZoneSettingsPage() {
 
   const deleteMutation = useDeleteDnsZone(projectId ?? '', {
     onSuccess: () => {
-      toast.success('DNS Zone', {
-        description: 'The DNS Zone has been deleted successfully',
-      });
       navigate(
         getPathWithParams(paths.project.detail.dnsZones.root, {
           projectId,

--- a/app/routes/project/detail/dns-zones/index.tsx
+++ b/app/routes/project/detail/dns-zones/index.tsx
@@ -134,11 +134,6 @@ export default function DnsZonesPage() {
   }, [zones]);
 
   const deleteMutation = useDeleteDnsZone(projectId ?? '', {
-    onSuccess: () => {
-      toast.success('DNS', {
-        description: 'The DNS has been deleted successfully',
-      });
-    },
     onError: (error) => {
       toast.error('DNS', {
         description: error.message || 'Failed to delete DNS',

--- a/app/routes/project/detail/domains/index.tsx
+++ b/app/routes/project/detail/domains/index.tsx
@@ -200,9 +200,6 @@ export default function DomainsPage() {
       onSubmit: async () => {
         try {
           await deleteDomainMutation.mutateAsync(domain?.name ?? '');
-          toast.success('Domain', {
-            description: 'The domain has been deleted successfully',
-          });
         } catch (error) {
           toast.error('Domain', {
             description: (error as Error).message || 'Failed to delete domain',

--- a/app/routes/project/detail/edge/detail/index.tsx
+++ b/app/routes/project/detail/edge/detail/index.tsx
@@ -34,9 +34,6 @@ export default function HttpProxyDetailPage() {
 
   const { confirmDelete, isPending: isDeleting } = useDeleteProxy(projectId ?? '', {
     onSuccess: () => {
-      toast.success('Proxy', {
-        description: 'The proxy has been deleted successfully',
-      });
       navigate(getPathWithParams(paths.project.detail.proxy.root, { projectId }));
     },
     onError: (error) => {

--- a/app/routes/project/detail/edge/index.tsx
+++ b/app/routes/project/detail/edge/index.tsx
@@ -62,11 +62,6 @@ export default function HttpProxyPage() {
   }, [searchParams, setSearchParams]);
 
   const { confirmDelete } = useDeleteProxy(projectId, {
-    onSuccess: () => {
-      toast.success('AI Edge', {
-        description: 'AI Edge has been deleted successfully',
-      });
-    },
     onError: (error) => {
       toast.error(error.message || 'Failed to delete AI Edge');
     },

--- a/app/routes/project/detail/metrics/index.tsx
+++ b/app/routes/project/detail/metrics/index.tsx
@@ -56,11 +56,6 @@ export default function ExportPoliciesPage() {
   const { confirm } = useConfirmationDialog();
 
   const deleteExportPolicyMutation = useDeleteExportPolicy(projectId ?? '', {
-    onSuccess: () => {
-      toast.success('Export policy deleted successfully', {
-        description: 'The export policy has been deleted successfully',
-      });
-    },
     onError: (error) => {
       toast.error(error.message);
     },

--- a/app/routes/project/detail/secrets/index.tsx
+++ b/app/routes/project/detail/secrets/index.tsx
@@ -60,11 +60,6 @@ export default function SecretsPage() {
   const data = queryData ?? initialData ?? [];
 
   const deleteSecretMutation = useDeleteSecret(projectId ?? '', {
-    onSuccess: () => {
-      toast.success('Secret deleted successfully', {
-        description: 'The secret has been deleted successfully',
-      });
-    },
     onError: (error) => {
       toast.error(error.message);
     },


### PR DESCRIPTION
This PR fixes some small org and invite revalidation issues and removes lots of toast messages that aren't needed. In all these cases where a toast is being removed we're already providing a visual cue by navigating or updating a list. 