### PR TITLE
fix(forms): Validate AI Edge origin client-side and disable autocap

### DIFF
--- a/app/components/input-name/input-name.tsx
+++ b/app/components/input-name/input-name.tsx
@@ -115,6 +115,9 @@ export const InputName = ({
           key={field.id}
           ref={inputRef}
           autoFocus={autoFocus}
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
           placeholder="e.g. my-name-3sd122"
         />
       </Field>

--- a/app/components/key-value-form-dialog.tsx
+++ b/app/components/key-value-form-dialog.tsx
@@ -62,7 +62,13 @@ export const KeyValueFormDialog = forwardRef<KeyValueFormDialogRef, KeyValueForm
         className="sm:max-w-lg">
         <div className="space-y-4 px-5 py-5">
           <Form.Field name="key" label="Key" required>
-            <Form.Input autoFocus placeholder="e.g. app" />
+            <Form.Input
+              autoFocus
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              placeholder="e.g. app"
+            />
           </Form.Field>
           <Form.Field name="value" label="Value" required>
             <Form.Input placeholder="e.g. Nginx" />

--- a/app/features/edge/dns-zone/dns-zone-form-dialog.tsx
+++ b/app/features/edge/dns-zone/dns-zone-form-dialog.tsx
@@ -86,6 +86,9 @@ export const DnsZoneFormDialog = forwardRef<DnsZoneFormDialogRef, DnsZoneFormDia
             required>
             <Form.Input
               autoFocus
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
               placeholder="e.g. example.com"
               data-e2e="create-dns-zone-name-input"
             />

--- a/app/features/edge/dns-zone/form/dns-record-form.tsx
+++ b/app/features/edge/dns-zone/form/dns-record-form.tsx
@@ -205,7 +205,13 @@ export function DnsRecordForm({
 
             {/* Name */}
             <Form.Field name="name" label="Name" required>
-              <Form.Input placeholder="e.g., www or @" disabled={loading} />
+              <Form.Input
+                placeholder="e.g., www or @"
+                disabled={loading}
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+              />
             </Form.Field>
 
             {/* TTL */}

--- a/app/features/edge/dns-zone/form/types/a-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/a-record-field.tsx
@@ -2,6 +2,11 @@ import { Form } from '@datum-cloud/datum-ui/form';
 
 export const ARecordField = () => (
   <Form.Field name="a.content" label="IPv4 Address" required>
-    <Form.Input placeholder="e.g., 192.168.1.1" />
+    <Form.Input
+      placeholder="e.g., 192.168.1.1"
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
+    />
   </Form.Field>
 );

--- a/app/features/edge/dns-zone/form/types/aaaa-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/aaaa-record-field.tsx
@@ -2,6 +2,11 @@ import { Form } from '@datum-cloud/datum-ui/form';
 
 export const AAAARecordField = () => (
   <Form.Field name="aaaa.content" label="IPv6 Address" required>
-    <Form.Input placeholder="e.g., 2001:0db8:85a3:0000:0000:8a2e:0370:7334" />
+    <Form.Input
+      placeholder="e.g., 2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
+    />
   </Form.Field>
 );

--- a/app/features/edge/dns-zone/form/types/alias-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/alias-record-field.tsx
@@ -2,6 +2,11 @@ import { Form } from '@datum-cloud/datum-ui/form';
 
 export const ALIASRecordField = () => (
   <Form.Field name="alias.content" label="Target Domain" required>
-    <Form.Input placeholder="e.g., example.com" />
+    <Form.Input
+      placeholder="e.g., example.com"
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
+    />
   </Form.Field>
 );

--- a/app/features/edge/dns-zone/form/types/caa-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/caa-record-field.tsx
@@ -40,7 +40,12 @@ export const CAARecordField = () => (
     </Form.Field>
 
     <Form.Field name="caa.value" label="Value" required>
-      <Form.Input placeholder="e.g., letsencrypt.org" />
+      <Form.Input
+        placeholder="e.g., letsencrypt.org"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
     </Form.Field>
   </>
 );

--- a/app/features/edge/dns-zone/form/types/cname-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/cname-record-field.tsx
@@ -2,6 +2,11 @@ import { Form } from '@datum-cloud/datum-ui/form';
 
 export const CNAMERecordField = () => (
   <Form.Field name="cname.content" label="Target Domain" required>
-    <Form.Input placeholder="e.g., example.com" />
+    <Form.Input
+      placeholder="e.g., example.com"
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
+    />
   </Form.Field>
 );

--- a/app/features/edge/dns-zone/form/types/https-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/https-record-field.tsx
@@ -7,11 +7,21 @@ export const HTTPSRecordField = () => (
     </Form.Field>
 
     <Form.Field name="https.target" label="Target" required>
-      <Form.Input placeholder="e.g., example.com or ." />
+      <Form.Input
+        placeholder="e.g., example.com or ."
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
     </Form.Field>
 
     <Form.Field name="https.params" label="Value" className="col-span-full sm:col-span-2">
-      <Form.Input placeholder='e.g., alpn="h3,h2" ipv4hint="127.0.0.1" ipv6hint="::1"' />
+      <Form.Input
+        placeholder='e.g., alpn="h3,h2" ipv4hint="127.0.0.1" ipv6hint="::1"'
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
     </Form.Field>
   </>
 );

--- a/app/features/edge/dns-zone/form/types/mx-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/mx-record-field.tsx
@@ -3,7 +3,12 @@ import { Form } from '@datum-cloud/datum-ui/form';
 export const MXRecordField = () => (
   <>
     <Form.Field name="mx.exchange" label="Mail Server" required>
-      <Form.Input placeholder="e.g., mail.example.com" />
+      <Form.Input
+        placeholder="e.g., mail.example.com"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
     </Form.Field>
 
     <Form.Field name="mx.preference" label="Priority" required>

--- a/app/features/edge/dns-zone/form/types/ns-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/ns-record-field.tsx
@@ -2,6 +2,11 @@ import { Form } from '@datum-cloud/datum-ui/form';
 
 export const NSRecordField = () => (
   <Form.Field name="ns.content" label="Nameserver" required>
-    <Form.Input placeholder="e.g., ns1.example.com" />
+    <Form.Input
+      placeholder="e.g., ns1.example.com"
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
+    />
   </Form.Field>
 );

--- a/app/features/edge/dns-zone/form/types/ptr-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/ptr-record-field.tsx
@@ -2,6 +2,11 @@ import { Form } from '@datum-cloud/datum-ui/form';
 
 export const PTRRecordField = () => (
   <Form.Field name="ptr.content" label="Target Domain" required>
-    <Form.Input placeholder="e.g., host.example.com" />
+    <Form.Input
+      placeholder="e.g., host.example.com"
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
+    />
   </Form.Field>
 );

--- a/app/features/edge/dns-zone/form/types/soa-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/soa-record-field.tsx
@@ -3,11 +3,21 @@ import { Form } from '@datum-cloud/datum-ui/form';
 export const SOARecordField = () => (
   <>
     <Form.Field name="soa.mname" label="Primary Nameserver (MNAME)" required>
-      <Form.Input placeholder="e.g., ns1.example.com" />
+      <Form.Input
+        placeholder="e.g., ns1.example.com"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
     </Form.Field>
 
     <Form.Field name="soa.rname" label="Responsible Email (RNAME)" required>
-      <Form.Input placeholder="e.g., admin.example.com" />
+      <Form.Input
+        placeholder="e.g., admin.example.com"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
     </Form.Field>
 
     <Form.Field name="soa.serial" label="Serial">

--- a/app/features/edge/dns-zone/form/types/srv-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/srv-record-field.tsx
@@ -3,7 +3,12 @@ import { Form } from '@datum-cloud/datum-ui/form';
 export const SRVRecordField = () => (
   <>
     <Form.Field name="srv.target" label="Target Server" required>
-      <Form.Input placeholder="e.g., server.example.com" />
+      <Form.Input
+        placeholder="e.g., server.example.com"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
     </Form.Field>
 
     <Form.Field name="srv.priority" label="Priority" required>

--- a/app/features/edge/dns-zone/form/types/svcb-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/svcb-record-field.tsx
@@ -7,11 +7,21 @@ export const SVCBRecordField = () => (
     </Form.Field>
 
     <Form.Field name="svcb.target" label="Target" required>
-      <Form.Input placeholder="e.g., example.com or ." />
+      <Form.Input
+        placeholder="e.g., example.com or ."
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
     </Form.Field>
 
     <Form.Field name="svcb.params" label="Value" className="col-span-full sm:col-span-2">
-      <Form.Input placeholder='E.g. alpn="h3,h2" ipv4hint="127.0.0.1" ipv6hint="::1"' />
+      <Form.Input
+        placeholder='E.g. alpn="h3,h2" ipv4hint="127.0.0.1" ipv6hint="::1"'
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
     </Form.Field>
   </>
 );

--- a/app/features/edge/dns-zone/form/types/tlsa-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/tlsa-record-field.tsx
@@ -23,6 +23,9 @@ export const TLSARecordField = () => (
         placeholder="e.g., 0EED2700D3F228FDB..."
         className="font-mono text-xs"
         rows={3}
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
       />
     </Form.Field>
   </>

--- a/app/features/edge/dns-zone/form/types/txt-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/txt-record-field.tsx
@@ -2,6 +2,12 @@ import { Form } from '@datum-cloud/datum-ui/form';
 
 export const TXTRecordField = () => (
   <Form.Field name="txt.content" label="Text Content" required className="col-span-full">
-    <Form.Input placeholder="e.g., v=spf1 include:_spf.example.com ~all" maxLength={255} />
+    <Form.Input
+      placeholder="e.g., v=spf1 include:_spf.example.com ~all"
+      maxLength={255}
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
+    />
   </Form.Field>
 );

--- a/app/features/edge/domain/bulk-add/bulk-add-domains-action.tsx
+++ b/app/features/edge/domain/bulk-add/bulk-add-domains-action.tsx
@@ -168,6 +168,9 @@ export const BulkAddDomainsAction = ({
           <Form.Textarea
             placeholder={'example.com, example.org\nexample.net'}
             className="h-48 resize-none"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
           />
         </Form.Field>
         <BulkDomainsSubmitButton />

--- a/app/features/edge/domain/domain-form-dialog.tsx
+++ b/app/features/edge/domain/domain-form-dialog.tsx
@@ -71,6 +71,9 @@ export const DomainFormDialog = forwardRef<DomainFormDialogRef, DomainFormDialog
           <Form.Input
             placeholder="e.g. example.com"
             autoFocus
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
             data-e2e="create-domain-name-input"
           />
         </Form.Field>

--- a/app/features/edge/proxy/form/protocol-endpoint-input.tsx
+++ b/app/features/edge/proxy/form/protocol-endpoint-input.tsx
@@ -20,7 +20,11 @@ interface ProtocolEndpointInputProps {
   onProtocolChange?: (protocol: string) => void;
 }
 
-export const ProtocolEndpointInput = ({ autoFocus, onIPChange, onProtocolChange }: ProtocolEndpointInputProps) => {
+export const ProtocolEndpointInput = ({
+  autoFocus,
+  onIPChange,
+  onProtocolChange,
+}: ProtocolEndpointInputProps) => {
   const { control: protocolControl, meta: protocolMeta } = Form.useField('protocol');
   const { control: endpointControl, meta: endpointMeta } = Form.useField('endpointHost');
 
@@ -65,6 +69,9 @@ export const ProtocolEndpointInput = ({ autoFocus, onIPChange, onProtocolChange 
       name={endpointMeta.name}
       id={endpointMeta.id}
       autoFocus={autoFocus}
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
       placeholder="e.g. api.example.com or 203.0.113.1:8080"
       className="text-xs!"
     />

--- a/app/features/edge/proxy/form/subdomain-hostname-field.tsx
+++ b/app/features/edge/proxy/form/subdomain-hostname-field.tsx
@@ -240,6 +240,9 @@ export function SubdomainHostnameField({
             onChange={handleCustomChange}
             onBlur={control.blur}
             disabled={fieldDisabled}
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
             placeholder="e.g. api.external-domain.com"
             className="text-input-foreground placeholder:text-input-placeholder h-9 min-w-0 flex-1 bg-transparent px-3 text-xs focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-hidden"
           />
@@ -301,6 +304,9 @@ export function SubdomainHostnameField({
             onChange={handlePrefixChange}
             onBlur={control.blur}
             disabled={fieldDisabled}
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
             placeholder="subdomain (leave blank to use apex)"
             className="text-input-foreground placeholder:text-input-placeholder h-9 min-w-0 flex-1 bg-transparent px-3 text-xs focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-hidden"
           />

--- a/app/features/edge/proxy/form/tls-field.tsx
+++ b/app/features/edge/proxy/form/tls-field.tsx
@@ -15,7 +15,12 @@ export const ProxyTlsField = ({ required = false }: ProxyTlsFieldProps) => {
           ? 'The hostname to use for TLS certificate validation with your IP-based endpoint (required for SNI and certificate hostname matching)'
           : 'The hostname to use for TLS certificate validation (SNI and certificate hostname matching). Leave empty to use the hostname from the endpoint URL.'
       }>
-      <Form.Input placeholder="e.g. secure.example.com" />
+      <Form.Input
+        placeholder="e.g. secure.example.com"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+      />
     </Form.Field>
   );
 };

--- a/app/features/edge/proxy/proxy-basic-auth-dialog.tsx
+++ b/app/features/edge/proxy/proxy-basic-auth-dialog.tsx
@@ -178,6 +178,9 @@ export const ProxyBasicAuthDialog = forwardRef<ProxyBasicAuthDialogRef, ProxyBas
                               onBlur={control.blur}
                               onFocus={control.focus}
                               placeholder="username"
+                              autoCapitalize="none"
+                              autoCorrect="off"
+                              spellCheck={false}
                             />
                           )}
                         </Form.Field>

--- a/app/features/metric/export-policies/form/sink/prometheus/prometheus-field.tsx
+++ b/app/features/metric/export-policies/form/sink/prometheus/prometheus-field.tsx
@@ -17,7 +17,13 @@ export const PrometheusField = ({
       <FieldLabel label="Prometheus Configuration" />
       <div className="flex w-full flex-col gap-4 rounded-md border p-4">
         <Form.Field name={`${baseName}.endpoint`} label="Endpoint URL" required className="w-full">
-          <Form.Input type="text" placeholder="e.g. http://localhost:9090" />
+          <Form.Input
+            type="text"
+            placeholder="e.g. http://localhost:9090"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+          />
         </Form.Field>
 
         <Separator />

--- a/app/features/metric/export-policies/providers/grafana/grafana-form.tsx
+++ b/app/features/metric/export-policies/providers/grafana/grafana-form.tsx
@@ -280,7 +280,12 @@ export function GrafanaForm({ projectId, onClose, onSuccess }: GrafanaFormProps)
                       </p>
                     </div>
                     <Form.Field name="instanceUrl" required>
-                      <Form.Input placeholder="e.g. https://your-instance.grafana.net" />
+                      <Form.Input
+                        placeholder="e.g. https://your-instance.grafana.net"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        spellCheck={false}
+                      />
                     </Form.Field>
                   </div>
                 </div>

--- a/app/features/secret/form/key-value-field-array.tsx
+++ b/app/features/secret/form/key-value-field-array.tsx
@@ -30,6 +30,9 @@ export function KeyValueFieldArray({ name = 'variables' }: KeyValueFieldArrayPro
                       onFocus={control.focus}
                       placeholder="e.g. username"
                       className="text-xs!"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      spellCheck={false}
                     />
                   )}
                 </Form.Field>

--- a/app/resources/http-proxies/http-proxy.schema.ts
+++ b/app/resources/http-proxies/http-proxy.schema.ts
@@ -240,30 +240,48 @@ export const httpProxyHostnameSchema = z.object({
 });
 
 // Helper function to validate hostname:port (without protocol)
-function isValidHostnamePort(value: string): boolean {
-  if (!value || typeof value !== 'string') return false;
+function parseHostnamePort(value: string): { hostname: string; port?: string } | null {
+  if (!value || typeof value !== 'string') return null;
   const trimmed = value.trim();
-  if (trimmed !== value) return false;
+  if (trimmed !== value) return null;
 
   // Check for port separator
   const parts = trimmed.split(':');
-  if (parts.length > 2) return false; // Only one colon allowed for port
+  if (parts.length > 2) return null; // Only one colon allowed for port
 
   const hostname = parts[0];
   const port = parts[1];
 
-  // Validate hostname (can be hostname or IP)
-  if (!hostname || hostname.length === 0) return false;
+  if (!hostname || hostname.length === 0 || hostname.length > 253) return null;
 
   // Validate port if present
   if (port !== undefined) {
     const portNum = Number.parseInt(port, 10);
-    if (Number.isNaN(portNum) || portNum < 1 || portNum > 65535) return false;
+    if (Number.isNaN(portNum) || portNum < 1 || portNum > 65535) return null;
   }
 
-  // Hostname can be a valid hostname or IP address
-  // Basic validation - more detailed validation happens when combining with protocol
-  return hostname.length > 0 && hostname.length <= 253;
+  return { hostname, port };
+}
+
+function isValidHostnamePort(value: string): boolean {
+  return parseHostnamePort(value) !== null;
+}
+
+/**
+ * Returns true when the host portion of a hostname:port string is either:
+ *   - A valid IP address, or
+ *   - A fully qualified domain (contains at least two dot-separated labels).
+ *
+ * This mirrors the API server's admission rule that rejects single-label
+ * hostnames like "hello" with "must be a domain with at least two segments
+ * separated by dots".
+ */
+function isFullyQualifiedHostOrIP(value: string): boolean {
+  const parsed = parseHostnamePort(value);
+  if (!parsed) return false;
+  if (isIPAddress(parsed.hostname)) return true;
+  const labels = parsed.hostname.split('.').filter(Boolean);
+  return labels.length >= 2;
 }
 
 export const httpProxySchema = z
@@ -280,6 +298,10 @@ export const httpProxySchema = z
       .refine(isValidHostnamePort, {
         message:
           'Origin must be a valid hostname or IP address with optional port (e.g., api.example.com:8080)',
+      })
+      .refine(isFullyQualifiedHostOrIP, {
+        message:
+          'Origin must be a fully qualified domain with at least two segments separated by dots (e.g., api.example.com) or a valid IP address',
       }),
     tlsHostname: z.string().min(1).max(253).optional(),
     trafficProtectionMode: trafficProtectionModeSchema.default('Enforce'),

--- a/cypress/component/http-proxy-schema.cy.ts
+++ b/cypress/component/http-proxy-schema.cy.ts
@@ -40,15 +40,19 @@ describe('httpProxySchema – endpointHost (Origin)', () => {
       ).to.equal(true);
     });
 
-    it('accepts an IPv4 address', () => {
+    it('accepts an IPv4 address (with required tlsHostname for HTTPS)', () => {
       expect(
-        httpProxySchema.safeParse(makeInput({ endpointHost: '203.0.113.1' })).success
+        httpProxySchema.safeParse(
+          makeInput({ endpointHost: '203.0.113.1', tlsHostname: 'tls.example.com' })
+        ).success
       ).to.equal(true);
     });
 
-    it('accepts an IPv4 address with a port', () => {
+    it('accepts an IPv4 address with a port (with required tlsHostname for HTTPS)', () => {
       expect(
-        httpProxySchema.safeParse(makeInput({ endpointHost: '203.0.113.1:8080' })).success
+        httpProxySchema.safeParse(
+          makeInput({ endpointHost: '203.0.113.1:8080', tlsHostname: 'tls.example.com' })
+        ).success
       ).to.equal(true);
     });
   });

--- a/cypress/component/http-proxy-schema.cy.ts
+++ b/cypress/component/http-proxy-schema.cy.ts
@@ -1,0 +1,125 @@
+import { httpProxySchema } from '@/resources/http-proxies';
+
+/**
+ * Builds a minimally valid input for `httpProxySchema`. Individual tests
+ * override only the field under test, keeping each assertion focused.
+ */
+function makeInput(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'my-proxy',
+    chosenName: 'My Proxy',
+    protocol: 'https' as const,
+    endpointHost: 'api.example.com',
+    ...overrides,
+  };
+}
+
+function endpointHostIssue(input: ReturnType<typeof makeInput>) {
+  const result = httpProxySchema.safeParse(input);
+  if (result.success) return null;
+  return result.error.issues.find((issue) => issue.path[0] === 'endpointHost') ?? null;
+}
+
+describe('httpProxySchema – endpointHost (Origin)', () => {
+  describe('valid origins are accepted', () => {
+    it('accepts a fully qualified hostname', () => {
+      expect(
+        httpProxySchema.safeParse(makeInput({ endpointHost: 'api.example.com' })).success
+      ).to.equal(true);
+    });
+
+    it('accepts a multi-label subdomain', () => {
+      expect(
+        httpProxySchema.safeParse(makeInput({ endpointHost: 'api.staging.example.com' })).success
+      ).to.equal(true);
+    });
+
+    it('accepts a hostname with a port', () => {
+      expect(
+        httpProxySchema.safeParse(makeInput({ endpointHost: 'api.example.com:8080' })).success
+      ).to.equal(true);
+    });
+
+    it('accepts an IPv4 address', () => {
+      expect(
+        httpProxySchema.safeParse(makeInput({ endpointHost: '203.0.113.1' })).success
+      ).to.equal(true);
+    });
+
+    it('accepts an IPv4 address with a port', () => {
+      expect(
+        httpProxySchema.safeParse(makeInput({ endpointHost: '203.0.113.1:8080' })).success
+      ).to.equal(true);
+    });
+  });
+
+  describe('rejects single-label hostnames (the case that previously hit the API)', () => {
+    it('rejects a bare word like "hello"', () => {
+      const issue = endpointHostIssue(makeInput({ endpointHost: 'hello' }));
+      expect(issue, 'should produce an endpointHost issue').to.not.equal(null);
+      expect(issue?.message).to.match(/at least two segments separated by dots/i);
+    });
+
+    it('rejects "localhost"', () => {
+      const issue = endpointHostIssue(makeInput({ endpointHost: 'localhost' }));
+      expect(issue).to.not.equal(null);
+    });
+
+    it('rejects a single label with a port ("hello:8080")', () => {
+      const issue = endpointHostIssue(makeInput({ endpointHost: 'hello:8080' }));
+      expect(issue).to.not.equal(null);
+    });
+  });
+
+  describe('rejects other malformed origins', () => {
+    it('rejects an empty string', () => {
+      const issue = endpointHostIssue(makeInput({ endpointHost: '' }));
+      expect(issue).to.not.equal(null);
+      expect(issue?.message).to.match(/required/i);
+    });
+
+    it('trims surrounding whitespace before validating', () => {
+      // Surrounding whitespace is stripped by the schema; the trimmed value
+      // is still a valid FQDN, so the parse should succeed.
+      expect(
+        httpProxySchema.safeParse(makeInput({ endpointHost: '  api.example.com  ' })).success
+      ).to.equal(true);
+    });
+
+    it('rejects a value containing a protocol scheme', () => {
+      // "https://api.example.com" parses as hostname "https" + port "//api.example.com" -> invalid port
+      const issue = endpointHostIssue(makeInput({ endpointHost: 'https://api.example.com' }));
+      expect(issue).to.not.equal(null);
+    });
+
+    it('rejects an invalid port', () => {
+      const issue = endpointHostIssue(makeInput({ endpointHost: 'api.example.com:99999' }));
+      expect(issue).to.not.equal(null);
+    });
+
+    it('rejects more than one colon (multiple ports)', () => {
+      const issue = endpointHostIssue(makeInput({ endpointHost: 'api.example.com:80:80' }));
+      expect(issue).to.not.equal(null);
+    });
+  });
+
+  describe('TLS hostname requirement for IP-based HTTPS origins', () => {
+    it('requires tlsHostname when endpoint is HTTPS + IP', () => {
+      const result = httpProxySchema.safeParse(
+        makeInput({ endpointHost: '203.0.113.1', protocol: 'https' })
+      );
+      expect(result.success).to.equal(false);
+      if (!result.success) {
+        const tlsIssue = result.error.issues.find((i) => i.path[0] === 'tlsHostname');
+        expect(tlsIssue).to.not.equal(undefined);
+      }
+    });
+
+    it('does not require tlsHostname when endpoint is HTTP + IP', () => {
+      const result = httpProxySchema.safeParse(
+        makeInput({ endpointHost: '203.0.113.1', protocol: 'http' })
+      );
+      expect(result.success).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

A [Sentry replay](https://sentry.prod.env.datum.net/organizations/sentry/explore/replays/64c44981126942cab44d7803fb6d6b7d/?groupId=899&referrer=%2Fissues%2F%3AgroupId%2F&t=195.8878000000119&t_main=errors) showed a user trying to create an AI Edge. Two UX issues compounded: mobile keyboards auto-capitalized the field, and the single-label hostname they typed only got rejected after the API round-trip with a confusing toast (_"Should be a domain with at least two segments separated by dots"_). The form never told them anything was wrong locally.

This PR fixes both:

- Tightens `httpProxySchema.endpointHost` so the same rule the server enforces runs client-side. The Origin must either be an IP address (with optional port) or a hostname with at least two dot-separated labels. Invalid values now fail validation inline on the field and the `createHttpProxy` mutation is never dispatched.
- Disables `autoCapitalize`, `autoCorrect`, and `spellCheck` on every input that collects a technical identifier — hostnames, domains, IPs, URLs, DNS record names and values, Kubernetes resource names (via the shared `InputName` component, which covers many call sites in one shot), basic-auth usernames, secret keys, and the key/value form dialog.

Display-name and description fields (first/last name, proxy display name, DNS zone description, org/project descriptions, etc.) are deliberately left alone — capitalization is desirable there.

A small Cypress component spec at `cypress/component/http-proxy-schema.cy.ts` covers the new validation behavior end-to-end through `httpProxySchema.safeParse`, including the exact `hello` case from the replay, IPv4 with/without port, multi-label subdomains, malformed ports, and the existing TLS-hostname-for-IP-HTTPS rule (regression guard).

<img width="1624" height="1061" alt="Screenshot 2026-05-14 at 17 42 09" src="https://github.com/user-attachments/assets/7710b6f4-1f9e-4ecf-abc5-93ce8b0973a2" />
