### PR TITLE
feat(feature-flags): add MiloFeatureFlagProvider for OpenFeature

### DIFF
--- a/app/lib/feature-flags/README.md
+++ b/app/lib/feature-flags/README.md
@@ -1,0 +1,62 @@
+# Feature flags
+
+OpenFeature server provider backed by Milo `AllowanceBucket`s.
+
+A feature flag is an `AllowanceBucket` with `spec.type=Feature`. The flag is
+**enabled** for an organization when the bucket has `status.available > 0`.
+
+## Flag keys
+
+The OpenFeature flag key is the **full** `spec.resourceType` of the registered
+flag, e.g.
+
+```
+billing.miloapis.com/cloud-portal-usage-metering-dashboard
+```
+
+There is no implicit prefix. Use the same string the registration uses.
+
+## Setup (loader-side)
+
+```ts
+import { MiloFeatureFlagProvider } from '@/lib/feature-flags';
+import { createAllowanceBucketService } from '@/resources/allowance-buckets';
+import { OpenFeature } from '@openfeature/server-sdk';
+
+OpenFeature.setProvider(
+  new MiloFeatureFlagProvider({
+    bucketService: createAllowanceBucketService(),
+  })
+);
+```
+
+Do this once at app boot. The provider caches the per-org bucket list for 5 s,
+so a single page render that checks several flags performs at most one LIST.
+
+## Usage in a route loader
+
+```ts
+import { OpenFeature } from '@openfeature/server-sdk';
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  const client = OpenFeature.getClient();
+  const usageMeteringEnabled = await client.getBooleanValue(
+    'billing.miloapis.com/cloud-portal-usage-metering-dashboard',
+    false,
+    { targetingKey: params.orgId! }
+  );
+  return { usageMeteringEnabled };
+};
+```
+
+## Failure mode
+
+The provider never throws on resolution. On API error, missing bucket, or
+missing `targetingKey`, it returns the caller's `defaultValue`. Closed-by-default
+gating is the responsibility of each call site.
+
+## Tests
+
+```sh
+bun run test:lib
+```

--- a/app/lib/feature-flags/index.ts
+++ b/app/lib/feature-flags/index.ts
@@ -1,0 +1,5 @@
+export {
+  MiloFeatureFlagProvider,
+  type MiloFeatureFlagProviderOptions,
+  type OrgBucketLister,
+} from './milo-provider';

