### PR TITLE
security: harden supply-chain posture (SHA pinning, scope tightening, script hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
   BUN_CACHE: ~/.bun/install/cache
@@ -281,6 +284,10 @@ jobs:
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@545f34cd6f35e9688c9a04a7e890281bcdbaefd2 # v1.14.0
     with:
       image-name: cloud-portal
+    # NOTE: `secrets: inherit` is required because the upstream workflow
+    # references `secrets.SENTRY_AUTH_TOKEN` without declaring it under
+    # `workflow_call.secrets`. Once upstream declares it, switch to an
+    # explicit `secrets:` block passing only SENTRY_AUTH_TOKEN.
     secrets: inherit
 
   publish-kustomize-bundles:
@@ -297,7 +304,8 @@ jobs:
       bundle-path: config
       image-overlays: config/base
       image-name: ghcr.io/datum-cloud/cloud-portal
-    secrets: inherit
+    # No explicit secrets block: upstream only uses GITHUB_TOKEN, which is
+    # automatically available to reusable workflows.
 
   # ─── PR Comment ─────────────────────────────────────────────
   pr-comment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with: { bun-version: latest }
+        with: { bun-version: 1.3.13 } # renovate: datasource=docker depName=oven/bun
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: cache-deps
         with:
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with: { bun-version: latest }
+        with: { bun-version: 1.3.13 } # renovate: datasource=docker depName=oven/bun
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with: { bun-version: latest }
+        with: { bun-version: 1.3.13 } # renovate: datasource=docker depName=oven/bun
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with: { bun-version: latest }
+        with: { bun-version: 1.3.13 } # renovate: datasource=docker depName=oven/bun
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
@@ -120,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with: { bun-version: latest }
+        with: { bun-version: 1.3.13 } # renovate: datasource=docker depName=oven/bun
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
@@ -190,7 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with: { bun-version: latest }
+        with: { bun-version: 1.3.13 } # renovate: datasource=docker depName=oven/bun
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     name: Install Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with: { bun-version: latest }
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: cache-deps
         with:
           path: |
@@ -42,9 +42,9 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
-      - uses: actions/cache@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ${{ env.BUN_CACHE }}
@@ -57,10 +57,10 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with: { bun-version: latest }
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ${{ env.BUN_CACHE }}
@@ -74,17 +74,17 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !failure() && !cancelled() }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with: { bun-version: latest }
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ${{ env.BUN_CACHE }}
             **/node_modules
           key: ${{ runner.os }}-deps-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package.json') }}
       - run: bun run build
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: build
           key: build-${{ github.sha }}
@@ -96,10 +96,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !failure() && !cancelled() }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with: { bun-version: latest }
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ${{ env.BUN_CACHE }}
@@ -118,16 +118,16 @@ jobs:
     timeout-minutes: 10
     if: ${{ !failure() && !cancelled() }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with: { bun-version: latest }
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ${{ env.BUN_CACHE }}
             **/node_modules
           key: ${{ runner.os }}-deps-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package.json') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: build
           key: build-${{ github.sha }}
@@ -167,7 +167,7 @@ jobs:
           'bun run start' http://localhost:3000/_healthz
           'bunx cypress run --spec "cypress/e2e/smoke/**" --config-file cypress.config.ts'
       - if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-smoke-artifacts-${{ github.run_id }}
           path: |
@@ -188,16 +188,16 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3]
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with: { bun-version: latest }
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ${{ env.BUN_CACHE }}
             **/node_modules
           key: ${{ runner.os }}-deps-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package.json') }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: build
           key: build-${{ github.sha }}
@@ -240,7 +240,7 @@ jobs:
           'bun run start' http://localhost:3000/_healthz
           'bunx cypress run --config-file cypress.config.ts'
       - if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-regression-artifacts-${{ github.run_id }}-shard-${{ matrix.shard }}
           path: |
@@ -278,7 +278,7 @@ jobs:
       contents: read
       packages: write
       attestations: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.14.0
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@545f34cd6f35e9688c9a04a7e890281bcdbaefd2 # v1.14.0
     with:
       image-name: cloud-portal
     secrets: inherit
@@ -291,7 +291,7 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.14.0
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@545f34cd6f35e9688c9a04a7e890281bcdbaefd2 # v1.14.0
     with:
       bundle-name: ghcr.io/datum-cloud/cloud-portal-kustomize
       bundle-path: config
