### PR TITLE
feat(e2e): project and members regression tests

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -207,6 +207,7 @@ jobs:
           AUTH_OIDC_ISSUER=$AUTH_OIDC_ISSUER
           AUTH_OIDC_CLIENT_ID=$AUTH_OIDC_CLIENT_ID
           SESSION_SECRET=$SESSION_SECRET
+          LOG_LEVEL=warn
           CYPRESS_BASE_URL=http://localhost:3000
           EOF
 
@@ -290,6 +291,7 @@ jobs:
           AUTH_OIDC_ISSUER=$AUTH_OIDC_ISSUER
           AUTH_OIDC_CLIENT_ID=$AUTH_OIDC_CLIENT_ID
           SESSION_SECRET=$SESSION_SECRET
+          LOG_LEVEL=warn
           CYPRESS_BASE_URL=http://localhost:3000
           EOF
 

--- a/app/features/organization/team/invitation-form.tsx
+++ b/app/features/organization/team/invitation-form.tsx
@@ -81,6 +81,7 @@ export const InvitationForm = ({ onSubmit, isSubmitting }: InvitationFormProps) 
                 delimiters={['Enter', ',', ';', ' ']}
                 normalizer={(val) => val.toLowerCase()}
                 showValidationErrors={false}
+                data-e2e="invite-emails-input"
               />
             )}
           </Form.Field>
@@ -89,7 +90,9 @@ export const InvitationForm = ({ onSubmit, isSubmitting }: InvitationFormProps) 
           <Form.Button onClick={() => navigate(-1)} disableOnSubmit>
             Return to List
           </Form.Button>
-          <Form.Submit loadingText="Inviting">Invite</Form.Submit>
+          <Form.Submit loadingText="Inviting" data-e2e="invite-submit">
+            Invite
+          </Form.Submit>
         </CardFooter>
       </Form.Root>
     </Card>

--- a/app/features/project/settings/danger-card.tsx
+++ b/app/features/project/settings/danger-card.tsx
@@ -53,6 +53,7 @@ export const ProjectDangerCard = ({ project }: { project: Project }) => {
       deleteText="Delete project"
       loading={deleteMutation.isPending}
       onDelete={deleteProject}
+      data-e2e="delete-project-button"
     />
   );
 };

