### PR TITLE
feat(edge): add WAF metrics to AI edge detail page

### DIFF
--- a/app/features/edge/proxy/metrics/edge-requests.tsx
+++ b/app/features/edge/proxy/metrics/edge-requests.tsx
@@ -28,8 +28,7 @@ export const HttpProxyEdgeRequests = ({
   const [series, setSeries] = useState<ChartSeries[]>([]);
 
   return (
-    <div className="flex flex-col gap-4">
-      <p className="text-sm font-medium">Requests per second</p>
+    <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <MetricsToolbar className="w-fit">
           <MetricsToolbar.CoreControls />
@@ -49,47 +48,45 @@ export const HttpProxyEdgeRequests = ({
         )}
       </div>
 
-      <MetricChart
-        query={({ filters, get }) => {
-          const regionFilter = createRegionFilter(get('regions'));
-          const selector = buildPrometheusLabelSelector({
-            baseLabels: {
-              resourcemanager_datumapis_com_project_name: projectId,
-              gateway_name: proxyId,
-              gateway_namespace: 'default',
-            },
-            customLabels: { label_topology_kubernetes_io_region: '!=""' },
-            filters: [regionFilter],
-          });
-          const step = filters.step ?? '15m';
-          // Group individual response codes into classes (2XX, 3XX, 4XX, 5XX).
-          // Use a sub-query (sum_over_time of 1m increases) to avoid increase()
-          // extrapolation inflating counts when data only partially covers the step window.
-          return (
-            `sum by (envoy_response_code_class) (` +
-            `sum_over_time(` +
-            `label_replace(` +
-            `increase(envoy_vhost_vcluster_upstream_rq${selector}[1m]),` +
-            `"envoy_response_code_class","$\{1}XX","envoy_response_code","([0-9]).*"` +
-            `)[${step}:1m]))`
-          );
-        }}
-        chartType="area"
-        showLegend={false}
-        colorOverrides={RESPONSE_CODE_COLORS}
-        height={220}
-        xAxisFormatter={(value) => {
-          const mins = Math.round((Date.now() - value) / 60000);
-          return mins < 60 ? `${mins}m` : `${Math.round(mins / 60)}h`;
-        }}
-        yAxisFormatter={(value) => String(Math.round(value))}
-        yAxisOptions={{ width: 55 }}
-        onSeriesChange={setSeries}
-        className="text-foreground shadow-none"
-      />
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="flex flex-col gap-2">
+          <p className="text-sm font-medium">Requests per second</p>
+          <MetricChart
+            query={({ filters, get }) => {
+              const regionFilter = createRegionFilter(get('regions'));
+              const selector = buildPrometheusLabelSelector({
+                baseLabels: {
+                  resourcemanager_datumapis_com_project_name: projectId,
+                  gateway_name: proxyId,
+                  gateway_namespace: 'default',
+                },
+                customLabels: { label_topology_kubernetes_io_region: '!=""' },
+                filters: [regionFilter],
+              });
+              const step = filters.step ?? '15m';
+              return (
+                `sum by (envoy_response_code_class) (` +
+                `sum_over_time(` +
+                `label_replace(` +
+                `increase(envoy_vhost_vcluster_upstream_rq${selector}[1m]),` +
+                `"envoy_response_code_class","$\{1}XX","envoy_response_code","([0-9]).*"` +
+                `)[${step}:1m]))`
+              );
+            }}
+            chartType="area"
+            showLegend={false}
+            colorOverrides={RESPONSE_CODE_COLORS}
+            height={140}
+            yAxisFormatter={(value) => String(Math.round(value))}
+            yAxisOptions={{ width: 55 }}
+            onSeriesChange={setSeries}
+            className="text-foreground shadow-none"
+          />
+        </div>
 
-      <p className="text-sm font-medium">P95 Upstream Latency</p>
-      <MetricChart
+        <div className="flex flex-col gap-2">
+          <p className="text-sm font-medium">P95 Upstream Latency</p>
+          <MetricChart
         query={({ filters }) =>
           buildHistogramQuantileQuery({
             quantile: 0.95,
@@ -108,11 +105,7 @@ export const HttpProxyEdgeRequests = ({
         showLegend={false}
         colorOverrides={{ Series: 'var(--primary)' }}
         valueFormat="milliseconds-auto"
-        height={220}
-        xAxisFormatter={(value) => {
-          const mins = Math.round((Date.now() - value) / 60000);
-          return mins < 60 ? `${mins}m` : `${Math.round(mins / 60)}h`;
-        }}
+        height={140}
         yAxisFormatter={(value) => formatValue(value, 'milliseconds-auto')}
         yAxisOptions={{ width: 55 }}
         tooltipContent={({ active, payload, label, ...props }) => {
@@ -145,6 +138,8 @@ export const HttpProxyEdgeRequests = ({
         }}
         className="text-foreground shadow-none"
       />
+        </div>
+      </div>
     </div>
   );
 };

--- a/app/features/edge/proxy/metrics/edge-requests.tsx
+++ b/app/features/edge/proxy/metrics/edge-requests.tsx
@@ -87,57 +87,57 @@ export const HttpProxyEdgeRequests = ({
         <div className="flex flex-col gap-2">
           <p className="text-sm font-medium">P95 Upstream Latency</p>
           <MetricChart
-        query={({ filters }) =>
-          buildHistogramQuantileQuery({
-            quantile: 0.95,
-            metric: 'envoy_vhost_vcluster_upstream_rq_time_bucket',
-            timeWindow: filters.step ?? '15m',
-            baseLabels: {
-              resourcemanager_datumapis_com_project_name: projectId,
-              gateway_name: proxyId,
-              gateway_namespace: 'default',
-            },
-            customLabels: { label_topology_kubernetes_io_region: '!=""' },
-            groupBy: ['le'],
-          })
-        }
-        chartType="area"
-        showLegend={false}
-        colorOverrides={{ Series: 'var(--primary)' }}
-        valueFormat="milliseconds-auto"
-        height={140}
-        yAxisFormatter={(value) => formatValue(value, 'milliseconds-auto')}
-        yAxisOptions={{ width: 55 }}
-        tooltipContent={({ active, payload, label, ...props }) => {
-          if (!active || !payload?.length) return null;
-          const filteredPayload = payload.filter((p) => (p.value as number) > 0);
-          if (!filteredPayload.length) return null;
-          return (
-            <MetricChartTooltipContent
-              active={active}
-              payload={filteredPayload}
-              label={label}
-              labelFormatter={(value) => <DateTime date={value} />}
-              formatter={(value, _name, item) => (
-                <div className="flex flex-1 items-center justify-between leading-none">
-                  <div className="flex items-center gap-1">
-                    <div
-                      className="size-2.5 shrink-0 rounded-[2px]"
-                      style={{ backgroundColor: item.payload.fill || item.color }}
-                    />
-                    <span className="font-medium">p95</span>
-                  </div>
-                  <div className="text-foreground font-medium">
-                    {formatValue(value as number, 'milliseconds-auto')}
-                  </div>
-                </div>
-              )}
-              {...props}
-            />
-          );
-        }}
-        className="text-foreground shadow-none"
-      />
+            query={({ filters }) =>
+              buildHistogramQuantileQuery({
+                quantile: 0.95,
+                metric: 'envoy_vhost_vcluster_upstream_rq_time_bucket',
+                timeWindow: filters.step ?? '15m',
+                baseLabels: {
+                  resourcemanager_datumapis_com_project_name: projectId,
+                  gateway_name: proxyId,
+                  gateway_namespace: 'default',
+                },
+                customLabels: { label_topology_kubernetes_io_region: '!=""' },
+                groupBy: ['le'],
+              })
+            }
+            chartType="area"
+            showLegend={false}
+            colorOverrides={{ Series: 'var(--primary)' }}
+            valueFormat="milliseconds-auto"
+            height={140}
+            yAxisFormatter={(value) => formatValue(value, 'milliseconds-auto')}
+            yAxisOptions={{ width: 55 }}
+            tooltipContent={({ active, payload, label, ...props }) => {
+              if (!active || !payload?.length) return null;
+              const filteredPayload = payload.filter((p) => (p.value as number) > 0);
+              if (!filteredPayload.length) return null;
+              return (
+                <MetricChartTooltipContent
+                  active={active}
+                  payload={filteredPayload}
+                  label={label}
+                  labelFormatter={(value) => <DateTime date={value} />}
+                  formatter={(value, _name, item) => (
+                    <div className="flex flex-1 items-center justify-between leading-none">
+                      <div className="flex items-center gap-1">
+                        <div
+                          className="size-2.5 shrink-0 rounded-[2px]"
+                          style={{ backgroundColor: item.payload.fill || item.color }}
+                        />
+                        <span className="font-medium">p95</span>
+                      </div>
+                      <div className="text-foreground font-medium">
+                        {formatValue(value as number, 'milliseconds-auto')}
+                      </div>
+                    </div>
+                  )}
+                  {...props}
+                />
+              );
+            }}
+            className="text-foreground shadow-none"
+          />
         </div>
       </div>
     </div>

--- a/app/features/edge/proxy/metrics/waf-events.tsx
+++ b/app/features/edge/proxy/metrics/waf-events.tsx
@@ -5,8 +5,12 @@ import {
   buildPrometheusLabelSelector,
   createRegionFilter,
 } from '@/modules/metrics';
+import { usePrometheusCard } from '@/modules/metrics/hooks';
+import { useMetrics } from '@/modules/metrics/context/metrics.context';
+import type { QueryBuilderContext } from '@/modules/metrics';
+import { formatValue } from '@/modules/prometheus';
 import type { ChartSeries } from '@/modules/prometheus';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 const OUTCOME_LABELS: Record<string, string> = {
   allowed: 'Allowed',
@@ -20,19 +24,91 @@ const OUTCOME_COLORS: Record<string, string> = {
   dropped: 'var(--color-chart-4)',
 };
 
+function windowDuration(ctx: QueryBuilderContext): string {
+  const { start, end } = ctx.timeRange;
+  const ms = end.getTime() - start.getTime();
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+function WafStat({
+  label,
+  query,
+}: {
+  label: string;
+  query: (ctx: QueryBuilderContext) => string;
+}) {
+  const { timeRange, step, buildQueryContext, filterState } = useMetrics();
+  const finalQuery = useMemo(() => query(buildQueryContext()), [query, buildQueryContext, filterState]);
+  const { data } = usePrometheusCard({ query: finalQuery, timeRange, step, metricFormat: 'short-number' });
+  const value = data ? formatValue(data.value, 'short-number', 0) : '—';
+  return (
+    <div className="text-foreground flex items-center gap-1 text-xs">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-semibold tabular-nums">{value}</span>
+    </div>
+  );
+}
+
 export const HttpProxyWafEvents = ({
   projectId,
   proxyId,
+  trafficProtectionMode,
 }: {
   projectId: string;
   proxyId: string;
+  trafficProtectionMode?: string;
 }) => {
   const [series, setSeries] = useState<ChartSeries[]>([]);
+
+  const blockedQuery = (ctx: QueryBuilderContext) => {
+    const regionFilter = createRegionFilter(ctx.get('regions'));
+    const selector = buildPrometheusLabelSelector({
+      baseLabels: {
+        resourcemanager_datumapis_com_project_name: projectId,
+        gateway_name: proxyId,
+      },
+      customLabels: {
+        label_topology_kubernetes_io_region: '!=""',
+        coraza_outcome: '=~"blocked|dropped"',
+      },
+      filters: [regionFilter],
+    });
+    return `sum(increase(coraza_envoy_filter_request_events_total${selector}[${windowDuration(ctx)}]))`;
+  };
+
+  const allowedQuery = (ctx: QueryBuilderContext) => {
+    const regionFilter = createRegionFilter(ctx.get('regions'));
+    const selector = buildPrometheusLabelSelector({
+      baseLabels: {
+        resourcemanager_datumapis_com_project_name: projectId,
+        gateway_name: proxyId,
+        coraza_outcome: 'allowed',
+        ...(trafficProtectionMode === 'Enforce'
+          ? { trafficprotectionpolicy_mode: 'Enforce' }
+          : { trafficprotectionpolicy_mode: 'Observe' }),
+      },
+      customLabels: { label_topology_kubernetes_io_region: '!=""' },
+      filters: [regionFilter],
+    });
+    return `sum(increase(coraza_envoy_filter_request_events_total${selector}[${windowDuration(ctx)}]))`;
+  };
+
+  const allowedLabel = trafficProtectionMode === 'Observe' ? 'Observed' : 'Allowed';
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <p className="text-sm font-medium">Traffic Protection Events</p>
+        <div className="flex items-center gap-4">
+          <p className="text-sm font-medium">Traffic Protection Events</p>
+          <WafStat label="Blocked" query={blockedQuery} />
+          <WafStat label={allowedLabel} query={allowedQuery} />
+        </div>
         {series.length > 0 && (
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
             {series.map((s) => (
@@ -70,11 +146,7 @@ export const HttpProxyWafEvents = ({
         chartType="area"
         showLegend={false}
         colorOverrides={OUTCOME_COLORS}
-        height={220}
-        xAxisFormatter={(value) => {
-          const mins = Math.round((Date.now() - value) / 60000);
-          return mins < 60 ? `${mins}m` : `${Math.round(mins / 60)}h`;
-        }}
+        height={140}
         yAxisFormatter={(value) => String(Math.round(value))}
         yAxisOptions={{ width: 55 }}
         onSeriesChange={setSeries}

--- a/app/features/edge/proxy/metrics/waf-events.tsx
+++ b/app/features/edge/proxy/metrics/waf-events.tsx
@@ -4,13 +4,14 @@ import {
   MetricChartTooltipContent,
   buildPrometheusLabelSelector,
   createRegionFilter,
+  useMetrics,
+  usePrometheusCard,
+  type QueryBuilderContext,
 } from '@/modules/metrics';
-import { usePrometheusCard } from '@/modules/metrics/hooks';
-import { useMetrics } from '@/modules/metrics/context/metrics.context';
-import type { QueryBuilderContext } from '@/modules/metrics';
-import { formatValue } from '@/modules/prometheus';
-import type { ChartSeries } from '@/modules/prometheus';
-import { useMemo, useState } from 'react';
+import { formatDurationFromMs } from '@/modules/metrics/utils/date-parsers';
+import { formatValue, type ChartSeries } from '@/modules/prometheus';
+import type { TrafficProtectionMode } from '@/resources/http-proxies';
+import { useCallback, useMemo, useState } from 'react';
 
 const OUTCOME_LABELS: Record<string, string> = {
   allowed: 'Allowed',
@@ -25,27 +26,22 @@ const OUTCOME_COLORS: Record<string, string> = {
 };
 
 function windowDuration(ctx: QueryBuilderContext): string {
-  const { start, end } = ctx.timeRange;
-  const ms = end.getTime() - start.getTime();
-  const seconds = Math.round(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  return `${Math.floor(hours / 24)}d`;
+  return formatDurationFromMs(ctx.timeRange.end.getTime() - ctx.timeRange.start.getTime());
 }
 
-function WafStat({
-  label,
-  query,
-}: {
-  label: string;
-  query: (ctx: QueryBuilderContext) => string;
-}) {
+function WafStat({ label, query }: { label: string; query: (ctx: QueryBuilderContext) => string }) {
   const { timeRange, step, buildQueryContext, filterState } = useMetrics();
-  const finalQuery = useMemo(() => query(buildQueryContext()), [query, buildQueryContext, filterState]);
-  const { data } = usePrometheusCard({ query: finalQuery, timeRange, step, metricFormat: 'short-number' });
+  const resolvedQuery = useMemo(
+    () => query(buildQueryContext()),
+    // filterState participates in identity of buildQueryContext output
+    [query, buildQueryContext, filterState]
+  );
+  const { data } = usePrometheusCard({
+    query: resolvedQuery,
+    timeRange,
+    step,
+    metricFormat: 'short-number',
+  });
   const value = data ? formatValue(data.value, 'short-number', 0) : '—';
   return (
     <div className="text-foreground flex items-center gap-1 text-xs">
@@ -62,42 +58,46 @@ export const HttpProxyWafEvents = ({
 }: {
   projectId: string;
   proxyId: string;
-  trafficProtectionMode?: string;
+  trafficProtectionMode?: TrafficProtectionMode;
 }) => {
   const [series, setSeries] = useState<ChartSeries[]>([]);
 
-  const blockedQuery = (ctx: QueryBuilderContext) => {
-    const regionFilter = createRegionFilter(ctx.get('regions'));
-    const selector = buildPrometheusLabelSelector({
-      baseLabels: {
-        resourcemanager_datumapis_com_project_name: projectId,
-        gateway_name: proxyId,
-      },
-      customLabels: {
-        label_topology_kubernetes_io_region: '!=""',
-        coraza_outcome: '=~"blocked|dropped"',
-      },
-      filters: [regionFilter],
-    });
-    return `sum(increase(coraza_envoy_filter_request_events_total${selector}[${windowDuration(ctx)}]))`;
-  };
+  const blockedQuery = useCallback(
+    (ctx: QueryBuilderContext) => {
+      const regionFilter = createRegionFilter(ctx.get('regions'));
+      const selector = buildPrometheusLabelSelector({
+        baseLabels: {
+          resourcemanager_datumapis_com_project_name: projectId,
+          gateway_name: proxyId,
+        },
+        customLabels: {
+          label_topology_kubernetes_io_region: '!=""',
+          coraza_outcome: '=~"blocked|dropped"',
+        },
+        filters: [regionFilter],
+      });
+      return `sum(increase(coraza_envoy_filter_request_events_total${selector}[${windowDuration(ctx)}]))`;
+    },
+    [projectId, proxyId]
+  );
 
-  const allowedQuery = (ctx: QueryBuilderContext) => {
-    const regionFilter = createRegionFilter(ctx.get('regions'));
-    const selector = buildPrometheusLabelSelector({
-      baseLabels: {
-        resourcemanager_datumapis_com_project_name: projectId,
-        gateway_name: proxyId,
-        coraza_outcome: 'allowed',
-        ...(trafficProtectionMode === 'Enforce'
-          ? { trafficprotectionpolicy_mode: 'Enforce' }
-          : { trafficprotectionpolicy_mode: 'Observe' }),
-      },
-      customLabels: { label_topology_kubernetes_io_region: '!=""' },
-      filters: [regionFilter],
-    });
-    return `sum(increase(coraza_envoy_filter_request_events_total${selector}[${windowDuration(ctx)}]))`;
-  };
+  const allowedQuery = useCallback(
+    (ctx: QueryBuilderContext) => {
+      const regionFilter = createRegionFilter(ctx.get('regions'));
+      const selector = buildPrometheusLabelSelector({
+        baseLabels: {
+          resourcemanager_datumapis_com_project_name: projectId,
+          gateway_name: proxyId,
+          coraza_outcome: 'allowed',
+          trafficprotectionpolicy_mode: trafficProtectionMode === 'Enforce' ? 'Enforce' : 'Observe',
+        },
+        customLabels: { label_topology_kubernetes_io_region: '!=""' },
+        filters: [regionFilter],
+      });
+      return `sum(increase(coraza_envoy_filter_request_events_total${selector}[${windowDuration(ctx)}]))`;
+    },
+    [projectId, proxyId, trafficProtectionMode]
+  );
 
   const allowedLabel = trafficProtectionMode === 'Observe' ? 'Observed' : 'Allowed';
 
@@ -146,6 +146,7 @@ export const HttpProxyWafEvents = ({
         chartType="area"
         showLegend={false}
         colorOverrides={OUTCOME_COLORS}
+        padToTimeRange
         height={140}
         yAxisFormatter={(value) => String(Math.round(value))}
         yAxisOptions={{ width: 55 }}

--- a/app/features/edge/proxy/metrics/waf-top-rules.tsx
+++ b/app/features/edge/proxy/metrics/waf-top-rules.tsx
@@ -1,0 +1,167 @@
+import { buildPrometheusLabelSelector, createRegionFilter, useMetrics } from '@/modules/metrics';
+import { usePrometheusAPIQuery } from '@/modules/metrics/hooks';
+import type { FormattedMetricData } from '@/modules/prometheus';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@shadcn/ui/table';
+import { useQueryState } from 'nuqs';
+import { useMemo } from 'react';
+
+interface WafTopRulesProps {
+  projectId: string;
+  proxyId: string;
+}
+
+const OWASP_RULE_NAMES: Record<string, string> = {
+  '949110': 'Inbound Anomaly Score Exceeded',
+  '949111': 'Inbound Anomaly Score Exceeded (Early Blocking)',
+  '959100': 'Outbound Anomaly Score Exceeded',
+  '941100': 'XSS Attack via libinjection',
+  '941110': 'XSS: Script Tag',
+  '941160': 'XSS: JavaScript URI',
+  '942100': 'SQL Injection via libinjection',
+  '942151': 'SQL Injection',
+  '942200': 'SQL Injection: MySQL Comment',
+  '942260': 'SQL Injection: Basic Authentication Bypass',
+  '942370': 'SQL Injection: Benchmark/Sleep',
+  '942550': 'SQL Injection: MySQL',
+  '930100': 'Path Traversal Attack',
+  '930110': 'Path Traversal: Double-Encoded',
+  '920350': 'Host Header is Numeric IP',
+  '920440': 'URL File Extension Restricted',
+  '921110': 'HTTP Request Smuggling',
+  '932100': 'Remote Command Execution: Unix',
+  '932110': 'Remote Command Execution: Windows',
+  '932235': 'Remote Command Execution: Unix Shell',
+  '933100': 'PHP Injection',
+  '934100': 'Node.js Injection',
+};
+
+function ruleLabel(ruleId: string): string {
+  if (ruleId === '—') return '—';
+  return OWASP_RULE_NAMES[ruleId] ?? `Rule ${ruleId}`;
+}
+
+interface RuleRow {
+  ruleId: string;
+  action: string;
+  events: number;
+}
+
+function durationFromMs(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+export const WafTopRules = ({ projectId, proxyId }: WafTopRulesProps) => {
+  const { buildQueryContext, refreshInterval } = useMetrics();
+
+  const [urlTimeRange] = useQueryState('timeRange');
+
+  const queryContext = useMemo(() => buildQueryContext(), [buildQueryContext, urlTimeRange]);
+
+  const windowDuration = useMemo(() => {
+    const { start, end } = queryContext.timeRange;
+    return durationFromMs(end.getTime() - start.getTime());
+  }, [queryContext.timeRange]);
+
+  const query = useMemo(() => {
+    const regionFilter = createRegionFilter(queryContext.get('regions'));
+    const selector = buildPrometheusLabelSelector({
+      baseLabels: {
+        resourcemanager_datumapis_com_project_name: projectId,
+        gateway_name: proxyId,
+      },
+      customLabels: { label_topology_kubernetes_io_region: '!=""' },
+      filters: [regionFilter],
+    });
+    return (
+      `topk(10, sum by (coraza_rule_id, coraza_rule_action) (` +
+      `increase(coraza_envoy_filter_request_events_total${selector}[${windowDuration}])` +
+      `))`
+    );
+  }, [projectId, proxyId, queryContext, windowDuration]);
+
+  const refetchMs = useMemo(() => {
+    if (refreshInterval === 'off') return false as const;
+    const match = refreshInterval.match(/^(\d+)([smh])$/);
+    if (!match) return false as const;
+    const val = parseInt(match[1]!, 10);
+    const unit = match[2];
+    if (unit === 's') return val * 1000;
+    if (unit === 'm') return val * 60 * 1000;
+    if (unit === 'h') return val * 3600 * 1000;
+    return false as const;
+  }, [refreshInterval]);
+
+  const queryKey = useMemo(
+    () => ['waf-top-rules', query, projectId, proxyId],
+    [query, projectId, proxyId]
+  );
+
+  const { data, isLoading, error } = usePrometheusAPIQuery<FormattedMetricData>(
+    queryKey,
+    { type: 'chart', query },
+    { enabled: !!query, refetchInterval: refetchMs }
+  );
+
+  const rows: RuleRow[] = useMemo(() => {
+    if (!data?.series?.length) return [];
+    return data.series
+      .map((series) => ({
+        ruleId: series.labels.coraza_rule_id ?? '—',
+        action: series.labels.coraza_rule_action ?? '—',
+        events: Math.round(series.data[0]?.value ?? 0),
+      }))
+      .filter((row) => row.ruleId !== '—' && row.events > 0)
+      .sort((a, b) => b.events - a.events);
+  }, [data]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm font-medium">Top Triggered Rules</p>
+      {isLoading ? (
+        <div className="bg-muted h-32 animate-pulse rounded-md" />
+      ) : error ? (
+        <p className="text-muted-foreground text-sm">No rule events in this time window.</p>
+      ) : rows.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No rule events in this time window.</p>
+      ) : (
+        <div className="scrollbar-hide overflow-x-auto rounded-md border">
+          <Table>
+            <TableHeader className="bg-background sticky top-0">
+              <TableRow>
+                <TableHead>Rule</TableHead>
+                <TableHead>Severity</TableHead>
+                <TableHead>Action</TableHead>
+                <TableHead className="text-right">Events</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row, index) => (
+                <TableRow key={`${row.ruleId}-${index}`} className="hover:bg-muted/50">
+                  <TableCell>
+                    <span className="text-sm">{ruleLabel(row.ruleId)}</span>
+                    {row.ruleId !== '—' && (
+                      <span className="text-muted-foreground ml-1.5 font-mono text-xs">
+                        {row.ruleId}
+                      </span>
+                    )}
+                  </TableCell>
+
+                  <TableCell>{row.action}</TableCell>
+                  <TableCell className="text-right font-mono text-sm">
+                    {row.events.toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/app/features/edge/proxy/metrics/waf-top-rules.tsx
+++ b/app/features/edge/proxy/metrics/waf-top-rules.tsx
@@ -1,11 +1,15 @@
-import { buildPrometheusLabelSelector, createRegionFilter, useMetrics } from '@/modules/metrics';
-import { usePrometheusAPIQuery } from '@/modules/metrics/hooks';
+import {
+  buildPrometheusLabelSelector,
+  createRegionFilter,
+  useMetrics,
+  usePrometheusAPIQuery,
+} from '@/modules/metrics';
+import { formatDurationFromMs, parseDurationToMs } from '@/modules/metrics/utils/date-parsers';
 import type { FormattedMetricData } from '@/modules/prometheus';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@shadcn/ui/table';
-import { useQueryState } from 'nuqs';
 import { useMemo } from 'react';
 
-interface WafTopRulesProps {
+interface HttpProxyWafTopRulesProps {
   projectId: string;
   proxyId: string;
 }
@@ -35,38 +39,25 @@ const OWASP_RULE_NAMES: Record<string, string> = {
   '934100': 'Node.js Injection',
 };
 
-function ruleLabel(ruleId: string): string {
-  if (ruleId === '—') return '—';
-  return OWASP_RULE_NAMES[ruleId] ?? `Rule ${ruleId}`;
-}
-
 interface RuleRow {
   ruleId: string;
-  action: string;
+  severity: string | null;
+  action: string | null;
   events: number;
 }
 
-function durationFromMs(ms: number): string {
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  return `${Math.floor(hours / 24)}d`;
-}
+export const HttpProxyWafTopRules = ({ projectId, proxyId }: HttpProxyWafTopRulesProps) => {
+  const { buildQueryContext, refreshInterval, filterState } = useMetrics();
 
-export const WafTopRules = ({ projectId, proxyId }: WafTopRulesProps) => {
-  const { buildQueryContext, refreshInterval } = useMetrics();
+  const queryContext = useMemo(() => buildQueryContext(), [buildQueryContext, filterState]);
 
-  const [urlTimeRange] = useQueryState('timeRange');
-
-  const queryContext = useMemo(() => buildQueryContext(), [buildQueryContext, urlTimeRange]);
-
-  const windowDuration = useMemo(() => {
-    const { start, end } = queryContext.timeRange;
-    return durationFromMs(end.getTime() - start.getTime());
-  }, [queryContext.timeRange]);
+  const windowDuration = useMemo(
+    () =>
+      formatDurationFromMs(
+        queryContext.timeRange.end.getTime() - queryContext.timeRange.start.getTime()
+      ),
+    [queryContext.timeRange]
+  );
 
   const query = useMemo(() => {
     const regionFilter = createRegionFilter(queryContext.get('regions'));
@@ -79,27 +70,27 @@ export const WafTopRules = ({ projectId, proxyId }: WafTopRulesProps) => {
       filters: [regionFilter],
     });
     return (
-      `topk(10, sum by (coraza_rule_id, coraza_rule_action) (` +
+      `topk(10, sum by (coraza_rule_id, coraza_rule_severity, coraza_rule_action) (` +
       `increase(coraza_envoy_filter_request_events_total${selector}[${windowDuration}])` +
       `))`
     );
   }, [projectId, proxyId, queryContext, windowDuration]);
 
-  const refetchMs = useMemo(() => {
-    if (refreshInterval === 'off') return false as const;
-    const match = refreshInterval.match(/^(\d+)([smh])$/);
-    if (!match) return false as const;
-    const val = parseInt(match[1]!, 10);
-    const unit = match[2];
-    if (unit === 's') return val * 1000;
-    if (unit === 'm') return val * 60 * 1000;
-    if (unit === 'h') return val * 3600 * 1000;
-    return false as const;
+  const refetchMs = useMemo<number | false>(() => {
+    if (refreshInterval === 'off') return false;
+    return parseDurationToMs(refreshInterval) ?? false;
   }, [refreshInterval]);
 
   const queryKey = useMemo(
-    () => ['waf-top-rules', query, projectId, proxyId],
-    [query, projectId, proxyId]
+    () => [
+      'waf-top-rules',
+      projectId,
+      proxyId,
+      query,
+      queryContext.timeRange.start.getTime(),
+      queryContext.timeRange.end.getTime(),
+    ],
+    [projectId, proxyId, query, queryContext.timeRange]
   );
 
   const { data, isLoading, error } = usePrometheusAPIQuery<FormattedMetricData>(
@@ -111,14 +102,17 @@ export const WafTopRules = ({ projectId, proxyId }: WafTopRulesProps) => {
   const rows: RuleRow[] = useMemo(() => {
     if (!data?.series?.length) return [];
     return data.series
-      .map((series) => ({
-        ruleId: series.labels.coraza_rule_id ?? '—',
-        action: series.labels.coraza_rule_action ?? '—',
+      .map<RuleRow>((series) => ({
+        ruleId: series.labels.coraza_rule_id ?? '',
+        severity: series.labels.coraza_rule_severity ?? null,
+        action: series.labels.coraza_rule_action ?? null,
         events: Math.round(series.data[0]?.value ?? 0),
       }))
-      .filter((row) => row.ruleId !== '—' && row.events > 0)
+      .filter((row) => row.ruleId !== '' && row.events > 0)
       .sort((a, b) => b.events - a.events);
   }, [data]);
+
+  const ruleLabel = (ruleId: string): string => OWASP_RULE_NAMES[ruleId] ?? `Rule ${ruleId}`;
 
   return (
     <div className="flex flex-col gap-3">
@@ -126,7 +120,7 @@ export const WafTopRules = ({ projectId, proxyId }: WafTopRulesProps) => {
       {isLoading ? (
         <div className="bg-muted h-32 animate-pulse rounded-md" />
       ) : error ? (
-        <p className="text-muted-foreground text-sm">No rule events in this time window.</p>
+        <p className="text-muted-foreground text-sm">Unable to load rule events.</p>
       ) : rows.length === 0 ? (
         <p className="text-muted-foreground text-sm">No rule events in this time window.</p>
       ) : (
@@ -145,14 +139,12 @@ export const WafTopRules = ({ projectId, proxyId }: WafTopRulesProps) => {
                 <TableRow key={`${row.ruleId}-${index}`} className="hover:bg-muted/50">
                   <TableCell>
                     <span className="text-sm">{ruleLabel(row.ruleId)}</span>
-                    {row.ruleId !== '—' && (
-                      <span className="text-muted-foreground ml-1.5 font-mono text-xs">
-                        {row.ruleId}
-                      </span>
-                    )}
+                    <span className="text-muted-foreground ml-1.5 font-mono text-xs">
+                      {row.ruleId}
+                    </span>
                   </TableCell>
-
-                  <TableCell>{row.action}</TableCell>
+                  <TableCell>{row.severity ?? '—'}</TableCell>
+                  <TableCell>{row.action ?? '—'}</TableCell>
                   <TableCell className="text-right font-mono text-sm">
                     {row.events.toLocaleString()}
                   </TableCell>

--- a/app/modules/metrics/components/metric-card.tsx
+++ b/app/modules/metrics/components/metric-card.tsx
@@ -203,23 +203,25 @@ export function MetricCard({
       error={error}
       className={cn('MetricCard', className)}
       isEmpty={!data}>
-      <div className="flex items-center justify-between">
-        <div className="text-2xl font-bold">{formattedValue}</div>
-        {IconComponent}
-      </div>
+      <div className="flex flex-col gap-1 px-6 pb-4">
+        <div className="flex items-center justify-between">
+          <div className="text-2xl font-bold">{formattedValue}</div>
+          {IconComponent}
+        </div>
 
-      {showTrend && trendIcon && trendText && (
-        <div className="text-muted-foreground flex items-center gap-1 text-xs">
-          {trendIcon}
-          <span>{trendText}</span>
-          <span>from last period</span>
-        </div>
-      )}
-      {data?.timestamp && (
-        <div className="text-muted-foreground text-xs">
-          Updated {new Date(data.timestamp).toLocaleTimeString()}
-        </div>
-      )}
+        {showTrend && trendIcon && trendText && (
+          <div className="text-muted-foreground flex items-center gap-1 text-xs">
+            {trendIcon}
+            <span>{trendText}</span>
+            <span>from last period</span>
+          </div>
+        )}
+        {data?.timestamp && (
+          <div className="text-muted-foreground text-xs">
+            Updated {new Date(data.timestamp).toLocaleTimeString()}
+          </div>
+        )}
+      </div>
     </BaseMetric>
   );
 }

--- a/app/modules/metrics/components/metric-chart.tsx
+++ b/app/modules/metrics/components/metric-chart.tsx
@@ -153,8 +153,23 @@ export function MetricChart({
 
   const chartData = useMemo(() => {
     if (!data) return [];
-    return transformForRecharts(data);
-  }, [data]);
+    const transformed = transformForRecharts(data);
+    if (transformed.length === 0) return transformed;
+
+    const seriesKeys = data.series.map((s) => s.name);
+    const zeros = Object.fromEntries(seriesKeys.map((k) => [k, 0]));
+    const startMs = finalTimeRange.start.getTime();
+    const endMs = finalTimeRange.end.getTime();
+
+    const result = [...transformed];
+    if (result[0]!.timestamp > startMs) {
+      result.unshift({ timestamp: startMs, ...zeros });
+    }
+    if (result[result.length - 1]!.timestamp < endMs) {
+      result.push({ timestamp: endMs, ...zeros });
+    }
+    return result;
+  }, [data, finalTimeRange]);
 
   // Handle data change callbacks
   useEffect(() => {
@@ -269,7 +284,7 @@ export function MetricChart({
             dataKey="timestamp"
             type="number"
             scale="time"
-            domain={['dataMin', 'dataMax']}
+            domain={[finalTimeRange.start.getTime(), finalTimeRange.end.getTime()]}
             tickFormatter={formatXAxisValue}
             tickLine={false}
             axisLine={false}

--- a/app/modules/metrics/components/metric-chart.tsx
+++ b/app/modules/metrics/components/metric-chart.tsx
@@ -66,6 +66,13 @@ export interface MetricChartProps extends Omit<PrometheusQueryOptions, 'query'> 
    */
   colorOverrides?: Record<string, string>;
   /**
+   * When true, fix the X-axis domain to the active time range and pad the data
+   * with zero-valued anchor points at the start/end. Use for charts that should
+   * always span the selected window (e.g., WAF events). Defaults to false so
+   * sparkline-style charts auto-fit to their data.
+   */
+  padToTimeRange?: boolean;
+  /**
    * Children to render below the chart
    */
   children?: ReactNode;
@@ -95,6 +102,7 @@ export function MetricChart({
   yAxisOptions,
   tooltipContent,
   colorOverrides,
+  padToTimeRange = false,
   children,
 }: MetricChartProps) {
   const { timeRange, step, buildQueryContext, filterState } = useMetrics();
@@ -154,7 +162,7 @@ export function MetricChart({
   const chartData = useMemo(() => {
     if (!data) return [];
     const transformed = transformForRecharts(data);
-    if (transformed.length === 0) return transformed;
+    if (!padToTimeRange || transformed.length === 0) return transformed;
 
     const seriesKeys = data.series.map((s) => s.name);
     const zeros = Object.fromEntries(seriesKeys.map((k) => [k, 0]));
@@ -169,7 +177,7 @@ export function MetricChart({
       result.push({ timestamp: endMs, ...zeros });
     }
     return result;
-  }, [data, finalTimeRange]);
+  }, [data, finalTimeRange, padToTimeRange]);
 
   // Handle data change callbacks
   useEffect(() => {
@@ -284,7 +292,11 @@ export function MetricChart({
             dataKey="timestamp"
             type="number"
             scale="time"
-            domain={[finalTimeRange.start.getTime(), finalTimeRange.end.getTime()]}
+            domain={
+              padToTimeRange
+                ? [finalTimeRange.start.getTime(), finalTimeRange.end.getTime()]
+                : ['dataMin', 'dataMax']
+            }
             tickFormatter={formatXAxisValue}
             tickLine={false}
             axisLine={false}

--- a/app/modules/metrics/utils/date-parsers.ts
+++ b/app/modules/metrics/utils/date-parsers.ts
@@ -6,6 +6,21 @@ import { endOfDay, startOfDay, subDays, subHours, subMinutes } from 'date-fns';
 import { fromZonedTime, toZonedTime } from 'date-fns-tz';
 
 /**
+ * Format a millisecond duration as a Prometheus-like duration string
+ * (e.g., 90s -> "1m", 7200000ms -> "2h"). Used to interpolate the active
+ * time window into PromQL range vectors like `metric[<window>]`.
+ */
+export function formatDurationFromMs(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+/**
  * Parse a Prometheus-like duration (e.g., 5s, 10m, 3h, 7d, 1w) into milliseconds.
  */
 export function parseDurationToMs(durationStr: string): number | null {

--- a/app/modules/prometheus/service.ts
+++ b/app/modules/prometheus/service.ts
@@ -47,7 +47,11 @@ export class PrometheusService {
       }
       case 'card': {
         const validatedOptions = validateQueryOptions(params);
-        return this.queryForCard(validatedOptions.query, params.metricFormat || 'number');
+        return this.queryForCard(
+          validatedOptions.query,
+          params.metricFormat || 'number',
+          validatedOptions.timeRange?.end
+        );
       }
       case 'connection': {
         const isConnected = await this.testConnection();

--- a/app/routes/project/detail/edge/detail/index.tsx
+++ b/app/routes/project/detail/edge/detail/index.tsx
@@ -2,6 +2,7 @@ import { DangerCard } from '@/components/danger-card/danger-card';
 import { useDeleteProxy } from '@/features/edge/proxy/hooks/use-delete-proxy';
 import { HttpProxyEdgeRequests } from '@/features/edge/proxy/metrics/edge-requests';
 import { HttpProxyWafEvents } from '@/features/edge/proxy/metrics/waf-events';
+import { HttpProxyWafTopRules } from '@/features/edge/proxy/metrics/waf-top-rules';
 import { ActivePopsCard } from '@/features/edge/proxy/overview/active-pops-card';
 import { HttpProxyConfigCard } from '@/features/edge/proxy/overview/config-card';
 import { HttpProxyGeneralCard } from '@/features/edge/proxy/overview/general-card';
@@ -90,11 +91,14 @@ export default function HttpProxyDetailPage() {
               <HttpProxyEdgeRequests projectId={projectId ?? ''} proxyId={proxyId ?? ''} />
               {effectiveProxy.trafficProtectionMode &&
                 effectiveProxy.trafficProtectionMode !== 'Disabled' && (
-                  <HttpProxyWafEvents
-                    projectId={projectId ?? ''}
-                    proxyId={proxyId ?? ''}
-                    trafficProtectionMode={effectiveProxy.trafficProtectionMode}
-                  />
+                  <>
+                    <HttpProxyWafEvents
+                      projectId={projectId ?? ''}
+                      proxyId={proxyId ?? ''}
+                      trafficProtectionMode={effectiveProxy.trafficProtectionMode}
+                    />
+                    <HttpProxyWafTopRules projectId={projectId ?? ''} proxyId={proxyId ?? ''} />
+                  </>
                 )}
             </CardContent>
           </Card>

--- a/app/routes/project/detail/edge/detail/index.tsx
+++ b/app/routes/project/detail/edge/detail/index.tsx
@@ -2,7 +2,6 @@ import { DangerCard } from '@/components/danger-card/danger-card';
 import { useDeleteProxy } from '@/features/edge/proxy/hooks/use-delete-proxy';
 import { HttpProxyEdgeRequests } from '@/features/edge/proxy/metrics/edge-requests';
 import { HttpProxyWafEvents } from '@/features/edge/proxy/metrics/waf-events';
-import { HttpProxyWafTopRules } from '@/features/edge/proxy/metrics/waf-top-rules';
 import { ActivePopsCard } from '@/features/edge/proxy/overview/active-pops-card';
 import { HttpProxyConfigCard } from '@/features/edge/proxy/overview/config-card';
 import { HttpProxyGeneralCard } from '@/features/edge/proxy/overview/general-card';
@@ -97,7 +96,6 @@ export default function HttpProxyDetailPage() {
                       proxyId={proxyId ?? ''}
                       trafficProtectionMode={effectiveProxy.trafficProtectionMode}
                     />
-                    <HttpProxyWafTopRules projectId={projectId ?? ''} proxyId={proxyId ?? ''} />
                   </>
                 )}
             </CardContent>

--- a/app/routes/project/detail/edge/detail/index.tsx
+++ b/app/routes/project/detail/edge/detail/index.tsx
@@ -90,7 +90,11 @@ export default function HttpProxyDetailPage() {
               <HttpProxyEdgeRequests projectId={projectId ?? ''} proxyId={proxyId ?? ''} />
               {effectiveProxy.trafficProtectionMode &&
                 effectiveProxy.trafficProtectionMode !== 'Disabled' && (
-                  <HttpProxyWafEvents projectId={projectId ?? ''} proxyId={proxyId ?? ''} />
+                  <HttpProxyWafEvents
+                    projectId={projectId ?? ''}
+                    proxyId={proxyId ?? ''}
+                    trafficProtectionMode={effectiveProxy.trafficProtectionMode}
+                  />
                 )}
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary

- Wires up Traffic Protection Events chart and inline Blocked/Allowed counters to the edge proxy detail page, shown only when WAF is enabled
- Fixes metric chart x-axis to span the full selected time window, with zero-value sentinels at boundaries so area charts don't appear clipped on either side
- Fixes metric card instant queries to evaluate at `timeRange.end` so displayed values reflect the selected window rather than the current moment
- Fixes WAF counter queries to use the full window duration and correct `coraza_outcome` label values (`blocked`/`dropped`/`allowed`)
- Compacts the edge requests layout: Requests per second and P95 Upstream Latency charts sit side-by-side at reduced height

<img width="1275" height="797" alt="image" src="https://github.com/user-attachments/assets/38841e5d-aa9d-4d82-9bcc-4fd8aff0086d" />

## Test plan

- [ ] Navigate to an AI Edge proxy detail page with WAF enabled — Traffic Protection Events chart and Blocked/Allowed inline counts should appear in the Metrics card
- [ ] Navigate to a proxy with WAF disabled — WAF section should not appear
- [ ] Change the time range selector — Blocked/Allowed counts should update to reflect the selected window
- [ ] Verify chart x-axis spans the full selected window (no empty sides)
- [ ] Verify Requests per second and P95 charts render side-by-side
- [ ] Proxy with `trafficProtectionMode: Observe` should show "Observed" instead of "Allowed"