### PR TITLE
fix(deps): pin zod to 4.3.6 to restore form validation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tslib": "^2.8.1",
         "urql": "^5.0.2",
-        "zod": "^4",
+        "zod": "4.3.6",
       },
       "devDependencies": {
         "@eslint/compat": "^2.0.5",
@@ -3371,7 +3371,7 @@
 
     "zen-observable-ts": ["zen-observable-ts@1.1.0", "", { "dependencies": { "@types/zen-observable": "0.8.3", "zen-observable": "0.8.15" } }, "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA=="],
 
-    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
@@ -3612,6 +3612,8 @@
     "eslint-plugin-react/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "eslint-plugin-react-hooks/zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
 
     "execa/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tslib": "^2.8.1",
     "urql": "^5.0.2",
-    "zod": "^4"
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@eslint/compat": "^2.0.5",


### PR DESCRIPTION
## Summary

Pin `zod` to exact `4.3.6` to fix the E2E regression failures where every dialog-based form silently fails to submit.

## Root cause

The lockfile regen in `7d83e69e` floated `zod` from `4.3.6` → `4.4.1` (package.json pin was `^4`). Zod 4.4 changed something that breaks Conform's `parseWithZod` for schemas that use `.and()` / object intersections — `submission.status` never reaches `"success"`, so Conform never invokes the user's `onSubmit`. The submit button stays idle, no validation errors surface, and any test waiting for a post-submit redirect times out at 30s.

## What's affected

- **Broken**: every `Form.Dialog` (create org, create project, create DNS record, create DNS zone, create AI edge, create machine account) — schemas use `.and()` for resource-name + form-input merging
- **Working**: `Form.Root` forms (e.g. `AccountProfileSettingsCard`) — plain object schemas, no `.and()`

## Evidence

- **Last-green CI**: run [25144063214](https://github.com/datum-cloud/cloud-portal/actions/runs/25144063214) at commit `ec6163fc` — bun.lock had `zod@4.3.6`
- **First-red CI**: run [25145876812](https://github.com/datum-cloud/cloud-portal/actions/runs/25145876812) at commit `db7c62e2` — bun.lock had `zod@4.4.1`
- **Local repro**: 5 dialog forms all fail to fire `onSubmit` on Confirm; pinning to `4.3.6` immediately restores them.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` & `prettier` clean (lefthook pre-commit)
- [x] Local: `bun run dev` then create org → submit succeeds → redirects to `/org/{id}/...`
- [ ] CI E2E regression suite goes green
- [ ] Spot-check other dialog forms (create project, create DNS zone, etc.)

## Future work

Once Conform 1.19.x ships a fix for the Zod 4.4 incompatibility (or Zod 4.4.x ships a fix), unpin back to a range. Tracked separately.