### PR TITLE
fix(edge): replace @shadcn/ui/table with @datum-cloud/datum-ui/table in WAF metrics

### DIFF
--- a/app/features/edge/proxy/metrics/waf-top-rules.tsx
+++ b/app/features/edge/proxy/metrics/waf-top-rules.tsx
@@ -6,7 +6,7 @@ import {
 } from '@/modules/metrics';
 import { formatDurationFromMs, parseDurationToMs } from '@/modules/metrics/utils/date-parsers';
 import type { FormattedMetricData } from '@/modules/prometheus';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@shadcn/ui/table';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@datum-cloud/datum-ui/table';
 import { useMemo } from 'react';
 
 interface HttpProxyWafTopRulesProps {


### PR DESCRIPTION
## Summary

- Fixes type check failure caused by me using the wrong table component after PR #1205 (shadcn removal) landing 
- `waf-top-rules.tsx` was importing `Table` components from `@shadcn/ui/table` which no longer exists
- Updated to use `@datum-cloud/datum-ui/table` to match the rest of the codebase

## Test plan

- [ ] Type check passes (`bun typecheck`)
- [ ] WAF metrics table renders correctly on the AI edge detail page