### PR TITLE
feat(e2e): organisation regression tests

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -243,7 +243,7 @@ jobs:
     name: E2E Regression Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -243,7 +243,7 @@ jobs:
     name: E2E Regression Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ !failure() && !cancelled() }}
     strategy:
       fail-fast: false
       matrix:

--- a/app/components/confirmation-dialog/confirmation-dialog.tsx
+++ b/app/components/confirmation-dialog/confirmation-dialog.tsx
@@ -145,6 +145,7 @@ export const ConfirmationDialog = ({
                 <Label className="cursor-text select-text">{dialogProps.confirmInputLabel}</Label>
                 <Input
                   type="text"
+                  data-e2e="confirmation-dialog-input"
                   placeholder={dialogProps.confirmInputPlaceholder}
                   value={confirmValidationValue}
                   onChange={(e) => setConfirmValidationValue(e.target.value)}
@@ -157,12 +158,18 @@ export const ConfirmationDialog = ({
         )}
 
         <Dialog.Footer>
-          <Button type="quaternary" theme="borderless" onClick={handleCancel} disabled={isPending}>
+          <Button
+            type="quaternary"
+            theme="borderless"
+            data-e2e="confirmation-dialog-cancel"
+            onClick={handleCancel}
+            disabled={isPending}>
             {dialogProps.cancelText}
           </Button>
           <Button
             type={dialogProps.variant === 'destructive' ? 'danger' : 'primary'}
             theme="solid"
+            data-e2e="confirmation-dialog-submit"
             onClick={handleConfirm}
             disabled={isDisabled || isPending}
             loading={isPending}>

--- a/app/components/danger-card/danger-card.tsx
+++ b/app/components/danger-card/danger-card.tsx
@@ -9,6 +9,7 @@ export const DangerCard = ({
   loading = false,
   disabled = false,
   onDelete,
+  'data-e2e': dataE2e,
 }: {
   title?: string;
   description?: string | React.ReactNode;
@@ -16,6 +17,7 @@ export const DangerCard = ({
   loading?: boolean;
   disabled?: boolean;
   onDelete: () => void;
+  'data-e2e'?: string;
 }) => {
   const isDisabled = loading || disabled;
   return (
@@ -39,6 +41,7 @@ export const DangerCard = ({
             theme="solid"
             size="xs"
             className="w-full md:w-auto"
+            data-e2e={dataE2e}
             disabled={isDisabled}
             loading={loading}
             onClick={onDelete}>

--- a/app/features/organization/settings/danger-card.tsx
+++ b/app/features/organization/settings/danger-card.tsx
@@ -47,6 +47,7 @@ export const OrganizationDangerCard = ({ organization }: { organization: Organiz
       deleteText="Delete organization"
       loading={deleteOrganization.isPending}
       onDelete={handleDeleteOrganization}
+      data-e2e="delete-organization-button"
     />
   );
 };

--- a/app/features/organization/settings/general-card.tsx
+++ b/app/features/organization/settings/general-card.tsx
@@ -63,7 +63,10 @@ export const OrganizationGeneralCard = ({ organization }: { organization: Organi
                   </Form.Field>
                 ) : (
                   <Form.Field name="description" label="Organization Name" required>
-                    <Form.Input data-e2e="edit-organization-name-input" placeholder="e.g. My Organization" />
+                    <Form.Input
+                      data-e2e="edit-organization-name-input"
+                      placeholder="e.g. My Organization"
+                    />
                   </Form.Field>
                 )}
                 <Form.Field name="name" label="Resource ID">

--- a/app/features/organization/settings/general-card.tsx
+++ b/app/features/organization/settings/general-card.tsx
@@ -63,7 +63,7 @@ export const OrganizationGeneralCard = ({ organization }: { organization: Organi
                   </Form.Field>
                 ) : (
                   <Form.Field name="description" label="Organization Name" required>
-                    <Form.Input placeholder="e.g. My Organization" />
+                    <Form.Input data-e2e="edit-organization-name-input" placeholder="e.g. My Organization" />
                   </Form.Field>
                 )}
                 <Form.Field name="name" label="Resource ID">
@@ -77,6 +77,7 @@ export const OrganizationGeneralCard = ({ organization }: { organization: Organi
                   htmlType="button"
                   type="quaternary"
                   theme="outline"
+                  data-e2e="edit-organization-cancel"
                   disabled={isSubmitting}
                   size="xs"
                   onClick={() => {
@@ -89,7 +90,7 @@ export const OrganizationGeneralCard = ({ organization }: { organization: Organi
                   }}>
                   Cancel
                 </Button>
-                <Form.Submit size="xs" loadingText="Saving">
+                <Form.Submit size="xs" loadingText="Saving" data-e2e="edit-organization-save">
                   Save
                 </Form.Submit>
               </CardFooter>

--- a/app/routes/account/organizations/index.tsx
+++ b/app/routes/account/organizations/index.tsx
@@ -172,6 +172,7 @@ export default function AccountOrganizations() {
                   type="primary"
                   theme="solid"
                   size="small"
+                  data-e2e="create-organization-button"
                   className="w-full sm:w-auto"
                   icon={<Icon icon={PlusIcon} className="size-4" />}>
                   Create organization
@@ -248,7 +249,7 @@ export default function AccountOrganizations() {
             label="Organization Name"
             description="Could be the name of your company or team. This can be changed."
             required>
-            <Form.Input placeholder="e.g. My Organization" autoFocus />
+            <Form.Input data-e2e="create-organization-name-input" placeholder="e.g. My Organization" autoFocus />
           </Form.Field>
 
           <Form.Field name="name">

--- a/app/routes/account/organizations/index.tsx
+++ b/app/routes/account/organizations/index.tsx
@@ -249,7 +249,11 @@ export default function AccountOrganizations() {
             label="Organization Name"
             description="Could be the name of your company or team. This can be changed."
             required>
-            <Form.Input data-e2e="create-organization-name-input" placeholder="e.g. My Organization" autoFocus />
+            <Form.Input
+              data-e2e="create-organization-name-input"
+              placeholder="e.g. My Organization"
+              autoFocus
+            />
           </Form.Field>
 
           <Form.Field name="name">

--- a/cypress/e2e/regression/organisations.cy.ts
+++ b/cypress/e2e/regression/organisations.cy.ts
@@ -42,11 +42,11 @@ describe('Organisations — regression', () => {
     // Wait for the resource ID to be auto-generated then submit
     cy.contains('button', 'Confirm').click();
 
-    // After creation the app navigates to the new org's detail page
+    // After creation the app navigates to /org/[orgId]/projects
     cy.url()
-      .should('match', /\/org\/[a-z0-9-]+$/)
+      .should('match', /\/org\/[a-z0-9-]+\//)
       .then((url) => {
-        createdOrgId = url.split('/org/')[1];
+        createdOrgId = url.split('/org/')[1].split('/')[0];
         Cypress.env('testOrgId', createdOrgId);
       });
   });

--- a/cypress/e2e/regression/organisations.cy.ts
+++ b/cypress/e2e/regression/organisations.cy.ts
@@ -43,10 +43,12 @@ describe('Organisations — regression', () => {
     cy.contains('button', 'Confirm').click();
 
     // After creation the app navigates to the new org's detail page
-    cy.url().should('match', /\/org\/[a-z0-9-]+$/).then((url) => {
-      createdOrgId = url.split('/org/')[1];
-      Cypress.env('testOrgId', createdOrgId);
-    });
+    cy.url()
+      .should('match', /\/org\/[a-z0-9-]+$/)
+      .then((url) => {
+        createdOrgId = url.split('/org/')[1];
+        Cypress.env('testOrgId', createdOrgId);
+      });
   });
 
   after(() => {

--- a/cypress/e2e/regression/organisations.cy.ts
+++ b/cypress/e2e/regression/organisations.cy.ts
@@ -1,0 +1,114 @@
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+
+/**
+ * Selector Reference — Organisations
+ *
+ * List page
+ * [data-e2e="organization-card-personal"]    Personal org row
+ * [data-e2e="organization-card-standard"]    Standard org row
+ * [data-e2e="organization-card-id-copy"]     Resource ID badge inside an org row
+ * [data-e2e="create-organization-button"]    "Create organization" button
+ *
+ * Create dialog
+ * [data-e2e="create-organization-name-input"] Organization Name input
+ *
+ * General settings
+ * [data-e2e="edit-organization-name-input"]  Organization Name input
+ * [data-e2e="edit-organization-save"]        Save button
+ * [data-e2e="edit-organization-cancel"]      Cancel button
+ *
+ * Danger zone
+ * [data-e2e="delete-organization-button"]    Delete organization button
+ *
+ * Confirmation dialog (shared)
+ * [data-e2e="confirmation-dialog-input"]     Type DELETE to confirm input
+ * [data-e2e="confirmation-dialog-submit"]    Confirm/Delete button
+ * [data-e2e="confirmation-dialog-cancel"]    Cancel button
+ */
+
+describe('Organisations — regression', () => {
+  const testOrgName = `e2e-test-org-${Date.now()}`;
+  let createdOrgId: string;
+
+  before(() => {
+    cy.login();
+
+    // Create org via UI
+    cy.visit(paths.account.organizations.root);
+    cy.get('[data-e2e="create-organization-button"]').click();
+    cy.get('[data-e2e="create-organization-name-input"]').type(testOrgName);
+
+    // Wait for the resource ID to be auto-generated then submit
+    cy.contains('button', 'Confirm').click();
+
+    // After creation the app navigates to the new org's detail page
+    cy.url().should('match', /\/org\/[a-z0-9-]+$/).then((url) => {
+      createdOrgId = url.split('/org/')[1];
+      Cypress.env('testOrgId', createdOrgId);
+    });
+  });
+
+  after(() => {
+    cy.login();
+    const orgId = createdOrgId || Cypress.env('testOrgId');
+    if (!orgId) return;
+
+    cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId }));
+    cy.get('[data-e2e="delete-organization-button"]').click();
+    cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
+    cy.get('[data-e2e="confirmation-dialog-submit"]').click();
+    cy.url().should('include', paths.account.organizations.root);
+  });
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('should appear in the organisations list after creation', () => {
+    cy.visit(paths.account.organizations.root);
+    cy.get('[data-e2e="organization-card-standard"]')
+      .should('have.length.at.least', 1)
+      .and('contain.text', testOrgName);
+  });
+
+  it('should load the org detail page', () => {
+    const orgId = createdOrgId || Cypress.env('testOrgId');
+    cy.visit(getPathWithParams(paths.org.detail.root, { orgId }));
+    cy.url().should('include', `/org/${orgId}`);
+  });
+
+  it('should update the org display name', () => {
+    const orgId = createdOrgId || Cypress.env('testOrgId');
+    const updatedName = `${testOrgName}-updated`;
+
+    cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId }));
+    cy.get('[data-e2e="edit-organization-name-input"]').clear().type(updatedName);
+    cy.get('[data-e2e="edit-organization-save"]').click();
+
+    // Toast confirms success — then verify the input reflects the saved value
+    cy.contains('The Organization has been updated successfully').should('be.visible');
+    cy.get('[data-e2e="edit-organization-name-input"]').should('have.value', updatedName);
+  });
+
+  it('should show quotas on the org quotas tab', () => {
+    const orgId = createdOrgId || Cypress.env('testOrgId');
+    cy.visit(getPathWithParams(paths.org.detail.settings.quotas, { orgId }));
+    cy.get('[data-e2e="org-quota-card"]').should('have.length.at.least', 1);
+  });
+
+  it('should delete the org and remove it from the list', () => {
+    const orgId = createdOrgId || Cypress.env('testOrgId');
+
+    cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId }));
+    cy.get('[data-e2e="delete-organization-button"]').click();
+    cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
+    cy.get('[data-e2e="confirmation-dialog-submit"]').click();
+
+    cy.url().should('include', paths.account.organizations.root);
+    cy.get('[data-e2e="organization-card-standard"]').should('not.contain.text', testOrgName);
+
+    // Mark cleaned up so after() skips re-deleting
+    Cypress.env('testOrgId', null);
+  });
+});

--- a/cypress/e2e/regression/organisations.cy.ts
+++ b/cypress/e2e/regression/organisations.cy.ts
@@ -5,58 +5,54 @@ import { getPathWithParams } from '@/utils/helpers/path.helper';
  * Selector Reference — Organisations
  *
  * List page
- * [data-e2e="organization-card-personal"]    Personal org row
- * [data-e2e="organization-card-standard"]    Standard org row
- * [data-e2e="organization-card-id-copy"]     Resource ID badge inside an org row
- * [data-e2e="create-organization-button"]    "Create organization" button
+ * [data-e2e="organization-card-personal"]     Personal org row
+ * [data-e2e="organization-card-standard"]     Standard org row
+ * [data-e2e="create-organization-button"]     "Create organization" button
  *
  * Create dialog
  * [data-e2e="create-organization-name-input"] Organization Name input
  *
  * General settings
- * [data-e2e="edit-organization-name-input"]  Organization Name input
- * [data-e2e="edit-organization-save"]        Save button
- * [data-e2e="edit-organization-cancel"]      Cancel button
+ * [data-e2e="edit-organization-name-input"]   Organization Name input
+ * [data-e2e="edit-organization-save"]         Save button
+ * [data-e2e="edit-organization-cancel"]       Cancel button
  *
  * Danger zone
- * [data-e2e="delete-organization-button"]    Delete organization button
+ * [data-e2e="delete-organization-button"]     Delete organization button
  *
  * Confirmation dialog (shared)
- * [data-e2e="confirmation-dialog-input"]     Type DELETE to confirm input
- * [data-e2e="confirmation-dialog-submit"]    Confirm/Delete button
- * [data-e2e="confirmation-dialog-cancel"]    Cancel button
+ * [data-e2e="confirmation-dialog-input"]      Type DELETE to confirm input
+ * [data-e2e="confirmation-dialog-submit"]     Confirm/Delete button
+ * [data-e2e="confirmation-dialog-cancel"]     Cancel button
  */
 
 describe('Organisations — regression', () => {
-  const testOrgName = `e2e-test-org-${Date.now()}`;
-  let createdOrgId: string;
+  const testName = `e2e-test-org-${Date.now()}`;
+  const updatedName = `${testName}-updated`;
+  let resourceId = '';
 
+  // Creates the test org once before all tests in this suite.
+  // If this fails, all tests are skipped — fix before() first.
   before(() => {
     cy.login();
-
-    // Create org via UI
     cy.visit(paths.account.organizations.root);
     cy.get('[data-e2e="create-organization-button"]').click();
-    cy.get('[data-e2e="create-organization-name-input"]').type(testOrgName);
-
-    // Wait for the resource ID to be auto-generated then submit
+    cy.get('[data-e2e="create-organization-name-input"]').type(testName);
     cy.contains('button', 'Confirm').click();
-
-    // After creation the app navigates to /org/[orgId]/projects
+    // App redirects to /org/[orgId]/projects after creation
     cy.url()
       .should('match', /\/org\/[a-z0-9-]+\//)
       .then((url) => {
-        createdOrgId = url.split('/org/')[1].split('/')[0];
-        Cypress.env('testOrgId', createdOrgId);
+        resourceId = url.split('/org/')[1].split('/')[0];
       });
   });
 
+  // Safety net — deletes the org if any test failed before the delete test ran.
+  // If the delete test already ran it sets resourceId = '' so this is a no-op.
   after(() => {
+    if (!resourceId) return;
     cy.login();
-    const orgId = createdOrgId || Cypress.env('testOrgId');
-    if (!orgId) return;
-
-    cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId }));
+    cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId: resourceId }));
     cy.get('[data-e2e="delete-organization-button"]').click();
     cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
     cy.get('[data-e2e="confirmation-dialog-submit"]').click();
@@ -71,46 +67,37 @@ describe('Organisations — regression', () => {
     cy.visit(paths.account.organizations.root);
     cy.get('[data-e2e="organization-card-standard"]')
       .should('have.length.at.least', 1)
-      .and('contain.text', testOrgName);
+      .and('contain.text', testName);
   });
 
   it('should load the org detail page', () => {
-    const orgId = createdOrgId || Cypress.env('testOrgId');
-    cy.visit(getPathWithParams(paths.org.detail.root, { orgId }));
-    cy.url().should('include', `/org/${orgId}`);
+    cy.visit(getPathWithParams(paths.org.detail.root, { orgId: resourceId }));
+    cy.url().should('include', `/org/${resourceId}`);
   });
 
   it('should update the org display name', () => {
-    const orgId = createdOrgId || Cypress.env('testOrgId');
-    const updatedName = `${testOrgName}-updated`;
-
-    cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId }));
-    cy.get('[data-e2e="edit-organization-name-input"]').clear().type(updatedName);
+    cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId: resourceId }));
+    // Clear and type as separate queries — React re-renders after clear() detach the node
+    cy.get('[data-e2e="edit-organization-name-input"]').clear();
+    cy.get('[data-e2e="edit-organization-name-input"]').type(updatedName);
     cy.get('[data-e2e="edit-organization-save"]').click();
-
-    // Toast confirms success — then verify the input reflects the saved value
     cy.contains('The Organization has been updated successfully').should('be.visible');
     cy.get('[data-e2e="edit-organization-name-input"]').should('have.value', updatedName);
   });
 
   it('should show quotas on the org quotas tab', () => {
-    const orgId = createdOrgId || Cypress.env('testOrgId');
-    cy.visit(getPathWithParams(paths.org.detail.settings.quotas, { orgId }));
+    cy.visit(getPathWithParams(paths.org.detail.settings.quotas, { orgId: resourceId }));
     cy.get('[data-e2e="org-quota-card"]').should('have.length.at.least', 1);
   });
 
   it('should delete the org and remove it from the list', () => {
-    const orgId = createdOrgId || Cypress.env('testOrgId');
-
-    cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId }));
+    cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId: resourceId }));
     cy.get('[data-e2e="delete-organization-button"]').click();
     cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
     cy.get('[data-e2e="confirmation-dialog-submit"]').click();
