### PR TITLE
fix(e2e): harden smoke tests against cold-start timeouts and empty table state

### DIFF
--- a/cypress/e2e/smoke/account.cy.ts
+++ b/cypress/e2e/smoke/account.cy.ts
@@ -41,10 +41,15 @@ describe('Load account settings', () => {
   it('should navigate to active sessions tab and render the sessions table', () => {
     cy.visit(paths.account.settings.activeSessions);
 
-    // Smoke goal: the page loads without crashing. The table is always rendered
-    // (even when the sessions list is empty) so waiting for it confirms the
-    // page settled past the React Query fetch.
-    cy.get('table', { timeout: 10000 }).should('exist');
+    // Smoke goal: the page loads without crashing. When sessions exist a
+    // <table> is rendered; when there are none, TableBodyOrEmpty swaps it for
+    // an EmptyContent card. Wait for either to confirm the page settled past
+    // the React Query fetch.
+    cy.get('body', { timeout: 10000 }).should(($body) => {
+      const hasTable = $body.find('table').length > 0;
+      const hasEmpty = $body.text().includes('No active sessions found.');
+      expect(hasTable || hasEmpty, 'sessions table or empty-state card').to.be.true;
+    });
 
     // Both `cy.login()` and the GraphQL sessions query are bypass-style: the
     // login helper signs the `_session` cookie directly and never seeds an

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -142,7 +142,7 @@ Cypress.Commands.add('getPersonalOrgId', (): Cypress.Chainable<string> => {
   // If not in env, fetch it from the page
   cy.visit(paths.account.organizations.root);
   return cy
-    .get('[data-e2e="organization-card-personal"]')
+    .get('[data-e2e="organization-card-personal"]', { timeout: 10000 })
     .should('be.visible')
     .find('[data-e2e="organization-card-id-copy"]')
     .should('be.visible')


### PR DESCRIPTION
## Summary

- **`getPersonalOrgId` timeout**: the first spec in a cold CI run (`ai-edge.cy.ts`) calls `cy.getPersonalOrgId()` which used the default 4 s Cypress timeout on the org-card selector. In CI the first API call is slow enough to miss that window. Added `{ timeout: 10000 }` to match what `createStandardOrg` already does.
- **Active-sessions `<table>` assumption**: `TableBodyOrEmpty` replaces the `<table>` element entirely with an `EmptyContent` card when data is empty and no filter is active. Test users authenticated via cookie (no real Zitadel session) always land in the empty state, so `cy.get('table')` never found the element. Replaced with a body assertion that accepts either the table or the "No active sessions found." text.

Fixes the `E2E Smoke` failure in the v0.6.3 release run: https://github.com/datum-cloud/cloud-portal/actions/runs/25196227392/job/73877628512

## Test plan

- [x] Run `bunx start-server-and-test 'bun run start' http://localhost:3000/_healthz 'bunx cypress run --spec "cypress/e2e/smoke/**" --config-file cypress.config.ts'` and confirm all 9 specs pass
- [x] Confirm `account.cy.ts` passes regardless of whether the test user has active sessions
- [x] Confirm CI smoke job passes on merge