### PR TITLE
chore(deps): bump conform-to/* and @hey-api/openapi-ts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,8 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.71",
         "@ai-sdk/react": "^3.0.170",
-        "@conform-to/react": "1.19.0",
-        "@conform-to/zod": "1.19.0",
+        "@conform-to/react": "1.19.1",
+        "@conform-to/zod": "1.19.1",
         "@datum-cloud/activity-ui": "^0.4.0",
         "@datum-cloud/datum-ui": "^0.8.1",
         "@epic-web/client-hints": "^1.3.9",
@@ -105,7 +105,7 @@
       "devDependencies": {
         "@eslint/compat": "^2.0.5",
         "@gqlts/cli": "^3.3.0",
-        "@hey-api/openapi-ts": "^0.96.1",
+        "@hey-api/openapi-ts": "^0.97.0",
         "@inquirer/prompts": "^8.4.2",
         "@react-router/dev": "^7.14.1",
         "@testing-library/cypress": "^10.1.0",
@@ -271,11 +271,11 @@
 
     "@chevrotain/utils": ["@chevrotain/utils@12.0.0", "", {}, "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA=="],
 
-    "@conform-to/dom": ["@conform-to/dom@1.19.0", "", {}, "sha512-2qegTdMy3ZT+SzzD8YyUWupAEhLl3X248bhrbhXdRsWjFdGSnTz12YB9j/f1MZ27A1LnmijKYiz2mgMdlblPAA=="],
+    "@conform-to/dom": ["@conform-to/dom@1.19.1", "", {}, "sha512-h4/T04zgASuiHMVEiXiyQA4jIW9zhpVFbp0HrWCQUDBxd8Zc1JbTarR7cuJyzkmqshC4tdm4VKIHguLp+7AYCw=="],
 
-    "@conform-to/react": ["@conform-to/react@1.19.0", "", { "dependencies": { "@conform-to/dom": "1.19.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-xK6+d2hHhiypLOpXIGLw9tD57N0GJFtmHBceaumS45tSV5Hr/bRiz1kioymJJrUUwV0bT+f1sTmHQZD6YJDOiw=="],
+    "@conform-to/react": ["@conform-to/react@1.19.1", "", { "dependencies": { "@conform-to/dom": "1.19.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-RrSfpy3B7bn1RoXCztlmQYMs113AWcvtqAluDqAx4yVbbVB+EcHWc3Ze/EXJhbtFDmljT2nMtcx/VY8f2RPGFg=="],
 
-    "@conform-to/zod": ["@conform-to/zod@1.19.0", "", { "dependencies": { "@conform-to/dom": "1.19.0" }, "peerDependencies": { "zod": "^3.21.0 || ^4.0.0" } }, "sha512-kqwuubmJPcyDlf3gXLWjKsWhTiox4ICL/eXLFZONjnEAOHGP1sUvfhvuYwJpH0PJu82kgz9JZG5iuVOcZGsygw=="],
+    "@conform-to/zod": ["@conform-to/zod@1.19.1", "", { "dependencies": { "@conform-to/dom": "1.19.1" }, "peerDependencies": { "zod": "^3.21.0 || ^4.0.0" } }, "sha512-S/C+Byhk87RdutjCuxhKcDf9lrmTx0V1OrtZPt5zrVG3RqcXVZz3NvLLZ7pNqdSg5DHGvuzPuotGfmPVu936ow=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
@@ -425,13 +425,13 @@
 
     "@hapi/topo": ["@hapi/topo@6.0.2", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg=="],
 
-    "@hey-api/codegen-core": ["@hey-api/codegen-core@0.8.0", "", { "dependencies": { "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "c12": "3.3.4", "color-support": "1.1.3" } }, "sha512-OuF/jenX9wz7AWHRBfb37v+jLkrfCt0FJXQuALNH2UsW6+bdZBmoibHl0K778SiHwneotJbAaEvX2S05wEqUQw=="],
+    "@hey-api/codegen-core": ["@hey-api/codegen-core@0.8.1", "", { "dependencies": { "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "c12": "3.3.4", "color-support": "1.1.3" } }, "sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA=="],
 
     "@hey-api/json-schema-ref-parser": ["@hey-api/json-schema-ref-parser@1.4.1", "", { "dependencies": { "@jsdevtools/ono": "7.1.3", "@types/json-schema": "7.0.15", "yaml": "2.8.3" } }, "sha512-DoPJGxVApDlktP1yYLjmOrF0YBEqb32ieCbx1S1i09n8TyCgdoh4yQaQ3kp0sMTauH+bwNKPsFh7S8qiWCoKZA=="],
 
-    "@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.96.1", "", { "dependencies": { "@hey-api/codegen-core": "0.8.0", "@hey-api/json-schema-ref-parser": "1.4.1", "@hey-api/shared": "0.4.1", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "color-support": "1.1.3", "commander": "14.0.3", "get-tsconfig": "4.14.0" }, "peerDependencies": { "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc" }, "bin": { "openapi-ts": "bin/run.js" } }, "sha512-EnH+6ncaVC1yNvYWcsO7MoeBSqCvYZaKvRDRqh+S7dsfb9lhe2mKUR2+7sDacGUBm7VDZZ7hg4q4egxlpZaf0g=="],
+    "@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.97.0", "", { "dependencies": { "@hey-api/codegen-core": "0.8.1", "@hey-api/json-schema-ref-parser": "1.4.1", "@hey-api/shared": "0.4.2", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "@lukeed/ms": "2.0.2", "ansi-colors": "4.1.3", "color-support": "1.1.3", "commander": "14.0.3", "get-tsconfig": "4.14.0" }, "peerDependencies": { "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc" }, "bin": { "openapi-ts": "bin/run.js" } }, "sha512-WZkKgrDlZpxKlDv2HkBCzaAYeuM+EtZKFmKGBv9/JblAKpX3JQTROi7PzlCZE3eisetRPSakbcRgn+LGyB7EiQ=="],
 
-    "@hey-api/shared": ["@hey-api/shared@0.4.1", "", { "dependencies": { "@hey-api/codegen-core": "0.8.0", "@hey-api/json-schema-ref-parser": "1.4.1", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "cross-spawn": "7.0.6", "open": "11.0.0", "semver": "7.7.4" } }, "sha512-EDAjvGpEamn2fOB7W87ZStyDSv5mEpnQCciVbiZ+Ll4EfawwIjHMMtDtRQOYol0YjTkAeEm274GFPAtg3xfPGA=="],
+    "@hey-api/shared": ["@hey-api/shared@0.4.2", "", { "dependencies": { "@hey-api/codegen-core": "0.8.1", "@hey-api/json-schema-ref-parser": "1.4.1", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "cross-spawn": "7.0.6", "open": "11.0.0", "semver": "7.7.4" } }, "sha512-4fconS10E0Xr4/acV8G+BkApxaIStxrT0GhB9BDTQWvrFTy5/nV933SyFk8qImcbpKvgv9hpn3N+7bV8oFrbjA=="],
 
     "@hey-api/spec-types": ["@hey-api/spec-types@0.2.0", "", { "dependencies": { "@hey-api/types": "0.1.4" } }, "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg=="],
 
@@ -510,6 +510,8 @@
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
+
+    "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.71",
     "@ai-sdk/react": "^3.0.170",
-    "@conform-to/react": "1.19.0",
-    "@conform-to/zod": "1.19.0",
+    "@conform-to/react": "1.19.1",
+    "@conform-to/zod": "1.19.1",
     "@datum-cloud/activity-ui": "^0.4.0",
     "@datum-cloud/datum-ui": "^0.8.1",
     "@epic-web/client-hints": "^1.3.9",
@@ -125,7 +125,7 @@
   "devDependencies": {
     "@eslint/compat": "^2.0.5",
     "@gqlts/cli": "^3.3.0",
-    "@hey-api/openapi-ts": "^0.96.1",
+    "@hey-api/openapi-ts": "^0.97.0",
     "@inquirer/prompts": "^8.4.2",
     "@react-router/dev": "^7.14.1",
     "@testing-library/cypress": "^10.1.0",


### PR DESCRIPTION
## Summary

Bundles 3 stale Renovate PRs into a single change rebased on latest main:

- `@conform-to/react` 1.19.0 → 1.19.1 (was #1211)
- `@conform-to/zod` 1.19.0 → 1.19.1 (was #1212)
- `@hey-api/openapi-ts` ^0.96.1 → ^0.97.0 (was #1214)

## Why bundle them?

#1211 and #1212 were both failing the **Type Check** CI step, but neither failure was caused by the version bump. Both PRs were opened on 2026-04-27, before #1205 (remove `@shadcn` module) merged. CI tripped on a stale `import ... from '@shadcn/ui/table'` reference that no longer exists on main. Rebasing on current main makes these clean.

#1214 was already green — bundling here keeps the dep-bump churn to a single PR/review/merge.

## Test plan

- [x] `bun install` — clean, no peer warnings
- [x] `bun run typecheck` — passes
- [x] `bun run build` — passes
- [x] Wait for CI: Type Check, Build, E2E Smoke, Lint, Unit Tests

## Supersedes

- Closes #1211
- Closes #1212
- Closes #1214