--- a/app/features/project/settings/general-card.tsx
+++ b/app/features/project/settings/general-card.tsx
@@ -58,7 +58,7 @@ export const ProjectGeneralCard = ({ project }: { project: Project }) => {
             <CardContent className="px-5 py-4">
               <div className="flex max-w-sm flex-col gap-5">
                 <Form.Field name="description" label="Project name" required>
-                  <Form.Input placeholder="e.g. My Project" />
+                  <Form.Input data-e2e="edit-project-name-input" placeholder="e.g. My Project" />
                 </Form.Field>
 
                 <Form.Field name="name" label="Resource ID">
@@ -71,6 +71,7 @@ export const ProjectGeneralCard = ({ project }: { project: Project }) => {
                 htmlType="button"
                 type="quaternary"
                 theme="outline"
+                data-e2e="edit-project-cancel"
                 disabled={isSubmitting}
                 size="xs"
                 onClick={() => {
@@ -83,7 +84,7 @@ export const ProjectGeneralCard = ({ project }: { project: Project }) => {
                 }}>
                 Cancel
               </Button>
-              <Form.Submit size="xs" loadingText="Saving">
+              <Form.Submit size="xs" loadingText="Saving" data-e2e="edit-project-save">
                 Save
               </Form.Submit>
             </CardFooter>

--- a/app/modules/datum-ui/components/data-table/core/data-table.types.ts
+++ b/app/modules/datum-ui/components/data-table/core/data-table.types.ts
@@ -238,6 +238,7 @@ export interface DataTableRowActionsProps<TData> {
    * The action() callback will still be called before opening (for optional pre-logic)
    */
   triggerInlineEdit?: boolean;
+  'data-e2e'?: string;
 }
 
 // =============================================================================

--- a/app/modules/datum-ui/components/data-table/features/actions/data-table-inline-actions.tsx
+++ b/app/modules/datum-ui/components/data-table/features/actions/data-table-inline-actions.tsx
@@ -54,6 +54,7 @@ export const DataTableInlineActions = <TData,>({
             size={showLabel ? 'small' : 'icon'}
             onClick={handleClick}
             disabled={isActionDisabled}
+            data-e2e={action['data-e2e']}
             className={cn('h-7 px-2', action.className)}>
             {action.icon}
             {showLabel && <span className="text-xs">{action.label}</span>}

--- a/app/routes/org/detail/projects/index.tsx
+++ b/app/routes/org/detail/projects/index.tsx
@@ -261,6 +261,7 @@ export default function OrgProjectsPage() {
                   type="primary"
                   theme="solid"
                   size="small"
+                  data-e2e="create-project-button"
                   className="w-full sm:w-auto"
                   onClick={() => setOpenDialog(true)}>
                   <Icon icon={PlusIcon} className="size-4" />
@@ -339,7 +340,11 @@ export default function OrgProjectsPage() {
             label="Project name"
             description="Could be the name of a site, initiative, project, goal, whatever works. Can be changed."
             required>
-            <Form.Input placeholder="e.g. My Project" autoFocus />
+            <Form.Input
+              data-e2e="create-project-name-input"
+              placeholder="e.g. My Project"
+              autoFocus
+            />
           </Form.Field>
 
           <Form.Field name="name">

--- a/app/routes/org/detail/team/index.tsx
+++ b/app/routes/org/detail/team/index.tsx
@@ -304,6 +304,7 @@ export default function OrgTeamPage() {
         hidden: (row: ITeamMember) =>
           row.type !== 'invitation' || row.invitationState !== 'Pending',
         action: (row: ITeamMember) => resendInvitation(row.id),
+        'data-e2e': 'resend-invitation-button',
       },
       // Cancel invitation (for invites only)
       {
@@ -314,6 +315,7 @@ export default function OrgTeamPage() {
         icon: <Icon icon={TrashIcon} className="size-4" />,
         hidden: (row: ITeamMember) => row.type !== 'invitation',
         action: (row: ITeamMember) => cancelInvitation(row),
+        'data-e2e': 'cancel-invitation-button',
       },
       // Remove member (for OTHER members, not self)
       {
@@ -388,7 +390,7 @@ export default function OrgTeamPage() {
                 orgId,
               })}
               className="w-full sm:w-auto">
-              <Button className="w-full">
+              <Button className="w-full" data-e2e="invite-member-button">
                 <Icon icon={UserPlusIcon} className="size-4" />
                 Invite Member
               </Button>

--- a/cypress/e2e/regression/members.cy.ts
+++ b/cypress/e2e/regression/members.cy.ts
@@ -1,0 +1,82 @@
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+
+/**
+ * Selector Reference — Members & Invitations
+ *
+ * Team list page
+ * [data-e2e="invite-member-button"]       "Invite Member" button
+ *
+ * Invite form page
+ * [data-e2e="invite-emails-input"]        Emails TagsInput container
+ * [data-e2e="invite-submit"]              Invite submit button
+ *
+ * Row actions (inline)
+ * [data-e2e="resend-invitation-button"]   Resend invitation button
+ * [data-e2e="cancel-invitation-button"]   Cancel invitation button
+ *
+ * Confirmation dialog (shared)
+ * [data-e2e="confirmation-dialog-submit"] Confirm button
+ *
+ * Note: Team pages require a Standard org — personal orgs return 500.
+ * This suite creates a dedicated Standard org in before() and cleans it up in after().
+ */
+
+describe('Members & Invitations — regression', () => {
+  const orgName = `e2e-test-members-${Date.now()}`;
+  const testEmail = `e2e-${Date.now()}@example.com`;
+  let orgId = '';
+
+  // Keep this simple: Cypress retries this query until timeout.
+  const invitationRow = (email: string): Cypress.Chainable<JQuery<HTMLElement>> =>
+    cy.contains('table tbody tr', email, { timeout: 60000 }).should('be.visible');
+
+  // Create a Standard org — team pages are restricted to Standard orgs only.
+  before(() => {
+    cy.login();
+    cy.createStandardOrg(orgName).then((id) => {
+      orgId = id;
+    });
+  });
+
+  after(() => {
+    if (!orgId) return;
+    cy.login();
+    cy.deleteOrganizationIfExists(orgId);
+  });
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('should show at least one member on the team page', () => {
+    cy.visit(getPathWithParams(paths.org.detail.team.root, { orgId }));
+    cy.get('table tbody tr').should('have.length.at.least', 1);
+  });
+
+  it('should invite a member', () => {
+    cy.visit(getPathWithParams(paths.org.detail.team.invite, { orgId }));
+    // Role is required — open the combobox and pick the first available option
+    cy.get('[role="combobox"]').first().click();
+    cy.get('[role="option"]').first().click();
+    cy.get('[data-e2e="invite-emails-input"] input').type(`${testEmail}{enter}`);
+    cy.get('[data-e2e="invite-submit"]').click();
+    // Form navigates to team root on success — invitation can take time to materialize.
+    invitationRow(testEmail);
+  });
+
+  it('should show a resend outcome message', () => {
+    cy.visit(getPathWithParams(paths.org.detail.team.root, { orgId }));
+    invitationRow(testEmail).closest('tr').find('[data-e2e="resend-invitation-button"]').click();
+    cy.contains(
+      /Invitation resent successfully|Please wait .* before resending this invitation/i
+    ).should('be.visible');
+  });
+
+  it('should cancel the invitation', () => {
+    cy.visit(getPathWithParams(paths.org.detail.team.root, { orgId }));
+    invitationRow(testEmail).closest('tr').find('[data-e2e="cancel-invitation-button"]').click();
+    cy.get('[data-e2e="confirmation-dialog-submit"]').click();
+    cy.contains('table tbody tr', testEmail).should('not.exist');
+  });
+});

--- a/cypress/e2e/regression/organisations.cy.ts
+++ b/cypress/e2e/regression/organisations.cy.ts
@@ -35,16 +35,9 @@ describe('Organisations — regression', () => {
   // If this fails, all tests are skipped — fix before() first.
   before(() => {
     cy.login();
-    cy.visit(paths.account.organizations.root);
-    cy.get('[data-e2e="create-organization-button"]').click();
-    cy.get('[data-e2e="create-organization-name-input"]').type(testName);
-    cy.contains('button', 'Confirm').click();
-    // App redirects to /org/[orgId]/projects after creation
-    cy.url()
-      .should('match', /\/org\/[a-z0-9-]+\//)
-      .then((url) => {
-        resourceId = url.split('/org/')[1].split('/')[0];
-      });
+    cy.createStandardOrg(testName).then((id) => {
+      resourceId = id;
+    });
   });
 
   // Safety net — deletes the org if any test failed before the delete test ran.
@@ -52,11 +45,7 @@ describe('Organisations — regression', () => {
   after(() => {
     if (!resourceId) return;
     cy.login();
-    cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId: resourceId }));
-    cy.get('[data-e2e="delete-organization-button"]').click();
-    cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
-    cy.get('[data-e2e="confirmation-dialog-submit"]').click();
-    cy.url().should('include', paths.account.organizations.root);
+    cy.deleteOrganizationIfExists(resourceId);
   });
 
   beforeEach(() => {

--- a/cypress/e2e/regression/projects.cy.ts
+++ b/cypress/e2e/regression/projects.cy.ts
@@ -1,0 +1,99 @@
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+
+/**
+ * Selector Reference — Projects
+ *
+ * List page
+ * [data-e2e="project-card"]               Project row
+ * [data-e2e="project-card-id-copy"]       Resource ID badge inside a project row
+ * [data-e2e="create-project-button"]      "Create project" button
+ *
+ * Create dialog
+ * [data-e2e="create-project-name-input"]  Project name input
+ *
+ * General settings
+ * [data-e2e="edit-project-name-input"]    Project name input
+ * [data-e2e="edit-project-save"]          Save button
+ * [data-e2e="edit-project-cancel"]        Cancel button
+ *
+ * Danger zone
+ * [data-e2e="delete-project-button"]      Delete project button
+ *
+ * Confirmation dialog (shared)
+ * [data-e2e="confirmation-dialog-input"]  Type DELETE to confirm input
+ * [data-e2e="confirmation-dialog-submit"] Confirm/Delete button
+ * [data-e2e="confirmation-dialog-cancel"] Cancel button
+ */
+
+describe('Projects — regression', () => {
+  const orgName = `e2e-test-projects-org-${Date.now()}`;
+  const testName = `e2e-test-project-${Date.now()}`;
+  const updatedName = `${testName}-updated`;
+  let orgId = '';
+  let resourceId = '';
+
+  // Creates the test project once before all tests in this suite.
+  // Project creation uses a background task queue (K8s reconciliation) so the
+  // dialog closes immediately — we wait for the card to appear in the list
+  // and extract the ID from there rather than from a URL redirect.
+  before(() => {
+    cy.login();
+    cy.createStandardOrg(orgName)
+      .then((id) => {
+        orgId = id;
+        return cy.createProjectInOrg(id, testName);
+      })
+      .then((id) => {
+        resourceId = id;
+      });
+  });
+
+  // Safety net — delete project and test org if tests fail early.
+  after(() => {
+    cy.login();
+    cy.deleteProjectIfExists(resourceId, orgId);
+    cy.deleteOrganizationIfExists(orgId);
+  });
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('should appear in the projects list after creation', () => {
+    cy.visit(getPathWithParams(paths.org.detail.projects.root, { orgId }));
+    cy.get('[data-e2e="project-card"]')
+      .should('have.length.at.least', 1)
+      .and('contain.text', testName);
+  });
+
+  it('should load the project detail page', () => {
+    cy.visit(getPathWithParams(paths.project.detail.root, { projectId: resourceId }));
+    cy.url().should('include', `/project/${resourceId}`);
+  });
+
+  it('should update the project display name', () => {
+    cy.visit(getPathWithParams(paths.project.detail.settings.general, { projectId: resourceId }));
+    cy.get('[data-e2e="edit-project-name-input"]').clear();
+    cy.get('[data-e2e="edit-project-name-input"]').type(updatedName);
+    cy.get('[data-e2e="edit-project-save"]').click();
+    cy.contains('The Project has been updated successfully').should('be.visible');
+    cy.get('[data-e2e="edit-project-name-input"]').should('have.value', updatedName);
+  });
+
+  it('should show quotas on the project quotas tab', () => {
+    cy.visit(getPathWithParams(paths.project.detail.settings.quotas, { projectId: resourceId }));
+    cy.get('[data-e2e="project-quota-card"]').should('have.length.at.least', 1);
+  });
+
+  it('should delete the project and remove it from the list', () => {
+    cy.visit(getPathWithParams(paths.project.detail.settings.general, { projectId: resourceId }));
+    cy.get('[data-e2e="delete-project-button"]').click();
+    cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
+    cy.get('[data-e2e="confirmation-dialog-submit"]').click();
+    cy.url().should('include', paths.org.detail.projects.root.replace('[orgId]', orgId));
+    cy.get('body').should('not.contain.text', testName);
+    // Clear last — signals after() that cleanup is done
+    resourceId = '';
+  });
+});

--- a/cypress/e2e/smoke/organisations.cy.ts
+++ b/cypress/e2e/smoke/organisations.cy.ts
@@ -120,34 +120,13 @@ describe('Load org list', () => {
       cy.visit(getPathWithParams(paths.org.detail.settings.activity, { orgId: personalOrgId }));
     });
 
-    // Check if activity table has data or shows empty state
-    cy.get('body').then(($body) => {
-      const activityCards = $body.find('[data-e2e="activity-card"]');
-
-      if (activityCards.length > 0) {
-        // Activity table has data - verify each row
-        cy.get('[data-e2e="activity-card"]').should('have.length.at.least', 1);
-
-        cy.get('[data-e2e="activity-card"]').each(($card, index) => {
-          // User - should be visible (org activity shows user column)
-          cy.get('[data-e2e="activity-user"]').eq(index).should('be.visible');
-
-          // Action - should be visible and not empty
-          cy.get('[data-e2e="activity-action"]').eq(index).should('be.visible').and('not.be.empty');
-
-          // Target/Details - should be visible
-          cy.get('[data-e2e="activity-target"]').eq(index).should('be.visible');
-
-          // Date - should be visible and not empty
-          cy.get('[data-e2e="activity-date"]').eq(index).should('be.visible').and('not.be.empty');
-
-          cy.log(`Verified row ${index + 1} in org activity table`);
-        });
-      } else {
-        // No activity cards found - verify empty state message
-        cy.contains('No activity found').should('be.visible');
-        cy.log('Verified empty state: No activity found');
-      }
+    // Use a should() callback so Cypress retries until loading resolves.
+    // A synchronous $body.find() check (inside .then()) races against the API
+    // response and must not be used — it resolves before data arrives.
+    cy.get('body', { timeout: 10000 }).should(($body) => {
+      const hasCards = $body.find('[data-e2e="activity-card"]').length > 0;
+      const hasEmpty = $body.text().includes('No activity found');
+      expect(hasCards || hasEmpty, 'activity table should show data or empty state').to.be.true;
     });
   });
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -83,6 +83,12 @@ Cypress.on('uncaught:exception', (err) => {
 // Aggressively prevent any parent window navigation
 // This runs before every page load to protect the Cypress UI window
 Cypress.on('window:before:load', (win) => {
+  // Optional CI noise reduction: silence browser console.info output.
+  // Enable with CYPRESS_E2E_SILENCE_INFO_LOGS=true
+  if (Cypress.env('E2E_SILENCE_INFO_LOGS')) {
+    win.console.info = () => {};
+  }
+
   try {
     // Override window.top to always return the current window
     const originalTop = win.top;
@@ -211,6 +217,111 @@ Cypress.Commands.add('logout', () => {
   cy.getCookie('_session').should('not.exist');
 });
 
+/**
+ * Create a standard org and return its orgId (resource name).
+ */
+Cypress.Commands.add('createStandardOrg', (displayName: string): Cypress.Chainable<string> => {
+  cy.visit(paths.account.organizations.root);
+  cy.get('[data-e2e="create-organization-button"]').click();
+  cy.get('[data-e2e="create-organization-name-input"]').type(displayName);
+  cy.contains('button', 'Confirm').click();
+
+  return cy
+    .url({ timeout: 30000 })
+    .should('match', /\/org\/[a-z0-9-]+\//)
+    .then((url) => {
+      const parsedOrgId = url.split('/org/')[1]?.split('/')[0]?.trim();
+      if (!parsedOrgId) {
+        throw new Error('Failed to extract created orgId from URL');
+      }
+      return parsedOrgId;
+    })
+    .then((parsedOrgId) => cy.wrap(parsedOrgId, { log: false }));
+});
+
+/**
+ * Create a project in an org and return projectId (resource name).
+ */
+Cypress.Commands.add(
+  'createProjectInOrg',
+  (orgId: string, displayName: string): Cypress.Chainable<string> => {
+    cy.visit(getPathWithParams(paths.org.detail.projects.root, { orgId }));
+    cy.url({ timeout: 30000 }).should(
+      'include',
+      paths.org.detail.projects.root.replace('[orgId]', orgId)
+    );
+    cy.get('body', { timeout: 30000 }).then(($body) => {
+      const hasToolbarCreate = $body.find('[data-e2e="create-project-button"]').length > 0;
+      if (hasToolbarCreate) {
+        cy.get('[data-e2e="create-project-button"]').should('be.visible').click();
+        return;
+      }
+
+      // Fresh org empty state uses a generic "Create project" button without data-e2e.
+      cy.contains('button', /^Create project$/i, { timeout: 30000 })
+        .should('be.visible')
+        .click();
+    });
+    cy.get('[data-e2e="create-project-name-input"]').type(displayName);
+    cy.contains('button', 'Confirm').click();
+
+    return cy
+      .contains('[data-e2e="project-card"]', displayName, { timeout: 90000 })
+      .find('[data-e2e="project-card-id-copy"]')
+      .invoke('text')
+      .then((projectId: string) => {
+        const trimmedId = projectId.trim();
+        if (!trimmedId) {
+          throw new Error('Created project card found, but project ID badge was empty.');
+        }
+        return trimmedId;
+      })
+      .then((trimmedId) => cy.wrap(trimmedId, { log: false }));
+  }
+);
+
+/**
+ * Best-effort project cleanup for regression suites.
+ */
+Cypress.Commands.add('deleteProjectIfExists', (projectId: string, orgId?: string) => {
+  if (!projectId) return;
+
+  cy.visit(getPathWithParams(paths.project.detail.settings.general, { projectId }));
+  cy.get('body').then(($body) => {
+    if (!$body.find('[data-e2e="delete-project-button"]').length) return;
+
+    cy.get('[data-e2e="delete-project-button"]').click();
+    cy.get('body').then(($dialogBody) => {
+      if (!$dialogBody.find('[data-e2e="confirmation-dialog-input"]').length) return;
+      cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
+      cy.get('[data-e2e="confirmation-dialog-submit"]').click();
+    });
+    if (orgId) {
+      cy.url().should('include', paths.org.detail.projects.root.replace('[orgId]', orgId));
+    }
+  });
+});
+
+/**
+ * Best-effort org cleanup for regression suites.
+ */
+Cypress.Commands.add('deleteOrganizationIfExists', (orgId: string) => {
+  if (!orgId) return;
+
+  cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId }));
+  cy.get('body').then(($body) => {
+    if (!$body.find('[data-e2e="delete-organization-button"]').length) return;
+
+    cy.get('[data-e2e="delete-organization-button"]').click();
+    cy.get('body').then(($dialogBody) => {
+      if (!$dialogBody.find('[data-e2e="confirmation-dialog-input"]').length) return;
+      cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
+      cy.get('[data-e2e="confirmation-dialog-submit"]').click();
+      cy.url().should('include', paths.account.organizations.root);
+    });
+  });
+});
+
 // TypeScript declarations for custom commands
 declare global {
   namespace Cypress {
@@ -245,6 +356,30 @@ declare global {
        * @example cy.logout()
        */
       logout(): Chainable<void>;
+
+      /**
+       * Create a standard organization and return its resource ID.
+       * @example cy.createStandardOrg('e2e-test-org').then((orgId) => { ... })
+       */
+      createStandardOrg(displayName: string): Chainable<string>;
+
+      /**
+       * Create a project in an org and return its resource ID.
+       * @example cy.createProjectInOrg(orgId, 'e2e-test-project').then((projectId) => { ... })
+       */
+      createProjectInOrg(orgId: string, displayName: string): Chainable<string>;
+
+      /**
+       * Best-effort cleanup: delete project if it still exists.
+       * @example cy.deleteProjectIfExists(projectId, orgId)
+       */
+      deleteProjectIfExists(projectId: string, orgId?: string): Chainable<void>;
+
+      /**
+       * Best-effort cleanup: delete org if it still exists.
+       * @example cy.deleteOrganizationIfExists(orgId)
+       */
+      deleteOrganizationIfExists(orgId: string): Chainable<void>;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `data-e2e` attributes to project create/edit/delete UI components
- Add `data-e2e` support to `DataTableRowActionsProps` and thread it through `DataTableInlineActions` Button
- Add `data-e2e` attributes to team invite button, invite form inputs, and resend/cancel row actions
- Add `cypress/e2e/regression/projects.cy.ts` — full project CRUD: create, detail page, update name, quotas tab, delete
- Add `cypress/e2e/regression/members.cy.ts` — invitation flow: list members, invite by email, resend invite, cancel invite

## Test plan

- [ ] Smoke tests pass on PR
- [ ] Regression tests pass when run manually against a live environment (`bunx cypress run --spec "cypress/e2e/regression/projects.cy.ts,cypress/e2e/regression/members.cy.ts"`)
- [ ] Project card appears in list after task queue completes (30s timeout)
- [ ] Invitation row shows resend/cancel buttons; both actions produce expected feedback
