### PR TITLE
fix(metrics): replace per-row export policy watches with single list watch

### DIFF
--- a/app/resources/export-policies/export-policy.watch.ts
+++ b/app/resources/export-policies/export-policy.watch.ts
@@ -28,6 +28,14 @@ export function useExportPoliciesWatch(projectId: string, options?: { enabled?: 
     queryKey: exportPolicyKeys.list(projectId),
     transform: (item) => toExportPolicy(item as ComDatumapisTelemetryV1Alpha1ExportPolicy),
     enabled: options?.enabled ?? true,
+    // In-place cache update for MODIFIED events. The list cache is a plain
+    // ExportPolicy[] (no { items: [] } envelope), so we map the array.
+    getItemKey: (policy) => policy.name,
+    updateListCache: (oldData, newItem) => {
+      const old = oldData as ExportPolicy[] | undefined;
+      if (!old) return [newItem];
+      return old.map((p) => (p.name === newItem.name ? newItem : p));
+    },
   });
 }
 

--- a/app/routes/project/detail/metrics/index.tsx
+++ b/app/routes/project/detail/metrics/index.tsx
@@ -5,9 +5,12 @@ import { ExportPolicyStatus } from '@/features/metric/export-policies/status';
 import {
   createExportPolicyService,
   useDeleteExportPolicy,
+  useExportPolicies,
+  useExportPoliciesWatch,
   type ExportPolicy,
 } from '@/resources/export-policies';
 import { paths } from '@/utils/config/paths.config';
+import { QUERY_STALE_TIME } from '@/utils/config/query.config';
 import { dataWithToast } from '@/utils/cookies';
 import { AppError, BadRequestError } from '@/utils/errors';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
@@ -50,10 +53,25 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 
 export default function ExportPoliciesPage() {
   const { projectId } = useParams();
-  const policies = useLoaderData<typeof loader>();
+  const initialData = useLoaderData<typeof loader>();
 
   const navigate = useNavigate();
   const { confirm } = useConfirmationDialog();
+
+  // Subscribe to live updates so the table reflects K8s state changes
+  // (status flips, creates/deletes from elsewhere) without per-row watches.
+  useExportPoliciesWatch(projectId ?? '');
+
+  // Seed the query cache from the SSR loader so the watch has a list to patch.
+  const { data: queryData } = useExportPolicies(projectId ?? '', {
+    initialData: initialData ?? [],
+    initialDataUpdatedAt: Date.now(),
+    refetchOnMount: false,
+    staleTime: QUERY_STALE_TIME,
+  });
+
+  const policies = queryData ?? initialData ?? [];
+
   const deleteExportPolicyMutation = useDeleteExportPolicy(projectId ?? '', {
     onError: (error) => {
       toast.error(error.message);
@@ -115,8 +133,6 @@ export default function ExportPoliciesPage() {
           return (
             <ExportPolicyStatus
               currentStatus={transformControlPlaneStatus(row.original.status)}
-              projectId={projectId}
-              id={row.original.name}
               showTooltip={false}
             />
           );


### PR DESCRIPTION
## Summary

The export-policies list table at `/project/:projectId/export-policies` was rendering `<ExportPolicyStatus projectId={...} id={row.name} />` inside every row's status cell. With those props set, the component's internal `shouldWatch` became true for any non-success/non-error policy and triggered:

- One SSE watch stream per pending row (`useExportPolicyWatch`)
- One polling query every 10 s per pending row (`useExportPolicy` with `refetchInterval`)

For projects with many export policies this fanned out into N concurrent watches + N polls. Service-accounts already solved the same shape with one list-level `useServiceAccountsWatch`; this PR mirrors that pattern.

## Changes

- **`app/resources/export-policies/export-policy.watch.ts`** — `useExportPoliciesWatch` now provides `getItemKey` and `updateListCache` so MODIFIED events patch the list cache in place (no network refetch). Same shape as `useServiceAccountsWatch`.
- **`app/routes/project/detail/metrics/index.tsx`**
  - Calls `useExportPoliciesWatch(projectId)` once at the page level → one SSE stream.
  - Seeds `useExportPolicies` from the loader (`initialData`, `refetchOnMount: false`, `staleTime`) so the list watch has a query cache to patch.
  - Drops `projectId` and `id` from the cell's `<ExportPolicyStatus>` so its `shouldWatch` resolves to false. The cell still receives `currentStatus={transformControlPlaneStatus(row.original.status)}` and the list watch keeps `row.original.status` fresh.

The detail card (`features/metric/export-policies/card/general-card.tsx`) still passes `projectId`/`id` to `ExportPolicyStatus`, which is the correct behavior on a single-resource page.

## Result

| | Before | After |
|---|---|---|
| SSE watch streams | N (one per pending row) | 1 |
| 10 s polling queries | N | 0 |
| Per-row `useExportPolicy` | Yes | No |
| Status freshness mechanism | Per-row refetch + watch | List-cache patch on MODIFIED |