### PR TITLE
fix(form): replace useInputControl with Form.useField in ProtocolEndpointInput

### DIFF
--- a/app/features/edge/proxy/form/protocol-endpoint-input.tsx
+++ b/app/features/edge/proxy/form/protocol-endpoint-input.tsx
@@ -1,5 +1,4 @@
 import { isIPAddress } from '@/utils/helpers/validation.helper';
-import { useInputControl } from '@conform-to/react';
 import { Form } from '@datum-cloud/datum-ui/form';
 import { InputWithAddons } from '@datum-cloud/datum-ui/input-with-addons';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@shadcn/ui/select';
@@ -17,18 +16,11 @@ interface ProtocolEndpointInputProps {
 }
 
 export const ProtocolEndpointInput = ({ autoFocus, onIPChange }: ProtocolEndpointInputProps) => {
-  const { fields } = Form.useFormContext();
-  const protocolField = fields.protocol as any;
-  const endpointField = fields.endpointHost as any;
+  const { control: protocolControl, meta: protocolMeta } = Form.useField('protocol');
+  const { control: endpointControl, meta: endpointMeta } = Form.useField('endpointHost');
 
-  const protocolControl = useInputControl(protocolField);
-  const endpointControl = useInputControl(endpointField);
-
-  const protocolValue =
-    (Array.isArray(protocolControl.value) ? protocolControl.value[0] : protocolControl.value) ||
-    'https';
-  const endpointValue =
-    (Array.isArray(endpointControl.value) ? endpointControl.value[0] : endpointControl.value) || '';
+  const protocolValue = (protocolControl.value as string) || 'https';
+  const endpointValue = (endpointControl.value as string) || '';
 
   const isIP = useMemo(() => {
     if (!endpointValue) return false;
@@ -52,10 +44,10 @@ export const ProtocolEndpointInput = ({ autoFocus, onIPChange }: ProtocolEndpoin
         <Select
           value={protocolValue}
           onValueChange={protocolControl.change}
-          name={protocolField.name}
+          name={protocolMeta.name}
           disabled={isIP}>
           <SelectTrigger
-            id={protocolField.id}
+            id={protocolMeta.id}
             className="bg-accent h-6 min-h-6 gap-1 border px-2 py-0 shadow-none focus:ring-0 focus-visible:ring-0">
             <SelectValue />
           </SelectTrigger>
@@ -68,8 +60,8 @@ export const ProtocolEndpointInput = ({ autoFocus, onIPChange }: ProtocolEndpoin
       value={endpointValue}
       onChange={(e) => endpointControl.change(e.target.value)}
       onBlur={endpointControl.blur}
-      name={endpointField.name}
-      id={endpointField.id}
+      name={endpointMeta.name}
+      id={endpointMeta.id}
       autoFocus={autoFocus}
       placeholder="e.g. api.example.com or 203.0.113.1:8080"
       className="text-xs!"


### PR DESCRIPTION
## Summary

- Fixes a runtime crash introduced by the form package migration in #1195
- `ProtocolEndpointInput` was calling `useInputControl` from `@conform-to/react` with `Form.useFormContext().fields.protocol`, but after the migration `fields` returns `NormalizedFieldMeta` (an adapter abstraction) rather than the raw Conform field object — which has a `key` property that `useInputControl` expects at line 24
- Replaced with `Form.useField('protocol')` and `Form.useField('endpointHost')` which return adapter-abstracted `control` and `meta` objects, removing the direct Conform dependency

## Root cause

The AI Edge create dialog was crashing immediately on open with:
> `TypeError: Cannot read properties of undefined (reading 'key')` at `ProtocolEndpointInput (protocol-endpoint-input.tsx:24)`

This caused the error boundary to take over, making the form invisible and failing the `http-proxies.cy.ts` E2E regression suite. The regression was introduced at `3dffa76b` (form refactor) but the crash originated in `ProtocolEndpointInput` reaching into Conform internals rather than using the form package's abstraction layer.

## Test plan

- [ ] Open the AI Edge list page and click "New" — dialog should open without crashing
- [ ] Verify protocol selector (http/https) and origin input both work
- [ ] Verify IP address detection still forces HTTPS protocol
- [ ] CI `http-proxies.cy.ts` regression suite passes