### PR TITLE
feat(e2e): add domains, secrets, and AI Edge regression tests

### DIFF
--- a/app/features/edge/domain/domain-form-dialog.tsx
+++ b/app/features/edge/domain/domain-form-dialog.tsx
@@ -69,7 +69,11 @@ export const DomainFormDialog = forwardRef<DomainFormDialogRef, DomainFormDialog
           description="Enter the domain where your service is running"
           required
           className="px-5">
-          <Form.Input placeholder="e.g. example.com" autoFocus />
+          <Form.Input
+            placeholder="e.g. example.com"
+            autoFocus
+            data-e2e="create-domain-name-input"
+          />
         </Form.Field>
       </Form.Dialog>
     );

--- a/app/features/edge/proxy/proxy-form-dialog.tsx
+++ b/app/features/edge/proxy/proxy-form-dialog.tsx
@@ -122,7 +122,12 @@ export const HttpProxyFormDialog = forwardRef<HttpProxyFormDialogRef, HttpProxyF
                       Name {meta.required && <span className="text-destructive/80">*</span>}
                     </label>
                   </div>
-                  <Form.Input autoFocus placeholder="e.g. Customer API" className="-mb-0.5" />
+                  <Form.Input
+                    autoFocus
+                    placeholder="e.g. Customer API"
+                    className="-mb-0.5"
+                    data-e2e="create-ai-edge-name-input"
+                  />
                   <input type="hidden" name="name" value={resourceName} />
                 </div>
               );

--- a/app/features/secret/form/overview/danger-card.tsx
+++ b/app/features/secret/form/overview/danger-card.tsx
@@ -46,6 +46,7 @@ export const SecretDangerCard = ({ secret }: { secret: ISecretControlResponse })
       deleteText="Delete secret"
       loading={deleteSecretMutation.isPending}
       onDelete={deleteSecret}
+      data-e2e="delete-secret-button"
     />
   );
 };

