### PR TITLE
fix(layout): pass HelpScout beaconId via loader data, not window.ENV

### DIFF
--- a/app/layouts/private.layout.tsx
+++ b/app/layouts/private.layout.tsx
@@ -64,6 +64,7 @@ export const loader = withMiddleware(
       return data({
         user,
         helpscoutSignature: helpscoutSignaturePromise,
+        helpscoutBeaconId: serverEnv.public.helpscoutBeaconId ?? null,
       });
     } catch {
       return redirect(paths.auth.logOut);
@@ -90,8 +91,11 @@ function FathomWrapper({ children }: { children: ReactNode }) {
 }
 
 export default function PrivateLayout() {
-  const data: { user: User; helpscoutSignature: Promise<string | null> } =
-    useLoaderData<typeof loader>();
+  const data: {
+    user: User;
+    helpscoutSignature: Promise<string | null>;
+    helpscoutBeaconId: string | null;
+  } = useLoaderData<typeof loader>();
 
   const { setTheme } = useTheme();
 
@@ -119,9 +123,9 @@ export default function PrivateLayout() {
             <Suspense fallback={null}>
               <Await resolve={data?.helpscoutSignature} errorElement={null}>
                 {(helpscoutSignature) =>
-                  helpscoutSignature && window.ENV?.helpscoutBeaconId ? (
+                  helpscoutSignature && data?.helpscoutBeaconId ? (
                     <HelpScoutBeacon
-                      beaconId={window.ENV.helpscoutBeaconId}
+                      beaconId={data.helpscoutBeaconId}
                       displayStyle="manual"
                       user={{
                         name: `${data?.user?.givenName} ${data?.user?.familyName}`,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -145,7 +145,7 @@ function Document({ children, nonce }: { children: React.ReactNode; nonce: strin
         <ThemeScript nonce={nonce} defaultTheme="light" attribute="class" />
         <Links />
       </head>
-      <body className="bg-background h-auto w-full">
+      <body className="!bg-background h-auto w-full">
         {children}
 
         <Toaster position="top-right" theme={resolvedTheme as 'light' | 'dark'} />
@@ -256,7 +256,7 @@ function ErrorLayout({ children }: { children: React.ReactNode }) {
         <ThemeScript nonce={nonce} defaultTheme="light" attribute="class" />
         <Links />
       </head>
-      <body className="bg-background h-auto w-full">
+      <body className="!bg-background h-auto w-full">
         <div className="bg-muted flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
           <div className="w-full max-w-sm md:max-w-3xl">{children}</div>
         </div>


### PR DESCRIPTION
The Await render in private.layout wraps a promise that resolves synchronously (Promise.resolve(hash)), so React renders the children during SSR. Touching `window.ENV.helpscoutBeaconId` there crashes the server render whenever HELPSCOUT_BEACON_ID is configured, which breaks every authenticated route locally.

Move the beaconId onto the loader's data payload so the gate works on both server and client without reaching for window. Pure render-side change; no behaviour change when the env var is unset.