### PR TITLE
Fix: accept invitations through the user's context

### DIFF
--- a/app/resources/invitations/invitation.service.ts
+++ b/app/resources/invitations/invitation.service.ts
@@ -213,6 +213,10 @@ export function createInvitationService() {
 
     /**
      * Update invitation state (accept/decline)
+     *
+     * Routed through the user-scoped control plane because the invitee is not
+     * yet a member of the organization — authz must evaluate against the User
+     * parent, where the acceptinvitation PolicyBinding is reachable.
      */
     async updateState(
       organizationId: string,
@@ -225,7 +229,7 @@ export function createInvitationService() {
         const payload = toUpdateInvitationStatePayload(state);
 
         const response = await patchIamMiloapisComV1Alpha1NamespacedUserInvitation({
-          baseURL: getOrgScopedBase(organizationId),
+          baseURL: getUserScopedBase(),
           path: {
             namespace: buildOrganizationNamespace(organizationId),
             name: invitationId,


### PR DESCRIPTION
## Summary

Users can't currently accept organization invitations from the portal — every click on **Join Organization** fails with a permissions error. This PR routes the accept/decline action through the user's own context so the invitee can act on their invitation.

## Why

The invitee isn't a member of the organization yet, so the request can't be made on the organization's behalf. The invitation list in the same service is already fetched through the user's context and works correctly — this PR aligns the accept/decline action with the same pattern.

## Test plan

- [ ] Invite a user who isn't already in the organization
- [ ] Sign in as the invitee and open the invitations inbox
- [ ] Click **Join Organization** and confirm the user is added with the expected role
- [ ] Click **Decline** on a separate invitation and confirm it disappears from the inbox

Closes #1161