### PR TITLE
fix(proxy): allow HTTP protocol for IP-based origins

### DIFF
--- a/app/features/edge/proxy/form/protocol-endpoint-input.tsx
+++ b/app/features/edge/proxy/form/protocol-endpoint-input.tsx
@@ -13,15 +13,14 @@ import { useEffect, useMemo } from 'react';
 /**
  * Custom component that combines protocol selector with endpoint input.
  * Used in proxy forms to allow users to select HTTP/HTTPS protocol and enter an endpoint hostname.
- *
- * When the entered origin is an IP address, the protocol is forced to HTTPS.
  */
 interface ProtocolEndpointInputProps {
   autoFocus?: boolean;
   onIPChange?: (isIP: boolean) => void;
+  onProtocolChange?: (protocol: string) => void;
 }
 
-export const ProtocolEndpointInput = ({ autoFocus, onIPChange }: ProtocolEndpointInputProps) => {
+export const ProtocolEndpointInput = ({ autoFocus, onIPChange, onProtocolChange }: ProtocolEndpointInputProps) => {
   const { control: protocolControl, meta: protocolMeta } = Form.useField('protocol');
   const { control: endpointControl, meta: endpointMeta } = Form.useField('endpointHost');
 
@@ -35,14 +34,12 @@ export const ProtocolEndpointInput = ({ autoFocus, onIPChange }: ProtocolEndpoin
   }, [endpointValue]);
 
   useEffect(() => {
-    if (isIP && protocolValue !== 'https') {
-      protocolControl.change('https');
-    }
-  }, [isIP, protocolValue, protocolControl]);
-
-  useEffect(() => {
     onIPChange?.(isIP);
   }, [isIP, onIPChange]);
+
+  useEffect(() => {
+    onProtocolChange?.(protocolValue);
+  }, [protocolValue, onProtocolChange]);
 
   return (
     <InputWithAddons
@@ -50,8 +47,7 @@ export const ProtocolEndpointInput = ({ autoFocus, onIPChange }: ProtocolEndpoin
         <Select
           value={protocolValue}
           onValueChange={protocolControl.change}
-          name={protocolMeta.name}
-          disabled={isIP}>
+          name={protocolMeta.name}>
           <SelectTrigger
             id={protocolMeta.id}
             className="bg-accent h-6 min-h-6 gap-1 border px-2 py-0 shadow-none focus:ring-0 focus-visible:ring-0">

--- a/app/features/edge/proxy/proxy-form-dialog.tsx
+++ b/app/features/edge/proxy/proxy-form-dialog.tsx
@@ -29,6 +29,7 @@ export const HttpProxyFormDialog = forwardRef<HttpProxyFormDialogRef, HttpProxyF
     const [open, setOpen] = useState(false);
     const [nameRandomSuffix] = useState(() => generateRandomString(6));
     const [isIPOrigin, setIsIPOrigin] = useState(false);
+    const [protocol, setProtocol] = useState('https');
 
     const navigate = useNavigate();
     const { trackAction } = useAnalytics();
@@ -138,10 +139,10 @@ export const HttpProxyFormDialog = forwardRef<HttpProxyFormDialogRef, HttpProxyF
             name="endpointHost"
             label="Origin"
             required>
-            <ProtocolEndpointInput onIPChange={setIsIPOrigin} />
+            <ProtocolEndpointInput onIPChange={setIsIPOrigin} onProtocolChange={setProtocol} />
           </Form.Field>
 
-          {isIPOrigin && <ProxyTlsField required />}
+          {isIPOrigin && <ProxyTlsField required={protocol === 'https'} />}
         </div>
       </Form.Dialog>
     );

--- a/app/features/edge/proxy/proxy-origins-dialog.tsx
+++ b/app/features/edge/proxy/proxy-origins-dialog.tsx
@@ -34,6 +34,7 @@ export const ProxyOriginsDialog = forwardRef<ProxyOriginsDialogRef, ProxyOrigins
     const [proxy, setProxy] = useState<HttpProxy | null>(null);
     const [defaultValues, setDefaultValues] = useState<Partial<OriginsConfigSchema>>();
     const [isIPOrigin, setIsIPOrigin] = useState(false);
+    const [protocol, setProtocol] = useState('https');
 
     const updateMutation = useUpdateHttpProxy(projectId, proxyName);
 
@@ -44,6 +45,7 @@ export const ProxyOriginsDialog = forwardRef<ProxyOriginsDialogRef, ProxyOrigins
       const { protocol, endpointHost } = parseEndpoint(proxyData.endpoint);
       const hostname = endpointHost.split(':')[0];
       setIsIPOrigin(isIPAddress(hostname));
+      setProtocol(protocol);
 
       setDefaultValues({
         protocol,
@@ -101,10 +103,10 @@ export const ProxyOriginsDialog = forwardRef<ProxyOriginsDialogRef, ProxyOrigins
             name="endpointHost"
             label="Origin"
             required>
-            <ProtocolEndpointInput autoFocus onIPChange={setIsIPOrigin} />
+            <ProtocolEndpointInput autoFocus onIPChange={setIsIPOrigin} onProtocolChange={setProtocol} />
           </Form.Field>
 
-          {isIPOrigin && <ProxyTlsField required />}
+          {isIPOrigin && <ProxyTlsField required={protocol === 'https'} />}
         </div>
       </Form.Dialog>
     );


### PR DESCRIPTION
## What

Removes the UI restriction that forced HTTPS and disabled the protocol selector when the origin is an IP address. The API accepts `http://` for IP origins without issue — this was purely a frontend constraint.

Also fixes a secondary problem: the TLS hostname field was shown as **required** whenever the origin was an IP, regardless of protocol. It now only requires TLS hostname when the protocol is `https` (consistent with the existing Zod schema validation).

## Why

I was trying to update a proxy origin from `https://` to `http://` in the console and couldn't — the protocol dropdown was greyed out and locked to HTTPS as soon as I entered an IP address. I had to drop to `datumctl apply` to make the change.

I'm not sure if there was an intentional reason to block HTTP for IP origins. If there was a security or product rationale I've forgotten about, we should revisit — but since the API allows it freely, keeping the restriction only in the UI seems like the wrong layer to enforce it. Flagging here in case someone remembers the original intent.

## Changes

- `protocol-endpoint-input.tsx` — removed the `useEffect` that auto-switched IP origins to `https` and the `disabled={isIP}` on the protocol `<Select>`; added `onProtocolChange` callback so parent forms can track the selected protocol
- `proxy-origins-dialog.tsx` — tracks protocol alongside IP state; TLS hostname only required when protocol is `https`
- `proxy-form-dialog.tsx` — same fix as the edit dialog