### PR TITLE
chore: fix bugs from ai chatbot in staging

### DIFF
--- a/app/features/project-bottom-bar/chat/chat-input.tsx
+++ b/app/features/project-bottom-bar/chat/chat-input.tsx
@@ -4,13 +4,16 @@ import Tooltip from '@datum-ui/components/tooltip/tooltip';
 import { cn } from '@shadcn/lib/utils';
 import type { Editor } from '@tiptap/react';
 import { EditorContent } from '@tiptap/react';
-import { Mic, MicOff, SendHorizonal, Square } from 'lucide-react';
+import { Mic, MicOff, RotateCw, SendHorizonal, Square } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 
 interface ChatInputProps {
   editor: Editor | null;
   isReady: boolean;
+  canRetry: boolean;
   onSend: () => void;
   onStop: () => void;
+  onRetry: () => void;
   speechSupported?: boolean;
   isListening?: boolean;
   frequencyData?: number[];
@@ -20,8 +23,10 @@ interface ChatInputProps {
 export function ChatInput({
   editor,
   isReady,
+  canRetry,
   onSend,
   onStop,
+  onRetry,
   speechSupported,
   isListening,
   frequencyData,
@@ -55,6 +60,25 @@ export function ChatInput({
             </button>
           </Tooltip>
         )}
+        <AnimatePresence mode="popLayout">
+          {canRetry && (
+            <motion.div
+              key="retry"
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.8 }}
+              transition={{ type: 'spring', stiffness: 500, damping: 30 }}>
+              <Tooltip message="Retry last message" side="top">
+                <button
+                  onClick={onRetry}
+                  aria-label="Retry last message"
+                  className="text-muted-foreground hover:text-foreground mb-1.5 shrink-0 rounded p-1.5 transition-colors">
+                  <Icon icon={RotateCw} className="size-4" />
+                </button>
+              </Tooltip>
+            </motion.div>
+          )}
+        </AnimatePresence>
         {isReady ? (
           <Tooltip message="Send message" side="top">
             <button

--- a/app/features/project-bottom-bar/chat/chat-panel.tsx
+++ b/app/features/project-bottom-bar/chat/chat-panel.tsx
@@ -97,6 +97,7 @@ export function ChatPanel() {
     userScrolledUp,
     editor,
     handleSendClick,
+    handleRetry,
     sidebarOpen,
     setSidebarOpen,
     speech,
@@ -341,8 +342,10 @@ export function ChatPanel() {
           <ChatInput
             editor={editor}
             isReady={isReady}
+            canRetry={isReady && messages.some((m) => m.role === 'user')}
             onSend={handleSendClick}
             onStop={stop}
+            onRetry={handleRetry}
             speechSupported={speech.isSupported}
             isListening={speech.isListening}
             frequencyData={speech.frequencyData}

--- a/app/features/project-bottom-bar/chat/use-chat-logic.ts
+++ b/app/features/project-bottom-bar/chat/use-chat-logic.ts
@@ -162,7 +162,8 @@ export function useChatLogic() {
     chatCreatedAtRef.current = Date.now();
     htmlByUserMsgIndex.current = [];
     setMessages([]);
-  }, [setMessages]);
+    clearError();
+  }, [setMessages, clearError]);
 
   const loadChat = useCallback(
     (chat: StoredChat) => {
@@ -252,6 +253,26 @@ export function useChatLogic() {
     }
   };
 
+  const handleRetry = useCallback(() => {
+    const lastUserMsg = [...messages].reverse().find((m) => m.role === 'user');
+    if (!lastUserMsg) return;
+
+    const text = lastUserMsg.parts.find((p) => p.type === 'text')?.text;
+    if (!text) return;
+
+    const lastUserIdx = messages.lastIndexOf(lastUserMsg);
+    const retainedHtml = htmlByUserMsgIndex.current.slice(0, -1);
+
+    setMessages(messages.slice(0, lastUserIdx));
+    htmlByUserMsgIndex.current = retainedHtml;
+    clearError();
+
+    requestAnimationFrame(() => {
+      htmlByUserMsgIndex.current.push(retainedHtml[retainedHtml.length] ?? `<p>${text}</p>`);
+      void sendMessage({ text });
+    });
+  }, [messages, setMessages, clearError, sendMessage]);
+
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
   return {
@@ -274,6 +295,7 @@ export function useChatLogic() {
     userScrolledUp,
     editor,
     handleSendClick,
+    handleRetry,
     sidebarOpen,
     setSidebarOpen,
     speech,

--- a/app/features/project-bottom-bar/project-bottom-bar.tsx
+++ b/app/features/project-bottom-bar/project-bottom-bar.tsx
@@ -1,6 +1,7 @@
 import { useProjectContext } from '@/providers/project.provider';
 import { Button } from '@datum-ui/components';
 import { Icon } from '@datum-ui/components/icons/icon-wrapper';
+import { Skeleton } from '@datum-ui/components/skeleton';
 import Tooltip from '@datum-ui/components/tooltip/tooltip';
 import { cn } from '@shadcn/lib/utils';
 import { BookOpen, Brain, type LucideIcon } from 'lucide-react';
@@ -52,6 +53,49 @@ function ToolbarButton({ panel, icon: icon, label, isActive, onClick }: ToolbarB
         <Icon icon={icon} className="text-icon-header size-4" />
       </Button>
     </Tooltip>
+  );
+}
+
+function ChatPanelSkeleton() {
+  return (
+    <div className="relative flex h-full overflow-hidden">
+      {/* Sidebar skeleton */}
+      <div className="bg-card hidden h-full w-[250px] shrink-0 flex-col gap-3 p-3 sm:flex">
+        <Skeleton className="h-8 w-full rounded-lg" />
+        <div className="flex flex-col gap-2 pt-2">
+          <Skeleton className="h-10 w-full rounded-lg" />
+          <Skeleton className="h-10 w-full rounded-lg" />
+          <Skeleton className="h-10 w-3/4 rounded-lg" />
+        </div>
+      </div>
+
+      {/* Resize handle */}
+      <div className="bg-muted hidden w-4 shrink-0 sm:block" />
+
+      {/* Chat area skeleton */}
+      <div className="bg-muted flex min-w-0 flex-1 flex-col">
+        <div className="flex flex-1 flex-col gap-3 p-4">
+          <Skeleton className="h-4 w-24 rounded" />
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-9 w-56 rounded-xl" />
+            <Skeleton className="h-9 w-44 rounded-xl" />
+            <Skeleton className="h-9 w-64 rounded-xl" />
+            <Skeleton className="h-9 w-52 rounded-xl" />
+            <Skeleton className="h-9 w-60 rounded-xl" />
+          </div>
+        </div>
+
+        {/* Input skeleton */}
+        <div className="px-2 pb-2">
+          <div className="mx-auto w-full sm:w-1/2">
+            <Skeleton className="h-[52px] w-full rounded-[28px]" />
+          </div>
+          <div className="mt-1 flex justify-center">
+            <Skeleton className="h-3 w-48 rounded" />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -134,7 +178,7 @@ export function ProjectBottomBar() {
             <div className="relative min-h-0 flex-1 overflow-hidden">
               {isDragging && <div className="absolute inset-0 z-50" />}
               <Activity mode={activePanel === 'chat' ? 'visible' : 'hidden'}>
-                <Suspense fallback={<div className="h-full w-full" />}>
+                <Suspense fallback={<ChatPanelSkeleton />}>
                   <ChatPanel key={project?.name ?? 'no-project'} />
                 </Suspense>
               </Activity>

--- a/app/server/routes/assistant.ts
+++ b/app/server/routes/assistant.ts
@@ -31,43 +31,61 @@ assistantRoutes.post('/', async (c) => {
     return c.json({ error: 'Unauthorized' }, 401);
   }
 
-  const anthropic = createAnthropic({ apiKey: env.server.anthropicApiKey });
-  const model = env.server.anthropicModel ?? 'claude-sonnet-4-6';
+  try {
+    const anthropic = createAnthropic({ apiKey: env.server.anthropicApiKey });
+    const model = env.server.anthropicModel ?? 'claude-sonnet-4-6';
 
-  const result = streamText({
-    model: anthropic(model),
-    system: buildSystemPrompt(projectName, orgName, projectDisplayName, orgDisplayName, clientOs),
-    messages: await convertToModelMessages(messages.slice(-MAX_MESSAGES)),
-    maxOutputTokens: 4096,
-    experimental_transform: smoothStream({ chunking: 'word', delayInMs: 40 }),
-    providerOptions: {
-      anthropic: {
-        thinking: {
-          type: 'enabled',
-          budgetTokens: 8000,
+    const result = streamText({
+      model: anthropic(model),
+      system: buildSystemPrompt(projectName, orgName, projectDisplayName, orgDisplayName, clientOs),
+      messages: await convertToModelMessages(messages.slice(-MAX_MESSAGES)),
+      maxOutputTokens: 4096,
+      experimental_transform: smoothStream({ chunking: 'word', delayInMs: 40 }),
+      providerOptions: {
+        anthropic: {
+          thinking: {
+            type: 'enabled',
+            budgetTokens: 8000,
+          },
+          metadata: { user_id: session.sub },
         },
-        metadata: { user_id: session.sub },
       },
-    },
-    stopWhen: stepCountIs(8),
-    tools: createAssistantTools({ accessToken: session.accessToken }),
-  });
+      stopWhen: stepCountIs(8),
+      tools: createAssistantTools({ accessToken: session.accessToken }),
+    });
 
-  result.usage.then(
-    (usage) => {
-      logger.info('assistant request completed', {
+    result.response.then(undefined, (err: unknown) => {
+      logger.error('assistant stream failed', {
         userId: session.sub,
         projectId: projectName,
         model,
-        inputTokens: usage.inputTokens,
-        outputTokens: usage.outputTokens,
-        totalTokens: usage.totalTokens,
+        error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
       });
-    },
-    (err: unknown) => {
-      logger.warn('failed to resolve assistant usage', { err });
-    }
-  );
+    });
 
-  return result.toUIMessageStreamResponse({ sendReasoning: true });
+    result.usage.then(
+      (usage) => {
+        logger.info('assistant request completed', {
+          userId: session.sub,
+          projectId: projectName,
+          model,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          totalTokens: usage.totalTokens,
+        });
+      },
+      () => {} // already logged via result.response rejection
+    );
+
+    return result.toUIMessageStreamResponse({ sendReasoning: true });
+  } catch (err) {
+    logger.error('assistant request failed', {
+      userId: session.sub,
+      projectId: projectName,
+      error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    return c.json({ error: 'Failed to start assistant' }, 500);
+  }
 });

--- a/app/styles/custom.css
+++ b/app/styles/custom.css
@@ -52,7 +52,15 @@
 .tiptap p.is-editor-empty:first-child::before {
   color: var(--muted-foreground);
   content: attr(data-placeholder);
-  float: left;
-  height: 0;
   pointer-events: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tiptap p.is-editor-empty:first-child {
+  position: relative;
 }

--- a/config/base/backend-traffic-policy.yaml
+++ b/config/base/backend-traffic-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
-  name: cloud-portal-tcp-keepalive
+  name: cloud-portal
 spec:
   targetRefs:
     - group: gateway.networking.k8s.io
@@ -11,3 +11,7 @@ spec:
     idleTime: 60s
     interval: 15s
     probes: 3
+  timeout:
+    http:
+      requestTimeout: "0s"
+      connectionIdleTimeout: 300s


### PR DESCRIPTION
## Summary

Streaming endpoints (assistant chat and watch SSE) were failing in staging with `ERR_HTTP2_PROTOCOL_ERROR`. The root cause is that the `BackendTrafficPolicy` for cloud-portal only configured TCP keepalive, with no HTTP timeout settings — so Envoy's default timeouts were interfering with long-lived streaming responses over HTTP/2. This meant the AI chat was unusable and real-time watch events were unreliable. Additionally, the chat UI had several UX gaps: errors persisted across new chats, there was no way to retry a failed message, the lazy-loaded panel showed a blank space while loading, and the input placeholder wrapped awkwardly on narrow screens.

This PR fixes the streaming infrastructure and improves the chat experience:

- **Fix HTTP/2 streaming** — Update the `BackendTrafficPolicy` to disable `requestTimeout` (allowing unbounded streaming responses) and set `connectionIdleTimeout` to 5 minutes, preventing Envoy from prematurely terminating SSE streams
- **Add server-side error logging** — Wrap the assistant route in try/catch and log stream failures via `result.response` rejection, making errors visible in staging logs instead of silently dropping
- **Clear errors on new chat** — Call `clearError()` in `startNewChat` so stale errors don't persist when starting a fresh conversation
- **Add retry button** — Add a retry action inside the chat input (next to the send button) that appears whenever the assistant has finished and there's a message to regenerate. Strips the last user message and failed response, then re-sends
- **Add loading skeleton** — Replace the empty `Suspense` fallback with a skeleton that mirrors the chat panel layout (sidebar, message area, input bar) while the lazy chunk loads
- **Fix placeholder truncation** — Switch the Tiptap placeholder from `float: left` to absolute positioning with `text-overflow: ellipsis` so it truncates on narrow screens instead of wrapping

## Changes

- **`config/base/backend-traffic-policy.yaml`** — Add `timeout.http.requestTimeout: "0s"` and `connectionIdleTimeout: 300s` to allow long-lived streaming connections through Envoy
- **`app/server/routes/assistant.ts`** — Wrap handler in try/catch, log stream errors with full context (message + stack trace)
- **`app/server/routes/watch.ts`** — Remove incorrect nginx-specific headers (not applicable to Envoy)
- **`app/features/project-bottom-bar/chat/use-chat-logic.ts`** — Clear error on new chat, add `handleRetry` callback
- **`app/features/project-bottom-bar/chat/chat-input.tsx`** — Add animated retry button inside the input pill with `canRetry` prop
- **`app/features/project-bottom-bar/chat/chat-panel.tsx`** — Wire retry handler and `canRetry` state through to ChatInput
- **`app/features/project-bottom-bar/project-bottom-bar.tsx`** — Add `ChatPanelSkeleton` as Suspense fallback
- **`app/styles/custom.css`** — Fix Tiptap placeholder to use absolute positioning with ellipsis truncation