### PR TITLE
fix(machine-accounts): disable Grant Role button for non-owners

### DIFF
--- a/app/routes/project/detail/layout.tsx
+++ b/app/routes/project/detail/layout.tsx
@@ -1,5 +1,6 @@
 import { ProjectBottomBar } from '@/features/project-bottom-bar';
 import { DashboardLayout } from '@/layouts/dashboard.layout';
+import { RbacProvider } from '@/modules/rbac';
 import { setSentryOrgContext, setSentryProjectContext } from '@/modules/sentry';
 import { useApp } from '@/providers/app.provider';
 import { ProjectProvider } from '@/providers/project.provider';
@@ -305,19 +306,21 @@ export default function ProjectLayout() {
   const currentProject = project ?? undefined;
 
   return (
-    <ProjectProvider value={projectContextValue}>
-      <DashboardLayout
-        navItems={navItems}
-        sidebarCollapsible="icon"
-        currentProject={currentProject}
-        currentOrg={currentOrg}
-        expandBehavior="push"
-        showBackdrop={false}
-        sidebarLoading={projectLoading}
-        switcherLoading={projectLoading || orgLoading}
-        bottomBar={env.public.chatbotEnabled ? <ProjectBottomBar /> : undefined}>
-        <Outlet />
-      </DashboardLayout>
-    </ProjectProvider>
+    <RbacProvider organizationId={currentOrg?.name}>
+      <ProjectProvider value={projectContextValue}>
+        <DashboardLayout
+          navItems={navItems}
+          sidebarCollapsible="icon"
+          currentProject={currentProject}
+          currentOrg={currentOrg}
+          expandBehavior="push"
+          showBackdrop={false}
+          sidebarLoading={projectLoading}
+          switcherLoading={projectLoading || orgLoading}
+          bottomBar={env.public.chatbotEnabled ? <ProjectBottomBar /> : undefined}>
+          <Outlet />
+        </DashboardLayout>
+      </ProjectProvider>
+    </RbacProvider>
   );
 }

--- a/app/routes/project/detail/machine-accounts/detail/policy-bindings.tsx
+++ b/app/routes/project/detail/machine-accounts/detail/policy-bindings.tsx
@@ -5,6 +5,7 @@ import {
   type PolicyBindingFormDialogRef,
 } from '@/features/policy-binding/form/policy-binding-form-dialog';
 import type { DataTableRowActionsProps } from '@/modules/datum-ui/components/data-table';
+import { useHasPermission } from '@/modules/rbac';
 import { useApp } from '@/providers/app.provider';
 import { useMachineAccount } from '@/resources/machine-accounts';
 import {
@@ -12,10 +13,12 @@ import {
   useDeletePolicyBinding,
   type PolicyBinding,
 } from '@/resources/policy-bindings';
+import { buildOrganizationNamespace } from '@/utils/common';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Button } from '@datum-cloud/datum-ui/button';
 import { Icon } from '@datum-cloud/datum-ui/icons';
 import { toast } from '@datum-cloud/datum-ui/toast';
+import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
 import { ShieldIcon } from 'lucide-react';
 import { useCallback, useMemo, useRef } from 'react';
 import { MetaFunction, useParams } from 'react-router';
@@ -31,6 +34,11 @@ export default function MachineAccountPolicyBindingsPage() {
   const { orgId } = useApp();
   const dialogRef = useRef<PolicyBindingFormDialogRef>(null);
   const { confirm } = useConfirmationDialog();
+
+  const { hasPermission: canGrantRole } = useHasPermission('policybindings', 'create', {
+    namespace: buildOrganizationNamespace(orgId ?? ''),
+    group: 'iam.miloapis.com',
+  });
 
   const { data: machineAccount } = useMachineAccount(projectId ?? '', machineAccountId ?? '');
 
@@ -90,14 +98,24 @@ export default function MachineAccountPolicyBindingsPage() {
         bindings={bindings}
         tableTitle={{
           actions: (
-            <Button
-              type="quaternary"
-              theme="outline"
-              size="small"
-              onClick={() => dialogRef.current?.show()}>
-              <Icon icon={ShieldIcon} className="size-4" />
-              Grant role on this project
-            </Button>
+            <Tooltip
+              message={
+                canGrantRole
+                  ? undefined
+                  : 'You must be an Owner of this project to grant roles to machine accounts'
+              }>
+              <span className="inline-block">
+                <Button
+                  type="quaternary"
+                  theme="outline"
+                  size="small"
+                  disabled={!canGrantRole}
+                  onClick={() => dialogRef.current?.show()}>
+                  <Icon icon={ShieldIcon} className="size-4" />
+                  Grant role on this project
+                </Button>
+              </span>
+            </Tooltip>
           ),
         }}
         rowActions={rowActions}


### PR DESCRIPTION
## Summary

- Checks `policybindings` create permission before showing the Grant Role button on the machine account policy bindings page
- Disables the button with an informative tooltip for users who lack the Owner role
- Adds `RbacProvider` to the project detail layout so permission hooks work within project routes (it previously only existed in the org layout)

<img width="1493" height="824" alt="image" src="https://github.com/user-attachments/assets/4ce8e3e6-dea8-48d6-96ac-6381eeeaf32a" />


## Test plan

- [ ] As an Owner, visit a machine account's Roles tab — Grant Role button is enabled
- [ ] As a non-Owner, visit a machine account's Roles tab — button is disabled with tooltip "You must be an Owner of this project to grant roles to machine accounts"
- [ ] Verify no `usePermissions must be used within RbacProvider` errors in the console on any project route