-
     cy.url().should('include', paths.account.organizations.root);
-    cy.get('[data-e2e="organization-card-standard"]').should('not.contain.text', testOrgName);
-
-    // Mark cleaned up so after() skips re-deleting
-    Cypress.env('testOrgId', null);
+    cy.get('[data-e2e="organization-card-standard"]').should('not.contain.text', testName);
+    // Clear last — signals after() that cleanup is done
+    resourceId = '';
   });
 });


### PR DESCRIPTION
## Summary

- Adds `data-e2e` attributes to all interactive org UI elements needed for regression testing (create button, form inputs, save/cancel, delete button,  confirmation dialog)
- `DangerCard` and `ConfirmationDialog` now support `data-e2e` passthrough — these are shared components that all future regression tests (projects, DNS zones, secrets, etc.) will reuse
- Adds `cypress/e2e/regression/organisations.cy.ts` covering full CRUD: create → detail loads → update name → quotas tab → delete
- Test manages its own data lifecycle (`before` creates, `after` cleans up) so it leaves the environment clean on both pass and fail

> **Note:** Regression tests are temporarily enabled on PRs to verify this works. Will be reverted to `main`-only after confirmation.

## Test plan

- [ ] E2E Smoke Tests pass
- [ ] E2E Regression Tests pass (all 5 org tests)
- [ ] Verify org is created and deleted cleanly in the test environment (no leftover `e2e-test-org-*` orgs after the run)

Ref https://github.com/datum-cloud/cloud-portal/issues/915