--- a/app/lib/feature-flags/milo-provider.test.ts
+++ b/app/lib/feature-flags/milo-provider.test.ts
@@ -1,0 +1,137 @@
+/// <reference types="bun-types/test" />
+import { MiloFeatureFlagProvider, type OrgBucketLister } from './milo-provider';
+import type { AllowanceBucket } from '@/resources/allowance-buckets';
+import { ErrorCode } from '@openfeature/server-sdk';
+import { describe, expect, mock, test } from 'bun:test';
+
+const FLAG = 'billing.miloapis.com/cloud-portal-usage-metering-dashboard';
+const ORG = 'acme';
+
+function bucket(resourceType: string, available: bigint | number): AllowanceBucket {
+  return {
+    uid: `uid-${resourceType}`,
+    name: `bucket-${resourceType}`,
+    namespace: `organization-${ORG}`,
+    resourceType,
+    status: { available, allocated: 0n, claimCount: 0 },
+  } as AllowanceBucket;
+}
+
+function mockLister(impl: (org: string) => Promise<AllowanceBucket[]>): {
+  service: OrgBucketLister;
+  list: ReturnType<typeof mock>;
+} {
+  const list = mock((_ns: 'organization', org: string) => impl(org));
+  return { service: { list } as OrgBucketLister, list };
+}
+
+describe('MiloFeatureFlagProvider', () => {
+  test('returns true / TARGETING_MATCH when bucket has available > 0', async () => {
+    const { service } = mockLister(async () => [bucket(FLAG, 1n)]);
+    const provider = new MiloFeatureFlagProvider({ bucketService: service });
+
+    const result = await provider.resolveBooleanEvaluation(FLAG, false, { targetingKey: ORG });
+
+    expect(result.value).toBe(true);
+    expect(result.reason).toBe('TARGETING_MATCH');
+  });
+
+  test('returns defaultValue / DEFAULT when no matching bucket exists', async () => {
+    const { service } = mockLister(async () => []);
+    const provider = new MiloFeatureFlagProvider({ bucketService: service });
+
+    const result = await provider.resolveBooleanEvaluation(FLAG, false, { targetingKey: ORG });
+
+    expect(result.value).toBe(false);
+    expect(result.reason).toBe('DEFAULT');
+  });
+
+  test('returns false / TARGETING_MATCH when bucket exists but available is 0', async () => {
+    const { service } = mockLister(async () => [bucket(FLAG, 0n)]);
+    const provider = new MiloFeatureFlagProvider({ bucketService: service });
+
+    const result = await provider.resolveBooleanEvaluation(FLAG, true, { targetingKey: ORG });
+
+    expect(result.value).toBe(false);
+    expect(result.reason).toBe('TARGETING_MATCH');
+  });
+
+  test('caches per-org bucket list across flag evaluations within TTL', async () => {
+    const { service, list } = mockLister(async () => [bucket(FLAG, 1n), bucket('other/flag', 1n)]);
+    const provider = new MiloFeatureFlagProvider({ bucketService: service, ttlMs: 5_000 });
+
+    await provider.resolveBooleanEvaluation(FLAG, false, { targetingKey: ORG });
+    await provider.resolveBooleanEvaluation('other/flag', false, { targetingKey: ORG });
+    await provider.resolveBooleanEvaluation(FLAG, false, { targetingKey: ORG });
+
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  test('refetches after TTL expires', async () => {
+    let now = 1_000;
+    const { service, list } = mockLister(async () => [bucket(FLAG, 1n)]);
+    const provider = new MiloFeatureFlagProvider({
+      bucketService: service,
+      ttlMs: 5_000,
+      now: () => now,
+    });
+
+    await provider.resolveBooleanEvaluation(FLAG, false, { targetingKey: ORG });
+    now += 6_000;
+    await provider.resolveBooleanEvaluation(FLAG, false, { targetingKey: ORG });
+
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  test('returns defaultValue / ERROR on lister failure without throwing', async () => {
+    const { service } = mockLister(async () => {
+      throw new Error('boom');
+    });
+    const provider = new MiloFeatureFlagProvider({ bucketService: service });
+
+    const result = await provider.resolveBooleanEvaluation(FLAG, true, { targetingKey: ORG });
+
+    expect(result.value).toBe(true);
+    expect(result.reason).toBe('ERROR');
+    expect(result.errorMessage).toContain('boom');
+  });
+
+  test('does not cache failures — next call re-fetches', async () => {
+    let calls = 0;
+    const lister = mock(async () => {
+      calls++;
+      if (calls === 1) throw new Error('transient');
+      return [bucket(FLAG, 1n)];
+    });
+    const provider = new MiloFeatureFlagProvider({
+      bucketService: { list: lister } as unknown as OrgBucketLister,
+    });
+
+    const first = await provider.resolveBooleanEvaluation(FLAG, false, { targetingKey: ORG });
+    const second = await provider.resolveBooleanEvaluation(FLAG, false, { targetingKey: ORG });
+
+    expect(first.reason).toBe('ERROR');
+    expect(second.value).toBe(true);
+    expect(lister).toHaveBeenCalledTimes(2);
+  });
+
+  test('returns defaultValue with TARGETING_KEY_MISSING when targetingKey is absent', async () => {
+    const { service, list } = mockLister(async () => []);
+    const provider = new MiloFeatureFlagProvider({ bucketService: service });
+
+    const result = await provider.resolveBooleanEvaluation(FLAG, false, {});
+
+    expect(result.value).toBe(false);
+    expect(result.errorCode).toBe(ErrorCode.TARGETING_KEY_MISSING);
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  test('non-boolean resolvers reject with TypeMismatchError', async () => {
+    const { service } = mockLister(async () => []);
+    const provider = new MiloFeatureFlagProvider({ bucketService: service });
+
+    await expect(provider.resolveStringEvaluation('x')).rejects.toThrow(/boolean/);
+    await expect(provider.resolveNumberEvaluation('x')).rejects.toThrow(/boolean/);
+    await expect(provider.resolveObjectEvaluation('x')).rejects.toThrow(/boolean/);
+  });
+});

--- a/app/lib/feature-flags/milo-provider.ts
+++ b/app/lib/feature-flags/milo-provider.ts
@@ -1,0 +1,148 @@
+import type { AllowanceBucket } from '@/resources/allowance-buckets';
+import {
+  ErrorCode,
+  StandardResolutionReasons,
+  TypeMismatchError,
+  type EvaluationContext,
+  type JsonValue,
+  type Provider,
+  type ProviderMetadata,
+  type ResolutionDetails,
+} from '@openfeature/server-sdk';
+
+const DEFAULT_TTL_MS = 5_000;
+
+/**
+ * Subset of the AllowanceBucket service used by the provider. The flag key
+ * passed to OpenFeature is the full bucket `spec.resourceType`
+ * (e.g. `billing.miloapis.com/cloud-portal-usage-metering-dashboard`), so
+ * the provider only needs to list buckets for the org.
+ */
+export interface OrgBucketLister {
+  list(namespace: 'organization', orgId: string): Promise<AllowanceBucket[]>;
+}
+
+export interface MiloFeatureFlagProviderOptions {
+  bucketService: OrgBucketLister;
+  /** Per-org cache TTL. Defaults to 5_000 ms. */
+  ttlMs?: number;
+  /** Override the clock for tests. */
+  now?: () => number;
+}
+
+interface CacheEntry {
+  expiresAt: number;
+  buckets: Map<string, AllowanceBucket>;
+}
+
+/**
+ * OpenFeature server provider backed by Milo AllowanceBuckets.
+ *
+ * Flag keys are the full `spec.resourceType` of a feature-typed
+ * ResourceRegistration (e.g. `billing.miloapis.com/cloud-portal-usage-metering-dashboard`).
+ * A flag is enabled for an org when an AllowanceBucket exists for
+ * (org, resourceType) with `status.available > 0`.
+ */
+export class MiloFeatureFlagProvider implements Provider {
+  readonly metadata: ProviderMetadata = { name: 'milo-allowance-bucket' };
+  readonly runsOn = 'server';
+
+  private readonly cache = new Map<string, Promise<CacheEntry>>();
+  private readonly bucketService: OrgBucketLister;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(opts: MiloFeatureFlagProviderOptions) {
+    this.bucketService = opts.bucketService;
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = opts.now ?? Date.now;
+  }
+
+  async resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    context: EvaluationContext
+  ): Promise<ResolutionDetails<boolean>> {
+    const orgName = context.targetingKey;
+    if (!orgName) {
+      return {
+        value: defaultValue,
+        reason: StandardResolutionReasons.DEFAULT,
+        errorCode: ErrorCode.TARGETING_KEY_MISSING,
+        errorMessage: 'targetingKey (organization name) is required',
+      };
+    }
+
+    let entry: CacheEntry;
+    try {
+      entry = await this.getOrgEntry(orgName);
+    } catch (err) {
+      return {
+        value: defaultValue,
+        reason: StandardResolutionReasons.ERROR,
+        errorCode: ErrorCode.GENERAL,
+        errorMessage: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    const bucket = entry.buckets.get(flagKey);
+    if (!bucket) {
+      return { value: defaultValue, reason: StandardResolutionReasons.DEFAULT };
+    }
+
+    const enabled = isAvailable(bucket.status?.available);
+    return {
+      value: enabled,
+      reason: StandardResolutionReasons.TARGETING_MATCH,
+    };
+  }
+
+  resolveStringEvaluation(_flagKey: string): Promise<ResolutionDetails<string>> {
+    return Promise.reject(new TypeMismatchError(BOOLEAN_ONLY_MESSAGE));
+  }
+
+  resolveNumberEvaluation(_flagKey: string): Promise<ResolutionDetails<number>> {
+    return Promise.reject(new TypeMismatchError(BOOLEAN_ONLY_MESSAGE));
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(_flagKey: string): Promise<ResolutionDetails<T>> {
+    return Promise.reject(new TypeMismatchError(BOOLEAN_ONLY_MESSAGE));
+  }
+
+  private getOrgEntry(orgName: string): Promise<CacheEntry> {
+    const cached = this.cache.get(orgName);
+    if (cached) {
+      return cached.then((entry) => {
+        if (entry.expiresAt > this.now()) return entry;
+        this.cache.delete(orgName);
+        return this.getOrgEntry(orgName);
+      });
+    }
+
+    const pending = this.bucketService.list('organization', orgName).then(
+      (buckets) => {
+        const byType = new Map<string, AllowanceBucket>();
+        for (const b of buckets) byType.set(b.resourceType, b);
+        return { expiresAt: this.now() + this.ttlMs, buckets: byType };
+      },
+      (err) => {
+        this.cache.delete(orgName);
+        throw err;
+      }
+    );
+
+    this.cache.set(orgName, pending);
+    return pending;
+  }
+}
+
+const BOOLEAN_ONLY_MESSAGE = 'milo feature flags are boolean entitlements; use getBooleanValue';
+
+function isAvailable(available: unknown): boolean {
+  if (available === undefined || available === null) return false;
+  try {
+    return BigInt(available as string | number | bigint) > 0n;
+  } catch {
+    return false;
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,7 @@
         "@typescript-eslint/eslint-plugin": "^8.59.1",
         "@typescript-eslint/parser": "^8.59.1",
         "@vitejs/plugin-react": "^5.1.4",
+        "bun-types": "^1.3.13",
         "cypress": "^15.14.0",
         "cypress-split": "^1.24.31",
         "cypress-vite": "^1.8.0",
@@ -1453,6 +1454,8 @@
     "builtin-status-codes": ["builtin-status-codes@3.0.0", "", {}, "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="],
 
     "bun": ["bun@1.3.13", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.13", "@oven/bun-darwin-x64": "1.3.13", "@oven/bun-darwin-x64-baseline": "1.3.13", "@oven/bun-linux-aarch64": "1.3.13", "@oven/bun-linux-aarch64-musl": "1.3.13", "@oven/bun-linux-x64": "1.3.13", "@oven/bun-linux-x64-baseline": "1.3.13", "@oven/bun-linux-x64-musl": "1.3.13", "@oven/bun-linux-x64-musl-baseline": "1.3.13", "@oven/bun-windows-aarch64": "1.3.13", "@oven/bun-windows-x64": "1.3.13", "@oven/bun-windows-x64-baseline": "1.3.13" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-b9T4xZ8KqCHs4+TkHJv540LG1B8OD7noKu0Qaizusx3jFtMDHY6osNqgbaOlwW2B8RB2AKzz+sjzlGKIGxIjZw=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@gqlts/runtime": "^3.3.0",
         "@hono/prometheus": "^1.0.3",
         "@monaco-editor/react": "^4.7.0",
+        "@openfeature/server-sdk": "^1.21.0",
         "@opentelemetry/auto-instrumentations-node": "^0.75.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.216.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
@@ -506,6 +507,10 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@openfeature/core": ["@openfeature/core@1.10.0", "", {}, "sha512-C3ynxtPYhe5qVJgQIqCNxZXeRXo4t1Eo86uiROr8+sD6F2OjEJGIp6VOGxz+r6jkad2s8Br9BnUJOvskhai/3A=="],
+
+    "@openfeature/server-sdk": ["@openfeature/server-sdk@1.21.0", "", { "peerDependencies": { "@openfeature/core": "^1.10.0" } }, "sha512-ZBVAiyMeN+dxurcXGJlvuOpYg9X7V923MVCI5dq/kE/5o8ys7MCOPhW44e4PS+XABHzSRTw44hcgWez93xwifw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:e2e:preview": "cypress run --config-file cypress.config.ts --quiet",
     "test:e2e:debug": "start-server-and-test 'bun run start' http://localhost:3000/_healthz 'cypress open'",
     "test:unit:prod": "cypress run --component --config-file cypress.config.ts --quiet",
-    "test:unit:debug": "cypress open --component"
+    "test:unit:debug": "cypress open --component",
+    "test:lib": "bun test app/lib"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.71",
@@ -35,6 +36,7 @@
     "@gqlts/runtime": "^3.3.0",
     "@hono/prometheus": "^1.0.3",
     "@monaco-editor/react": "^4.7.0",
+    "@openfeature/server-sdk": "^1.21.0",
     "@opentelemetry/auto-instrumentations-node": "^0.75.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.216.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
     "@vitejs/plugin-react": "^5.1.4",
+    "bun-types": "^1.3.13",
     "cypress": "^15.14.0",
     "cypress-split": "^1.24.31",
     "cypress-vite": "^1.8.0",


### PR DESCRIPTION
## Summary

- Adds `app/lib/feature-flags/` with a `MiloFeatureFlagProvider` implementing the OpenFeature server `Provider` interface, backed by the existing `AllowanceBucket` resource service.
- Flag key = full bucket `spec.resourceType` (e.g. `billing.miloapis.com/cloud-portal-usage-metering-dashboard`). No implicit prefix — matches the registration verbatim, including service-prefixed flags like the one in milo-os/billing#28.
- 5s per-org cache so a single render that checks multiple flags issues at most one LIST.
- Closed-by-default on miss / error / missing `targetingKey`. Non-boolean resolvers reject with `TypeMismatchError`.
- 9 unit tests under bun's built-in test runner; added `test:lib` script.
- README in the module documents loader-side setup, flag-key convention, and failure semantics.

## Why

Closes cloud-portal#1209 and ticks the "Frontend provider (TypeScript)" box on datum-cloud/enhancements#711. Lets us gate UI on org-level entitlements (`AllowanceBucket.status.available > 0`) with no parallel feature-flag system. The first consumer will be the usage-metering dashboard from datum-cloud/enhancements#68 once it lands.

## How to use

### Flag keys

The OpenFeature flag key is the **full** `spec.resourceType` of the registered flag — no implicit prefix. Use the same string the registration uses:

```
billing.miloapis.com/cloud-portal-usage-metering-dashboard
```

### Setup (do this once at app boot)

```ts
import { OpenFeature } from '@openfeature/server-sdk';
import { MiloFeatureFlagProvider } from '@/lib/feature-flags';
import { createAllowanceBucketService } from '@/resources/allowance-buckets';

OpenFeature.setProvider(
  new MiloFeatureFlagProvider({
    bucketService: createAllowanceBucketService(),
  })
);
```

The provider caches the per-org bucket list for 5s, so a single page render that checks several flags performs at most one LIST.

### Evaluating a flag in a route loader

```ts
import { OpenFeature } from '@openfeature/server-sdk';

export const loader = async ({ params }: LoaderFunctionArgs) => {
  const client = OpenFeature.getClient();
  const usageMeteringEnabled = await client.getBooleanValue(
    'billing.miloapis.com/cloud-portal-usage-metering-dashboard',
    false,
    { targetingKey: params.orgId! }
  );
  return { usageMeteringEnabled };
};
```

### Failure mode

The provider never throws on resolution. On API error, missing bucket, or missing `targetingKey` it returns the caller's `defaultValue`. **Closed-by-default gating is the responsibility of each call site** — pass `false` as the default for any flag that should stay off when the system is unhealthy.

## Notes / open items

- The provider is **not yet wired up** in any loader — gating an actual route is a follow-up PR that will ship together with the dashboard it gates.
- The Go OpenFeature provider was deferred per #711, so there's no canonical Go reference. This TS provider sets the convention: flag keys are full `resourceType` strings.

## Test plan

- [x] `bun run test:lib` — 9/9 passing (enabled, absent, available=0, cache hit, TTL refetch, fetch error, no-cache-on-failure, missing targetingKey, non-boolean rejection)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [ ] Smoke from a loader once a real flag/grant exists in a staging cluster