--- a/app/routes/project/detail/domains/detail/settings.tsx
+++ b/app/routes/project/detail/domains/detail/settings.tsx
@@ -72,6 +72,7 @@ export default function DomainSettingsPage() {
           deleteText="Delete domain"
           loading={deleteDomainMutation.isPending}
           onDelete={deleteDomain}
+          data-e2e="delete-domain-button"
         />
       </Col>
     </Row>

--- a/app/routes/project/detail/domains/index.tsx
+++ b/app/routes/project/detail/domains/index.tsx
@@ -520,6 +520,7 @@ export default function DomainsPage() {
                 theme="solid"
                 size="small"
                 className="w-full sm:w-auto"
+                data-e2e="create-domain-button"
                 onClick={() => domainFormRef.current?.show()}>
                 <Icon icon={PlusIcon} className="size-4" />
                 Add domain

--- a/app/routes/project/detail/edge/detail/index.tsx
+++ b/app/routes/project/detail/edge/detail/index.tsx
@@ -93,6 +93,7 @@ export default function HttpProxyDetailPage() {
             deleteText="Delete AI Edge"
             loading={isDeleting}
             onDelete={() => confirmDelete(effectiveProxy)}
+            data-e2e="delete-ai-edge-button"
           />
         </Col>
       </Row>

--- a/app/routes/project/detail/edge/index.tsx
+++ b/app/routes/project/detail/edge/index.tsx
@@ -259,6 +259,7 @@ export default function HttpProxyPage() {
               theme="solid"
               size="small"
               className="w-full sm:w-auto"
+              data-e2e="create-ai-edge-button"
               onClick={() => proxyFormRef.current?.show()}>
               <Icon icon={PlusIcon} className="size-4" />
               New

--- a/app/routes/project/detail/secrets/index.tsx
+++ b/app/routes/project/detail/secrets/index.tsx
@@ -169,6 +169,7 @@ export default function SecretsPage() {
               theme="solid"
               size="small"
               className="w-full sm:w-auto"
+              data-e2e="create-secret-button"
               onClick={() => secretFormDialogRef.current?.show()}>
               <Icon icon={PlusIcon} className="size-4" />
               Add secret

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,3 +1,4 @@
+import { registerSharedResourceTasks } from './cypress/support/shared-resources';
 import { defineConfig } from 'cypress';
 import cypressSplit from 'cypress-split';
 import 'dotenv/config';
@@ -18,6 +19,10 @@ export default defineConfig({
     supportFile: 'cypress/support/e2e.ts',
     setupNodeEvents(on, config) {
       cypressSplit(on, config);
+
+      // Shared regression resources (1 org + 1 project per shard)
+      registerSharedResourceTasks(on);
+
       on('task', {
         log(message) {
           console.log(message);

--- a/cypress/e2e/regression/dns-zones.cy.ts
+++ b/cypress/e2e/regression/dns-zones.cy.ts
@@ -22,45 +22,18 @@ import { getPathWithParams } from '@/utils/helpers/path.helper';
  * [data-e2e="confirmation-dialog-input"]  Type DELETE to confirm input
  * [data-e2e="confirmation-dialog-submit"] Confirm button
  *
- * Note: Uses a dedicated Standard org + project created in before() and
- * cleaned up in after(). DNS zone creation is synchronous (no task queue).
+ * Uses shared regression resources (1 org + 1 project per shard).
  */
 
 describe('DNS Zones — regression', () => {
-  const orgName = `e2e-test-dns-org-${Date.now()}`;
-  const projectName = `e2e-test-dns-project-${Date.now()}`;
-  // Use a unique subdomain to avoid conflicts between runs
   const zoneDomain = `e2e-${Date.now()}.example.com`;
-  let orgId = '';
   let projectId = '';
   let dnsZoneId = '';
 
   before(() => {
-    cy.login();
-    cy.createStandardOrg(orgName)
-      .then((id) => {
-        orgId = id;
-        return cy.createProjectInOrg(id, projectName);
-      })
-      .then((id) => {
-        projectId = id;
-      });
-  });
-
-  after(() => {
-    cy.login();
-    if (dnsZoneId) {
-      cy.visit(
-        getPathWithParams(paths.project.detail.dnsZones.detail.settings, {
-          projectId,
-          dnsZoneId,
-        })
-      );
-      cy.get('[data-e2e="delete-dns-zone-button"]').click();
-      cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
-      cy.get('[data-e2e="confirmation-dialog-submit"]').click();
-    }
-    cy.deleteOrganizationIfExists(orgId);
+    cy.ensureSharedResources().then((res) => {
+      projectId = res.projectId;
+    });
   });
 
   beforeEach(() => {
@@ -69,9 +42,6 @@ describe('DNS Zones — regression', () => {
 
   it('should create a DNS zone and appear in the list', () => {
     cy.visit(getPathWithParams(paths.project.detail.dnsZones.root, { projectId }));
-    // Wait for the page to fully load before checking which button is present,
-    // same pattern as createProjectInOrg — avoids clicking a button before React
-    // has wired up the onClick handler.
     cy.url({ timeout: 10000 }).should('include', `project/${projectId}/dns-zones`);
     cy.get('body', { timeout: 10000 }).then(($body) => {
       if ($body.find('[data-e2e="create-dns-zone-button"]').length > 0) {
@@ -100,8 +70,6 @@ describe('DNS Zones — regression', () => {
   });
 
   it('should load the DNS records tab', () => {
-    // Navigate via the list → click zone row → then DNS Records tab
-    // (avoids relying on dnsZoneId closure which may be empty if test 1 failed)
     cy.visit(getPathWithParams(paths.project.detail.dnsZones.root, { projectId }));
     cy.contains('[data-e2e="dns-zone-name"]', zoneDomain, { timeout: 10000 }).click();
     cy.contains('a', 'DNS Records').click();
@@ -116,8 +84,11 @@ describe('DNS Zones — regression', () => {
         dnsZoneId,
       })
     );
-    cy.get('[data-e2e="delete-dns-zone-button"]').click();
-    cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
+    // Wait for page to fully settle (description form autofocuses and scrolls up)
+    cy.get('[data-e2e="delete-dns-zone-button"]', { timeout: 10000 }).should('exist');
+    cy.wait(500);
+    cy.get('[data-e2e="delete-dns-zone-button"]').scrollIntoView().click();
+    cy.get('[data-e2e="confirmation-dialog-input"]', { timeout: 10000 }).type('DELETE');
     cy.get('[data-e2e="confirmation-dialog-submit"]').click();
     cy.url().should('include', `project/${projectId}/dns-zones`);
     cy.contains('[data-e2e="dns-zone-name"]', zoneDomain).should('not.exist');

--- a/cypress/e2e/regression/domains.cy.ts
+++ b/cypress/e2e/regression/domains.cy.ts
@@ -1,0 +1,84 @@
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+
+/**
+ * Selector Reference — Domains
+ *
+ * List page
+ * [data-e2e="create-domain-button"]      "Add domain" button (header)
+ * [data-e2e="domain-card"]               Domain row cell
+ * [data-e2e="domain-name"]               Domain name text
+ *
+ * Create dialog
+ * [data-e2e="create-domain-name-input"]  Domain name input
+ *
+ * Settings page
+ * [data-e2e="delete-domain-button"]      Delete domain button
+ *
+ * Confirmation dialog (shared)
+ * [data-e2e="confirmation-dialog-submit"] Confirm button
+ * Note: showConfirmInput is false for domains — no text input required
+ *
+ * Uses shared regression resources (1 org + 1 project per shard).
+ */
+
+describe('Domains — regression', () => {
+  const domainName = `e2e-${Date.now()}.example.com`;
+  let projectId = '';
+  let domainId = '';
+
+  before(() => {
+    cy.ensureSharedResources().then((res) => {
+      projectId = res.projectId;
+    });
+  });
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('should create a domain and appear in the list', () => {
+    cy.visit(getPathWithParams(paths.project.detail.domains.root, { projectId }));
+    cy.url({ timeout: 10000 }).should('include', `project/${projectId}/domains`);
+    cy.get('body', { timeout: 10000 }).then(($body) => {
+      if ($body.find('[data-e2e="create-domain-button"]').length > 0) {
+        cy.get('[data-e2e="create-domain-button"]').should('be.visible').click({ force: true });
+      } else {
+        cy.contains('button', /add domain/i, { timeout: 10000 })
+          .should('be.visible')
+          .click({ force: true });
+      }
+    });
+    cy.get('[data-e2e="create-domain-name-input"]').type(domainName);
+    cy.get('[role="dialog"]').contains('button', 'Add domain').click();
+
+    // After creation the app navigates to the overview page — extract domain ID from URL
+    cy.url()
+      .should('match', /\/domains\/[a-z0-9-]+\//)
+      .then((url) => {
+        const match = url.match(/\/domains\/([a-z0-9-]+)\//);
+        if (match) domainId = match[1];
+      });
+  });
+
+  it('should show the domain on the list page', () => {
+    cy.visit(getPathWithParams(paths.project.detail.domains.root, { projectId }));
+    cy.contains('[data-e2e="domain-name"]', domainName, { timeout: 10000 }).should('be.visible');
+  });
+
+  it('should delete the domain', () => {
+    cy.visit(
+      getPathWithParams(paths.project.detail.domains.detail.settings, {
+        projectId,
+        domainId,
+      })
+    );
+    cy.get('[data-e2e="delete-domain-button"]', { timeout: 10000 }).should('exist');
+    cy.wait(500);
+    cy.get('[data-e2e="delete-domain-button"]').scrollIntoView().click();
+    cy.get('[data-e2e="confirmation-dialog-submit"]', { timeout: 10000 }).click();
+    cy.url().should('include', `project/${projectId}/domains`);
+    cy.contains('[data-e2e="domain-name"]', domainName).should('not.exist');
+    domainId = '';
+  });
+});

--- a/cypress/e2e/regression/http-proxies.cy.ts
+++ b/cypress/e2e/regression/http-proxies.cy.ts
@@ -1,0 +1,88 @@
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+
+/**
+ * Selector Reference — AI Edge (HTTP Proxies)
+ *
+ * List page
+ * [data-e2e="create-ai-edge-button"]        "New" button (header)
+ * [data-e2e="ai-edge-card"]                 AI Edge row cell
+ * [data-e2e="ai-edge-name"]                 AI Edge display name text
+ *
+ * Create dialog
+ * [data-e2e="create-ai-edge-name-input"]    Name input (chosenName)
+ * input[placeholder*="api.example.com"]     Origin endpoint input (custom component)
+ *
+ * Detail page
+ * [data-e2e="delete-ai-edge-button"]        Delete AI Edge button (DangerCard)
+ *
+ * Confirmation dialog (shared)
+ * [data-e2e="confirmation-dialog-input"]    Type DELETE to confirm input
+ * [data-e2e="confirmation-dialog-submit"]   Confirm button
+ * Note: showConfirmInput is true for AI Edge delete
+ *
+ * Uses shared regression resources (1 org + 1 project per shard).
+ */
+
+describe('AI Edge — regression', () => {
+  const edgeName = `e2e-edge-${Date.now()}`;
+  let projectId = '';
+  let proxyId = '';
+
+  before(() => {
+    cy.ensureSharedResources().then((res) => {
+      projectId = res.projectId;
+    });
+  });
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('should create an AI Edge and appear in the list', () => {
+    cy.visit(getPathWithParams(paths.project.detail.proxy.root, { projectId }));
+    cy.url({ timeout: 10000 }).should('include', `project/${projectId}/edge`);
+    cy.get('body', { timeout: 10000 }).then(($body) => {
+      if ($body.find('[data-e2e="create-ai-edge-button"]').length > 0) {
+        cy.get('[data-e2e="create-ai-edge-button"]').should('be.visible').click();
+      } else {
+        cy.contains('button', /^new$/i, { timeout: 10000 }).should('be.visible').click();
+      }
+    });
+
+    cy.get('[data-e2e="create-ai-edge-name-input"]').type(edgeName);
+    cy.get('input[placeholder*="api.example.com"]').type('api.example.com');
+
+    cy.contains('button', 'Create').click();
+
+    // After creation the app navigates to the proxy detail page — extract ID from URL
+    cy.url()
+      .should('match', /\/edge\/[a-z0-9-]+/)
+      .then((url) => {
+        const match = url.match(/\/edge\/([a-z0-9-]+)/);
+        if (match) proxyId = match[1];
+      });
+  });
+
+  it('should show the AI Edge on the list page', () => {
+    cy.visit(getPathWithParams(paths.project.detail.proxy.root, { projectId }));
+    cy.contains('[data-e2e="ai-edge-name"]', edgeName, { timeout: 10000 }).should('be.visible');
+  });
+
+  it('should delete the AI Edge', () => {
+    cy.visit(
+      getPathWithParams(paths.project.detail.proxy.detail.root, {
+        projectId,
+        proxyId,
+      })
+    );
+    cy.get('[data-e2e="delete-ai-edge-button"]', { timeout: 10000 }).should('exist');
+    cy.wait(500);
+    cy.get('[data-e2e="delete-ai-edge-button"]').scrollIntoView().click();
+    cy.get('[data-e2e="confirmation-dialog-input"]', { timeout: 10000 }).type('DELETE');
+    cy.get('[data-e2e="confirmation-dialog-submit"]').click();
+    cy.url().should('include', `project/${projectId}/edge`);
+    cy.contains('[data-e2e="ai-edge-name"]', edgeName).should('not.exist');
+    proxyId = '';
+  });
+});

--- a/cypress/e2e/regression/members.cy.ts
+++ b/cypress/e2e/regression/members.cy.ts
@@ -41,8 +41,7 @@ describe('Members & Invitations — regression', () => {
 
   after(() => {
     if (!orgId) return;
-    cy.login();
-    cy.deleteOrganizationIfExists(orgId);
+    cy.task('deleteOrgViaApi', orgId);
   });
 
   beforeEach(() => {
@@ -76,7 +75,7 @@ describe('Members & Invitations — regression', () => {
   it('should cancel the invitation', () => {
     cy.visit(getPathWithParams(paths.org.detail.team.root, { orgId }));
     invitationRow(testEmail).closest('tr').find('[data-e2e="cancel-invitation-button"]').click();
-    cy.get('[data-e2e="confirmation-dialog-submit"]').click();
+    cy.get('[data-e2e="confirmation-dialog-submit"]', { timeout: 10000 }).click();
     cy.contains('table tbody tr', testEmail).should('not.exist');
   });
 });

--- a/cypress/e2e/regression/organisations.cy.ts
+++ b/cypress/e2e/regression/organisations.cy.ts
@@ -40,12 +40,11 @@ describe('Organisations — regression', () => {
     });
   });
 
-  // Safety net — deletes the org if any test failed before the delete test ran.
+  // Safety net — deletes the org via API if any test failed before the delete test ran.
   // If the delete test already ran it sets resourceId = '' so this is a no-op.
   after(() => {
     if (!resourceId) return;
-    cy.login();
-    cy.deleteOrganizationIfExists(resourceId);
+    cy.task('deleteOrgViaApi', resourceId);
   });
 
   beforeEach(() => {
@@ -66,9 +65,10 @@ describe('Organisations — regression', () => {
 
   it('should update the org display name', () => {
     cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId: resourceId }));
-    // Clear and type as separate queries — React re-renders after clear() detach the node
-    cy.get('[data-e2e="edit-organization-name-input"]').clear();
-    cy.get('[data-e2e="edit-organization-name-input"]').type(updatedName);
+    const suffix = '-updated';
+    cy.get('[data-e2e="edit-organization-name-input"]', { timeout: 10000 })
+      .should('be.visible')
+      .type(suffix, { force: true });
     cy.get('[data-e2e="edit-organization-save"]').click();
     cy.contains('The Organization has been updated successfully').should('be.visible');
     cy.get('[data-e2e="edit-organization-name-input"]').should('have.value', updatedName);
@@ -81,8 +81,10 @@ describe('Organisations — regression', () => {
 
   it('should delete the org and remove it from the list', () => {
     cy.visit(getPathWithParams(paths.org.detail.settings.general, { orgId: resourceId }));
-    cy.get('[data-e2e="delete-organization-button"]').click();
-    cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
+    cy.get('[data-e2e="delete-organization-button"]', { timeout: 10000 }).should('exist');
+    cy.wait(500);
+    cy.get('[data-e2e="delete-organization-button"]').scrollIntoView().click();
+    cy.get('[data-e2e="confirmation-dialog-input"]', { timeout: 10000 }).type('DELETE');
     cy.get('[data-e2e="confirmation-dialog-submit"]').click();
     cy.url().should('include', paths.account.organizations.root);
     cy.get('[data-e2e="organization-card-standard"]').should('not.contain.text', testName);

--- a/cypress/e2e/regression/projects.cy.ts
+++ b/cypress/e2e/regression/projects.cy.ts
@@ -49,11 +49,10 @@ describe('Projects — regression', () => {
       });
   });
 
-  // Safety net — delete project and test org if tests fail early.
+  // Safety net — delete org via API if tests fail early (org delete cascades to project).
   after(() => {
-    cy.login();
-    cy.deleteProjectIfExists(resourceId, orgId);
-    cy.deleteOrganizationIfExists(orgId);
+    if (!orgId) return;
+    cy.task('deleteOrgViaApi', orgId);
   });
 
   beforeEach(() => {
@@ -74,8 +73,10 @@ describe('Projects — regression', () => {
 
   it('should update the project display name', () => {
     cy.visit(getPathWithParams(paths.project.detail.settings.general, { projectId: resourceId }));
-    cy.get('[data-e2e="edit-project-name-input"]').clear();
-    cy.get('[data-e2e="edit-project-name-input"]').type(updatedName);
+    const suffix = '-updated';
+    cy.get('[data-e2e="edit-project-name-input"]', { timeout: 10000 })
+      .should('be.visible')
+      .type(suffix, { force: true });
     cy.get('[data-e2e="edit-project-save"]').click();
     cy.contains('The Project has been updated successfully').should('be.visible');
     cy.get('[data-e2e="edit-project-name-input"]').should('have.value', updatedName);
@@ -88,8 +89,10 @@ describe('Projects — regression', () => {
 
   it('should delete the project and remove it from the list', () => {
     cy.visit(getPathWithParams(paths.project.detail.settings.general, { projectId: resourceId }));
-    cy.get('[data-e2e="delete-project-button"]').click();
-    cy.get('[data-e2e="confirmation-dialog-input"]').type('DELETE');
+    cy.get('[data-e2e="delete-project-button"]', { timeout: 10000 }).should('exist');
+    cy.wait(500);
+    cy.get('[data-e2e="delete-project-button"]').scrollIntoView().click();
+    cy.get('[data-e2e="confirmation-dialog-input"]', { timeout: 10000 }).type('DELETE');
     cy.get('[data-e2e="confirmation-dialog-submit"]').click();
     cy.url().should('include', paths.org.detail.projects.root.replace('[orgId]', orgId));
     cy.get('body').should('not.contain.text', testName);

--- a/cypress/e2e/regression/secrets.cy.ts
+++ b/cypress/e2e/regression/secrets.cy.ts
@@ -1,0 +1,102 @@
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+
+/**
+ * Selector Reference — Secrets
+ *
+ * List page
+ * [data-e2e="create-secret-button"]      "Add secret" button (header)
+ * [data-e2e="secret-card"]               Secret row cell
+ * [data-e2e="secret-name"]               Secret name text
+ *
+ * Create dialog
+ * input[name="name"]                     Resource name input (InputName)
+ * [role="combobox"]                      Type select trigger
+ * [role="option"]                        Type select option
+ * input[placeholder="e.g. username"]     Key input (first variable)
+ * textarea[placeholder="value"]          Value input (first variable)
+ *
+ * Overview page (delete lives on overview, not a dedicated settings page)
+ * [data-e2e="delete-secret-button"]      Delete secret button
+ *
+ * Confirmation dialog (shared)
+ * [data-e2e="confirmation-dialog-submit"] Confirm button
+ * Note: showConfirmInput is false on the overview DangerCard path
+ *
+ * Uses shared regression resources (1 org + 1 project per shard).
+ */
+
+describe('Secrets — regression', () => {
+  const secretName = `e2e-secret-${Date.now()}`;
+  let projectId = '';
+  let secretId = '';
+
+  before(() => {
+    cy.ensureSharedResources().then((res) => {
+      projectId = res.projectId;
+    });
+  });
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('should create a secret and appear in the list', () => {
+    cy.visit(getPathWithParams(paths.project.detail.secrets.root, { projectId }));
+    cy.url({ timeout: 10000 }).should('include', `project/${projectId}/secrets`);
+    cy.get('body', { timeout: 10000 }).then(($body) => {
+      if ($body.find('[data-e2e="create-secret-button"]').length > 0) {
+        cy.get('[data-e2e="create-secret-button"]').should('be.visible').click();
+      } else {
+        cy.contains('button', /add secret/i, { timeout: 10000 })
+          .should('be.visible')
+          .click();
+      }
+    });
+
+    // Resource name — InputName renders a plain input with name="name"
+    cy.get('input[name="name"]').type(secretName);
+
+    // Type — Form.Select is a Radix combobox; open then pick the first option (Opaque)
+    cy.get('[role="combobox"]').first().click();
+    cy.get('[role="option"]').first().click();
+
+    // Variables — the form pre-populates one empty key/value row
+    cy.get('input[placeholder="e.g. username"]').first().type('api_key');
+    cy.get('textarea[placeholder="value"]').first().type('secret-value');
+
+    cy.contains('button', 'Create').click();
+
+    // After creation the app navigates to the secret detail root — extract ID from URL
+    cy.url()
+      .should('match', /\/secrets\/[a-z0-9-]+/)
+      .then((url) => {
+        const match = url.match(/\/secrets\/([a-z0-9-]+)/);
+        if (match) secretId = match[1];
+      });
+  });
+
+  it('should show the secret on the list page', () => {
+    cy.visit(getPathWithParams(paths.project.detail.secrets.root, { projectId }));
+    cy.contains('[data-e2e="secret-name"]', secretName, { timeout: 10000 }).should('be.visible');
+  });
+
+  it('should delete the secret', () => {
+    cy.visit(
+      getPathWithParams(paths.project.detail.secrets.detail.overview, {
+        projectId,
+        secretId,
+      })
+    );
+    cy.get('[data-e2e="delete-secret-button"]', { timeout: 10000 }).should('exist');
+    cy.wait(1000);
+    cy.get('[data-e2e="delete-secret-button"]')
+      .scrollIntoView()
+      .should('be.visible')
+      .click({ force: true });
+    cy.get('[data-e2e="confirmation-dialog-submit"]', { timeout: 10000 }).click();
+    cy.url().should('include', `project/${projectId}/secrets`);
+    cy.contains('[data-e2e="secret-name"]', secretName).should('not.exist');
+    secretId = '';
+  });
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -322,6 +322,49 @@ Cypress.Commands.add('deleteOrganizationIfExists', (orgId: string) => {
   });
 });
 
+/**
+ * Shared regression resources — 1 org + 1 project per Cypress process (shard).
+ *
+ * Usage in regression specs:
+ *   before(() => {
+ *     cy.ensureSharedResources().then(({ orgId, projectId }) => { ... });
+ *   });
+ *
+ * The first spec to call this creates the resources; subsequent specs reuse them.
+ * Cleanup happens via after:run at the Node level (see shared-resources.ts).
+ */
+Cypress.Commands.add(
+  'ensureSharedResources',
+  (): Cypress.Chainable<{ orgId: string; projectId: string }> => {
+    return cy
+      .task<{
+        orgId: string;
+        projectId: string;
+        timestamp: number;
+      } | null>('getSharedResources', null, { log: false })
+      .then((existing) => {
+        if (existing) {
+          return cy.wrap({ orgId: existing.orgId, projectId: existing.projectId }, { log: false });
+        }
+
+        // First spec in this shard — create the shared org + project
+        const timestamp = Date.now();
+        const orgName = `e2e-shared-org-${timestamp}`;
+        const projectName = `e2e-shared-project-${timestamp}`;
+
+        cy.login();
+        return cy.createStandardOrg(orgName).then((orgId) => {
+          return cy.createProjectInOrg(orgId, projectName).then((projectId) => {
+            const resources = { orgId, projectId, timestamp };
+            return cy.task('setSharedResources', resources, { log: false }).then(() => {
+              return cy.wrap({ orgId, projectId }, { log: false });
+            });
+          });
+        });
+      }) as Cypress.Chainable<{ orgId: string; projectId: string }>;
+  }
+);
+
 // TypeScript declarations for custom commands
 declare global {
   namespace Cypress {
@@ -380,6 +423,14 @@ declare global {
        * @example cy.deleteOrganizationIfExists(orgId)
        */
       deleteOrganizationIfExists(orgId: string): Chainable<void>;
+
+      /**
+       * Get or create shared regression resources (1 org + 1 project per shard).
+       * First call creates them; subsequent calls return the cached IDs.
+       * Cleanup is automatic via a global after() hook.
+       * @example cy.ensureSharedResources().then(({ orgId, projectId }) => { ... })
+       */
+      ensureSharedResources(): Chainable<{ orgId: string; projectId: string }>;
     }
   }
 }

--- a/cypress/support/shared-resources.ts
+++ b/cypress/support/shared-resources.ts
@@ -1,0 +1,112 @@
+/**
+ * Shared regression test resources — Node-side (runs in setupNodeEvents).
+ *
+ * Problem: Each regression spec creates its own org + project, leading to
+ * resource sprawl and unreliable cleanup when tests fail mid-run.
+ *
+ * Solution: Lazily create one org + project per Cypress process (shard).
+ * Multiple specs in the same shard share these resources. Cleanup runs
+ * via `after:run` which fires even when tests fail.
+ *
+ * In CI with cypress-split, each shard is its own process — so each shard
+ * gets its own org + project with no cross-shard conflicts.
+ */
+
+export interface SharedResources {
+  orgId: string;
+  projectId: string;
+  timestamp: number;
+}
+
+let cachedResources: SharedResources | null = null;
+
+/**
+ * Returns the cached shared resources (or null if not yet created).
+ * Creation happens browser-side via cy.task('createSharedResources')
+ * because it needs cy.login(), cy.createStandardOrg(), etc.
+ */
+export function getSharedResources(): SharedResources | null {
+  return cachedResources;
+}
+
+/**
+ * Stores shared resources after browser-side creation.
+ */
+export function setSharedResources(resources: SharedResources): SharedResources {
+  cachedResources = resources;
+  return cachedResources;
+}
+
+/**
+ * Clears cached resources (called after cleanup).
+ */
+export function clearSharedResources(): null {
+  cachedResources = null;
+  return null;
+}
+
+/**
+ * Delete an org via the control-plane API (Node-side, no browser needed).
+ * Used by after:run to clean up even when tests crash.
+ */
+async function deleteOrgViaApi(orgId: string): Promise<void> {
+  const apiUrl = process.env.API_URL;
+  const accessToken = process.env.ACCESS_TOKEN;
+
+  if (!apiUrl || !accessToken) {
+    console.warn('[shared-resources] Cannot cleanup: API_URL or ACCESS_TOKEN not set');
+    return;
+  }
+
+  const url = `${apiUrl}/apis/resourcemanager.miloapis.com/v1alpha1/organizations/${orgId}`;
+  console.log(`[shared-resources] Deleting shared org via API: ${orgId}`);
+
+  try {
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (response.ok || response.status === 404) {
+      console.log(`[shared-resources] Org ${orgId} deleted (${response.status})`);
+    } else {
+      const body = await response.text().catch(() => '');
+      console.warn(`[shared-resources] Failed to delete org ${orgId}: ${response.status} ${body}`);
+    }
+  } catch (error) {
+    console.warn(`[shared-resources] Error deleting org ${orgId}:`, error);
+  }
+}
+
+/**
+ * Register shared resource tasks and cleanup hooks.
+ * Call this from setupNodeEvents in cypress.config.ts.
+ */
+export function registerSharedResourceTasks(on: Cypress.PluginEvents): void {
+  on('task', {
+    getSharedResources(): SharedResources | null {
+      return getSharedResources();
+    },
+    setSharedResources(resources: SharedResources): SharedResources {
+      return setSharedResources(resources);
+    },
+    clearSharedResources(): null {
+      return clearSharedResources();
+    },
+    deleteOrgViaApi(orgId: string): Promise<null> {
+      return deleteOrgViaApi(orgId).then(() => null);
+    },
+  });
+
+  // Cleanup after ALL specs in this shard complete — fires in Node even if tests crash.
+  on('after:run', async () => {
+    const resources = getSharedResources();
+    if (!resources) return;
+
+    await deleteOrgViaApi(resources.orgId);
+    clearSharedResources();
+  });
+}


### PR DESCRIPTION
## Summary
- Add `data-e2e` attributes to Domains (create button, form input, settings DangerCard), Secrets (create button, overview DangerCard), and AI Edge (create button, form name input, detail DangerCard)
- Add 3 new Cypress regression test files: `domains.cy.ts`, `secrets.cy.ts`, `http-proxies.cy.ts`
- Each test suite covers: create resource → verify in list → delete via detail/settings page
