### PR TITLE
fix(form): remove redundant key prop from Form.Dialog components

### DIFF
--- a/app/features/edge/domain/domain-form-dialog.tsx
+++ b/app/features/edge/domain/domain-form-dialog.tsx
@@ -53,7 +53,6 @@ export const DomainFormDialog = forwardRef<DomainFormDialogRef, DomainFormDialog
 
     return (
       <Form.Dialog
-        key={open ? 'open' : 'closed'}
         open={open}
         onOpenChange={setOpen}
         title="Add a Domain"

--- a/app/features/edge/proxy/proxy-form-dialog.tsx
+++ b/app/features/edge/proxy/proxy-form-dialog.tsx
@@ -93,7 +93,6 @@ export const HttpProxyFormDialog = forwardRef<HttpProxyFormDialogRef, HttpProxyF
 
     return (
       <Form.Dialog
-        key={open ? 'open-create' : 'closed'}
         open={open}
         onOpenChange={setOpen}
         title="New AI Edge"

--- a/app/features/machine-account/form/machine-account-key-form-dialog.tsx
+++ b/app/features/machine-account/form/machine-account-key-form-dialog.tsx
@@ -115,7 +115,6 @@ export const MachineAccountKeyFormDialog = forwardRef<
 
   return (
     <Form.Dialog
-      key={open ? 'open' : 'closed'}
       open={open}
       onOpenChange={setOpen}
       title="New Key"

--- a/app/features/secret/form/secret-form-dialog.tsx
+++ b/app/features/secret/form/secret-form-dialog.tsx
@@ -61,7 +61,6 @@ export const SecretFormDialog = forwardRef<SecretFormDialogRef>((_props, ref) =>
 
   return (
     <Form.Dialog
-      key={open ? 'open' : 'closed'}
       open={open}
       onOpenChange={setOpen}
       title="New Secret"


### PR DESCRIPTION
## Summary

Fixes the AI Edge E2E regression that has been failing on main since [3dffa76b](https://github.com/datum-cloud/cloud-portal/commit/3dffa76b) (_refactor(form): migrate to @datum-cloud/datum-ui/form with adapter architecture_).

The regression was introduced when the form package was migrated from \`@datum-ui/components/form\` to \`@datum-cloud/datum-ui/form\`. The new package's \`Form.Dialog\` internally uses Radix UI's \`Presence\` component to unmount/remount dialog content when \`open\` toggles — making the \`key={open ? 'open' : 'closed'}\` trick redundant. With the old package the extra remount was harmless; with the new package it adds a Radix portal re-initialization cycle that pushes past Cypress's 4000ms default timeout in CI, causing \`[data-e2e="create-ai-edge-name-input"]\` to never appear.

The fix removes the \`key\` prop from 4 dialogs that only used it for open/close resets. Form state still resets correctly on close because Radix's \`Presence\` unmounts the content when the dialog closes and remounts it fresh (with \`defaultValues\`) when it reopens.

## Files changed

- \`proxy-form-dialog.tsx\` — fixes the failing AI Edge regression test
- \`domain-form-dialog.tsx\`
- \`secret-form-dialog.tsx\`
- \`machine-account-key-form-dialog.tsx\`

> Note: 4 other dialogs (\`key-value-form-dialog\`, \`dns-zone-form-dialog\`, \`policy-binding-form-dialog\`, \`machine-account-form-dialog\`) use dynamic keys encoding the item being edited and need a separate fix.

## Test plan

- [ ] CI E2E regression passes for \`http-proxies.cy.ts\` (AI Edge create/list/delete)
- [ ] Manually verify dialog form resets correctly when closed and reopened for each affected dialog