@@ -310,9 +310,9 @@ jobs:
       pull-requests: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Build test summary
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');
@@ -362,7 +362,7 @@ jobs:
 
             fs.writeFileSync('pr-summary.md', body);
 
-      - uses: peter-evans/create-or-update-comment@v5
+      - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: pr-summary.md

--- a/.github/workflows/set-project-month.yaml
+++ b/.github/workflows/set-project-month.yaml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   set-month:
-    uses: datum-cloud/actions/.github/workflows/set-project-month.yaml@v1.14.0
+    uses: datum-cloud/actions/.github/workflows/set-project-month.yaml@545f34cd6f35e9688c9a04a7e890281bcdbaefd2 # v1.14.0
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # syntax = docker/dockerfile:1
 
 # Use the latest Bun version
-FROM oven/bun:1.3.13 AS base
+FROM oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da08ea6262ae30e AS base
 
 # Install system dependencies and clean up in the same layer
 RUN apt-get update && \

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests", "docker:pinDigests"],
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security", "renovate"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security", "renovate"]

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,15 @@
     "labels": ["security", "renovate"]
   },
   "osvVulnerabilityAlerts": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": [
+        "bun-version:\\s*(?<currentValue>\\S+)\\s*}\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)"
+      ]
+    }
+  ],
   "packageRules": [
     {
       "matchPackagePatterns": [".*"],

--- a/scripts/graphql.ts
+++ b/scripts/graphql.ts
@@ -32,9 +32,26 @@ import {
   type DefinitionNode,
   type TypeDefinitionNode,
 } from 'graphql';
-import { spawn, execSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+
+/**
+ * Validates that a URL uses http or https. Rejects file://, data://, etc.
+ * to prevent the script from being pointed at unexpected schemes.
+ */
+function assertHttpUrl(url: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`URL must use http or https, got: ${parsed.protocol}`);
+  }
+  return parsed;
+}
 
 const OUTPUT_DIR = 'app/modules/graphql/generated';
 const TEMP_SCHEMA_FILE = 'temp-filtered-schema.graphql';
@@ -75,7 +92,6 @@ function exec(command: string, args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: 'inherit',
-      shell: true,
     });
 
     child.on('close', (code) => {
@@ -96,31 +112,33 @@ function exec(command: string, args: string[]): Promise<void> {
 async function fetchSchema(url: string): Promise<GraphQLSchema> {
   console.log(`Fetching full schema (this may take a moment)...`);
 
+  const parsed = assertHttpUrl(url);
   const query = getIntrospectionQuery();
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 300_000);
+
   try {
-    // Write query to temp file to avoid shell escaping issues
-    const tempQueryFile = '/tmp/graphql-introspection-query.json';
-    await writeFile(tempQueryFile, JSON.stringify({ query }));
+    const response = await fetch(parsed, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query }),
+      signal: controller.signal,
+    });
 
-    // Use curl with file input for reliable large response handling
-    const result = execSync(
-      `curl -s -X POST "${url}" -H "Content-Type: application/json" -d @${tempQueryFile}`,
-      {
-        maxBuffer: 100 * 1024 * 1024, // 100MB buffer
-        timeout: 300000, // 5 minute timeout
-      }
-    ).toString();
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
 
-    await rm(tempQueryFile, { force: true });
-
-    const data = JSON.parse(result) as { data: IntrospectionQuery };
+    const data = (await response.json()) as { data?: IntrospectionQuery };
     if (!data.data) {
       throw new Error('Invalid introspection response');
     }
     return buildClientSchema(data.data);
   } catch (error) {
     throw new Error(`Failed to fetch schema: ${error}`);
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/scripts/openapi.ts
+++ b/scripts/openapi.ts
@@ -15,6 +15,21 @@ import { join } from 'node:path';
 const CONTROL_PLANE_DIR = 'app/modules/control-plane';
 const TEMP_SPEC_FILE = 'temp-openapi-spec.json';
 
+/**
+ * Validates that a URL uses http or https. Rejects file://, data://, etc.
+ */
+function assertHttpUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`URL must use http or https, got: ${parsed.protocol}`);
+  }
+}
+
 interface ResourceSelection {
   resource: string;
   folder: string;
@@ -30,6 +45,7 @@ interface ResourceInfo {
  * Fetch the list of available OpenAPI resources from the API
  */
 async function fetchResourceList(apiUrl: string, token: string): Promise<ResourceInfo[]> {
+  assertHttpUrl(apiUrl);
   const url = `${apiUrl}/openapi/v3`;
 
   console.log(`\nFetching available resources from ${url}...`);
@@ -83,6 +99,7 @@ async function fetchSpec(
   serverRelativeURL: string
 ): Promise<object> {
   // serverRelativeURL is like "/openapi/v3/apis/iam.miloapis.com/v1alpha1?hash=..."
+  assertHttpUrl(apiUrl);
   const url = `${apiUrl}${serverRelativeURL}`;
 
   const response = await fetch(url, {


### PR DESCRIPTION
## Summary

Five-commit supply-chain hardening pass. Each change is independently revertible and addresses a finding from a security audit of CI, build, and codegen tooling.

- **Pin every `uses:` to a 40-char commit SHA** (workflows + reusable workflows). Defends against tag-rewrite / maintainer-compromise attacks (cf. tj-actions/changed-files). Trailing `# vN` comments keep the diff readable.
- **Pin `oven-sh/setup-bun` to `1.3.13`** (matches the Dockerfile) instead of `latest`. A Renovate customManager regex bumps the value via the `oven/bun` Docker datasource.
- **Add workflow-level `permissions: contents: read`**, dropping the default GITHUB_TOKEN scope to read-only for the eight jobs without an explicit permissions block.
- **Remove `secrets: inherit` from `publish-kustomize-bundles`** (upstream only uses `GITHUB_TOKEN`, which is auto-passed). Keep it on `publish-container-image` with a comment explaining the upstream dependency on `secrets.SENTRY_AUTH_TOKEN`.
- **Harden `scripts/graphql.ts`**: replace `execSync` + `curl` (with user-supplied URL interpolated into the command string — a real injection vector) with native `fetch()` + `AbortController`. Drop `shell: true` from the `spawn` call. Add `assertHttpUrl()` to reject non-http(s) schemes.
- **Harden `scripts/openapi.ts`**: add `assertHttpUrl()` guards on both fetch sites (defense-in-depth; already used native fetch).
- **Pin Dockerfile base image** `oven/bun:1.3.13` to its multi-arch index digest.
- **Renovate**: enable `helpers:pinGitHubActionDigests` + `docker:pinDigests` presets so future updates land as SHA/digest bumps (with version comment) instead of letting pins go stale.

## Commits

| SHA | Change |
|---|---|
| `0caf9119` | Pin GitHub Actions to commit SHAs |
| `8a09e2d3` | Pin Bun version in CI to match Dockerfile |
| `dd183381` | Tighten GITHUB_TOKEN scope and drop unneeded `secrets: inherit` |
| `08c67e2a` | Harden codegen scripts against shell injection |
| `7cd88690` | Pin Dockerfile base image by digest |

## Follow-ups (not in this PR)

- `datum-cloud/actions` `publish-docker.yaml` references `secrets.SENTRY_AUTH_TOKEN` without declaring it under `workflow_call.secrets`. Once upstream declares it, switch `publish-container-image` from `secrets: inherit` to an explicit single-secret pass-through.
- Add OSV / Socket scanning to PRs.
- Add `gitleaks` (or similar) secret-scan stage to `lefthook.yml`.
- Generate SBOMs + SLSA provenance attestations from the publish jobs (the `attestations: write` permission is already granted but unused).
- Move runtime caret ranges in `package.json` to exact pins (covered by audit item #10).

## Test plan

- [ ] CI green on this PR (lint, typecheck, build, unit, e2e smoke + regression all pass with newly-pinned action SHAs and Bun 1.3.13).
- [ ] Container build succeeds against the digest-pinned base image on amd64 and arm64.
- [ ] Manual local run of `bun run graphql` against a valid `http://` URL still fetches the schema and generates the Gqlts client.
- [ ] Manual local run of `bun run graphql` against a `file://` URL fails fast with a clear error.
- [ ] `publish-container-image` still has access to `SENTRY_AUTH_TOKEN` when invoked on a release (verify the upstream Sentry sourcemap upload step still runs).
- [ ] `publish-kustomize-bundles` still publishes correctly without `secrets: inherit`.