### PR TITLE
chore: remove unused react-day-picker dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,6 @@
         "prom-client": "^15.1.3",
         "rate-limit-redis": "^5.0.0",
         "react": "^19.2.5",
-        "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.5",
         "react-dropzone": "^15.0.0",
         "react-router": "^7.14.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "prom-client": "^15.1.3",
     "rate-limit-redis": "^5.0.0",
     "react": "^19.2.5",
-    "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.5",
     "react-dropzone": "^15.0.0",
     "react-router": "^7.14.2",


### PR DESCRIPTION
## Summary
- `react-day-picker` is declared in `package.json` but has zero imports across the codebase (`grep -rn react-day-picker app/` returns nothing; no `DayPicker` usages either).
- Drop it to shrink the dependency surface and close out the v9→v10 major-bump Renovate PR (#1242) as unneeded.

## Test plan
- [ ] `bun install` cleanly updates `bun.lock`
- [ ] `bun run typecheck` passes
- [ ] `bun run build` passes

Closes #1242