### PR TITLE
fix: patch hono bun adapter globals for Vite SSR module runner

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,41 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 import { reactRouterHonoServer } from 'react-router-hono-server/dev';
+import type { Plugin } from 'vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
+
+// react-router-hono-server@2.25.x loads the Bun server adapter through
+// Vite's SSRCompatModuleRunner during dev. Several hono/bun/* modules
+// reference the `Bun` global which doesn't exist in the SSR module runner.
+// This plugin guards those accesses. ssr.noExternal: ['hono'] is required
+// so Vite processes hono through its transform pipeline.
+function patchHonoBunAdapter(): Plugin {
+  return {
+    name: 'patch-hono-bun-adapter',
+    enforce: 'pre',
+    transform(code: string, id: string) {
+      if (!id.includes('hono') || !id.includes('adapter/bun')) return;
+
+      // ssg.js: top-level `var { write } = Bun;` crashes on module load
+      if (id.includes('ssg')) {
+        return code.replace(
+          'var { write } = Bun;',
+          'var write = typeof Bun !== "undefined" ? Bun.write : undefined;'
+        );
+      }
+
+      // serve-static.js: `Bun.file()` called at request time — in dev Vite
+      // handles static files so we can safely return null to pass through
+      if (id.includes('serve-static')) {
+        return code.replace(
+          'const file = Bun.file(path);',
+          'if (typeof Bun === "undefined") return null;\n      const file = Bun.file(path);'
+        );
+      }
+    },
+  };
+}
 
 // Workaround for issue with running react router in a production build
 //
@@ -33,8 +66,13 @@ export default defineConfig((config) => {
       optimizeDeps: {
         include: ['react-dom/server.node'],
       },
+      // Force hono through Vite's transform pipeline so patchHonoBunAdapter()
+      // can guard the top-level `Bun` reference in hono/bun/ssg.js.
+      // Without this, SSR external modules bypass all transform hooks.
+      noExternal: ['hono'],
     },
     plugins: [
+      patchHonoBunAdapter(),
       tailwindcss(),
       reactRouterHonoServer({ runtime: 'bun' }),
       process.env.CYPRESS ? react() : reactRouter(),


### PR DESCRIPTION
## Summary

`bun run dev` throws `Bun is not defined` on every request, broken since 9cd0662e (\"fix(deps): remediate Snyk-identified dependency vulnerabilities\", Apr 13 2026) which bumped `react-router-hono-server` from `2.24.1 → 2.25.2`.

In 2.25.x the dev plugin loads the Bun server adapter through Vite's \`SSRCompatModuleRunner\`, which runs in a Node.js context where the \`Bun\` global doesn't exist. Two \`hono/bun\` modules are affected:

- \`hono/bun/ssg.js\` — references \`Bun\` at module load time (top-level \`var { write } = Bun;\`)
- \`hono/bun/serve-static.js\` — calls \`Bun.file()\` at request time

**Fix:** a \`enforce: 'pre'\` Vite plugin that patches those two lines to guard against \`Bun\` being undefined, plus \`ssr.noExternal: ['hono']\` so Vite's transform pipeline actually processes those files (SSR external modules bypass transforms by default). Production builds are unaffected — they run under Bun natively.

We cannot revert the dep bump as it addresses a Snyk vulnerability.

## Test plan

- [x] Run \`bun run dev\` — server should start without \`Bun is not defined\` errors
- [x] Navigate to the app in browser — pages should load normally
- [x] Run \`bun run build\` — production build should complete without errors