### PR TITLE
feat: auto-set project month field on PR open

### DIFF
--- a/.github/workflows/set-project-month.yaml
+++ b/.github/workflows/set-project-month.yaml
@@ -1,0 +1,10 @@
+name: Set Project Month
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  set-month:
+    uses: datum-cloud/actions/.github/workflows/set-project-month.yaml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds the `set-project-month` reusable workflow from `datum-cloud/actions`
- Automatically adds new PRs to the org project (#60) and sets the **Month** field to the current calendar month (e.g. `May 2026`)
- Triggers on `opened`, `ready_for_review`, and `reopened` events
- Requires the `ORG_PROJECT_TOKEN` org secret to be set (classic PAT with `project` scope)

## Test plan

- [ ] Merge datum-cloud/actions#61 first
- [ ] Confirm `ORG_PROJECT_TOKEN` org secret is in place
- [ ] Open a test PR and verify it appears in project #60 with the correct Month set