### PR TITLE
fix(dev): pre-bundle late-discovered deps to stop dev flicker

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,17 +60,13 @@ export default defineConfig((config) => {
     },
     optimizeDeps: {
       include: [
-        // Top-imported datum-ui subpaths (counts from PR #1205 audit)
-        '@datum-cloud/datum-ui/popover', // 9 consumer files
-        '@datum-cloud/datum-ui/chart', // 6
-        '@datum-cloud/datum-ui/command', // 5
-        '@datum-cloud/datum-ui/separator', // 4
-        '@datum-cloud/datum-ui/avatar', // 4
-        '@datum-cloud/datum-ui/table', // 3
-        '@datum-cloud/datum-ui/select', // 3
-        '@datum-cloud/datum-ui/button', // heavy use across migrated files
-        '@datum-cloud/datum-ui/badge', // heavy use
-        '@datum-cloud/datum-ui/utils', // cn helper, 81 consumer files
+        // Pre-bundle all datum-ui subpath exports so navigating to a route
+        // that pulls in a not-yet-seen component doesn't trigger a re-optimize
+        // + full page reload in dev.
+        '@datum-cloud/datum-ui/*',
+        'recharts',
+        'class-variance-authority',
+        'd3-geo',
       ],
     },
     ssr: {


### PR DESCRIPTION
## Summary
- Replace hand-curated `@datum-cloud/datum-ui/*` subpath list in `optimizeDeps.include` with a glob so every subpath export is pre-bundled.
- Add `recharts`, `class-variance-authority`, and `d3-geo` to `optimizeDeps.include` — these were getting late-discovered mid-session and triggering full-page reloads.

## Why
In `bun run dev`, navigating to a route that imported a not-yet-optimized dep caused Vite to re-run `optimizeDeps`, invalidate the module graph, and force a full reload (CSS rebuild + flicker + bounce back to where you were). The second navigation worked because the dep was now cached in `node_modules/.vite/deps`. Pre-bundling these at server start eliminates the in-session re-optimize.

## Test plan
- [x] `bun run dev`, navigate between dashboard / charts / map routes — no full reloads, no `[vite] new dependencies optimized:` log lines mid-session
- [x] If new deps still get late-discovered, append them to the include list