### PR TITLE
fix(errors): filter expected 4xx from Sentry and propagate proper status

### DIFF
--- a/app/components/error/generic.tsx
+++ b/app/components/error/generic.tsx
@@ -7,7 +7,7 @@ import { BuildingIcon, RefreshCcwIcon } from 'lucide-react';
 // import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 
-export const GenericError = ({ message }: { message: string }) => {
+export const GenericError = ({ message, status }: { message: string; status?: number }) => {
   const navigate = useNavigate();
   // const [isDebug, setIsDebug] = useState(false);
 
@@ -15,16 +15,39 @@ export const GenericError = ({ message }: { message: string }) => {
   //   setIsDebug(window.ENV?.DEBUG || ['localhost', '127.0.0.1'].includes(window.location.hostname));
   // }, []);
 
+  const isNotFound = status === 404;
+  const isForbidden = status === 403;
+  const title = isNotFound
+    ? "We couldn't find that page."
+    : isForbidden
+      ? "You don't have access to this."
+      : 'Whoops! Something went wrong.';
+
   return (
     <Card>
       <CardContent className="flex min-h-[500px] flex-col items-center justify-center gap-6">
         <LogoIcon width={64} className="mb-4" />
         <div className="flex max-w-xl flex-col gap-2">
-          <p className="w-full text-center text-2xl font-bold">Whoops! Something went wrong.</p>
+          <p className="w-full text-center text-2xl font-bold">{title}</p>
 
           <p className="text-muted-foreground text-center text-sm">
-            Something went wrong on our end. Our team has been notified, and we&apos;re working to
-            fix it. Please try again later. If the issue persists, reach out to{' '}
+            {isNotFound ? (
+              <>
+                The page or resource you&apos;re looking for doesn&apos;t exist or has been moved.
+                Check the URL or head back to your organization. If you think this is a mistake,
+                reach out to{' '}
+              </>
+            ) : isForbidden ? (
+              <>
+                You don&apos;t have permission to view this resource. If you think you should, ask
+                an administrator for access or reach out to{' '}
+              </>
+            ) : (
+              <>
+                Something went wrong on our end. Our team has been notified, and we&apos;re working
+                to fix it. Please try again later. If the issue persists, reach out to{' '}
+              </>
+            )}
             <Link to={`mailto:support@datum.net`} className="text-primary underline">
               support@datum.net
             </Link>

--- a/app/components/error/generic.tsx
+++ b/app/components/error/generic.tsx
@@ -24,11 +24,13 @@ export const GenericError = ({ message, status }: { message: string; status?: nu
       : 'Whoops! Something went wrong.';
 
   return (
-    <Card>
+    <Card data-e2e="error-page" data-error-status={status ?? ''}>
       <CardContent className="flex min-h-[500px] flex-col items-center justify-center gap-6">
         <LogoIcon width={64} className="mb-4" />
         <div className="flex max-w-xl flex-col gap-2">
-          <p className="w-full text-center text-2xl font-bold">{title}</p>
+          <p data-e2e="error-page-title" className="w-full text-center text-2xl font-bold">
+            {title}
+          </p>
 
           <p className="text-muted-foreground text-center text-sm">
             {isNotFound ? (

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,10 +1,11 @@
 import { NonceProvider } from '@/hooks/useNonce';
+import { AppError, isUserFacingErrorStatus } from '@/utils/errors/app-error';
 import { createReadableStreamFromReadable } from '@react-router/node';
 import * as Sentry from '@sentry/react-router';
 import { isbot } from 'isbot';
 import { PassThrough } from 'node:stream';
 import { renderToPipeableStream } from 'react-dom/server';
-import type { AppLoadContext, EntryContext } from 'react-router';
+import type { AppLoadContext, EntryContext, HandleErrorFunction } from 'react-router';
 import { ServerRouter } from 'react-router';
 
 const ABORT_DELAY = 5_000;
@@ -68,7 +69,14 @@ async function handleRequest(
 // Wrap the handleRequest function with Sentry
 export default Sentry.wrapSentryHandleRequest(handleRequest);
 
-// Export handleError for Sentry error capture
-export const handleError = Sentry.createSentryHandleError({
-  logErrors: false,
-});
+// Export handleError for Sentry error capture.
+// Skip expected user-facing statuses (401/403/404) and aborted requests — these are
+// not bugs. Other 4xx codes (400/409/429/...) reaching this handler usually indicate
+// a code path that forgot to catch an error inline, so we still want them captured.
+export const handleError: HandleErrorFunction = (error, { request }) => {
+  if (request.signal.aborted) return;
+
+  if (error instanceof AppError && isUserFacingErrorStatus(error.status)) return;
+
+  Sentry.captureException(error);
+};

--- a/app/modules/axios/axios.server.ts
+++ b/app/modules/axios/axios.server.ts
@@ -14,6 +14,7 @@ import {
   AppError,
   AuthenticationError,
   AuthorizationError,
+  isUserFacingErrorStatus,
   NotFoundError,
   ValidationError,
 } from '@/utils/errors';
@@ -158,15 +159,19 @@ const onResponseError = (error: AxiosError): Promise<never> => {
 
   const message = parsed?.message ?? resolveRawMessage(responseData, error);
 
-  // Capture API error to Sentry with resource context and fingerprinting
-  captureApiError({
-    error,
-    method: config?.method,
-    url: config?.url,
-    status: httpStatus,
-    message: parsed?.originalMessage ?? message,
-    requestId,
-  });
+  // Capture API error to Sentry with resource context and fingerprinting.
+  // Skip expected user-facing statuses (401/403/404) — these are not bugs and
+  // are surfaced to the user via the route error boundary.
+  if (!isUserFacingErrorStatus(httpStatus)) {
+    captureApiError({
+      error,
+      method: config?.method,
+      url: config?.url,
+      status: httpStatus,
+      message: parsed?.originalMessage ?? message,
+      requestId,
+    });
+  }
 
   switch (httpStatus) {
     case 401: {

--- a/app/resources/activity-logs/activity-log.helpers.ts
+++ b/app/resources/activity-logs/activity-log.helpers.ts
@@ -146,11 +146,24 @@ export function getResourceFilterOptions(scopeType: ScopeType): FilterOption[] {
 // ============================================
 
 /**
+ * Choose the correct indefinite article ('a' / 'an') for a label.
+ *
+ * Heuristic: 'an' before words starting with A/E/I/O.
+ * 'U' is intentionally excluded because words/acronyms beginning with U often
+ * produce a 'you' consonant sound ("a User", "a URL"). Acronyms like "AI",
+ * "Export Policy", "Invitation", "Organization" all correctly resolve to 'an'.
+ */
+function indefiniteArticle(label: string): 'a' | 'an' {
+  return /^[aeioAEIO]/.test(label) ? 'an' : 'a';
+}
+
+/**
  * Humanizes an action based on verb and resource.
  *
  * @example
  * humanizeAction('create', 'domains') // "Added a Domain"
  * humanizeAction('delete', 'dnszones') // "Deleted a DNS Zone"
+ * humanizeAction('create', 'httpproxies') // "Added an AI Edge"
  */
 export function humanizeAction(verb: string, resource: string): string {
   const verbText = VERB_PAST_TENSE[verb] || verb.charAt(0).toUpperCase() + verb.slice(1);
@@ -158,7 +171,7 @@ export function humanizeAction(verb: string, resource: string): string {
   const label = getResourceLabel(resource);
   const singularLabel = label !== resource ? label : resource.replace(/s$/, '');
 
-  return `${verbText} a ${singularLabel}`;
+  return `${verbText} ${indefiniteArticle(singularLabel)} ${singularLabel}`;
 }
 
 /**

--- a/app/resources/dns-records/dns-record.service.ts
+++ b/app/resources/dns-records/dns-record.service.ts
@@ -26,6 +26,7 @@ import { logger } from '@/modules/logger';
 import type { PaginationParams } from '@/resources/base/base.schema';
 import type { ServiceOptions } from '@/resources/base/types';
 import { getProjectScopedBase } from '@/resources/base/utils';
+import { NotFoundError } from '@/utils/errors';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
 export const dnsRecordKeys = {
@@ -157,7 +158,7 @@ export function createDnsRecordService() {
       });
 
       if (!response.data) {
-        throw new Error(`DNS RecordSet ${recordSetId} not found`);
+        throw new NotFoundError('DNS Record Set', recordSetId);
       }
 
       return toDnsRecordSet(response.data);

--- a/app/resources/dns-zones/dns-zone.service.ts
+++ b/app/resources/dns-zones/dns-zone.service.ts
@@ -22,6 +22,7 @@ import { logger } from '@/modules/logger';
 import type { PaginationParams } from '@/resources/base/base.schema';
 import type { ServiceOptions } from '@/resources/base/types';
 import { getProjectScopedBase } from '@/resources/base/utils';
+import { NotFoundError } from '@/utils/errors';
 import { parseOrThrow } from '@/utils/errors/error-formatter';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
@@ -101,7 +102,7 @@ export function createDnsZoneService() {
       });
 
       if (!response.data) {
-        throw new Error(`DNS Zone ${name} not found`);
+        throw new NotFoundError('DNS Zone', name);
       }
 
       return toDnsZone(response.data);

--- a/app/resources/domains/domain.service.ts
+++ b/app/resources/domains/domain.service.ts
@@ -22,6 +22,7 @@ import type { IExtendedControlPlaneStatus } from '@/resources/base';
 import type { PaginationParams } from '@/resources/base/base.schema';
 import type { ServiceOptions } from '@/resources/base/types';
 import { getProjectScopedBase } from '@/resources/base/utils';
+import { NotFoundError } from '@/utils/errors';
 import { mapApiError } from '@/utils/errors/error-mapper';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
 
@@ -98,7 +99,7 @@ export function createDomainService() {
       });
 
       if (!response.data) {
-        throw new Error(`Domain ${name} not found`);
+        throw new NotFoundError('Domain', name);
       }
 
       return toDomain(response.data);

--- a/app/resources/export-policies/export-policy.service.ts
+++ b/app/resources/export-policies/export-policy.service.ts
@@ -24,6 +24,7 @@ import { logger } from '@/modules/logger';
 import type { IExtendedControlPlaneStatus } from '@/resources/base';
 import type { ServiceOptions } from '@/resources/base/types';
 import { getProjectScopedBase } from '@/resources/base/utils';
+import { NotFoundError } from '@/utils/errors';
 import { mapApiError } from '@/utils/errors/error-mapper';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
 
@@ -109,7 +110,7 @@ export function createExportPolicyService() {
       const data = response.data as ComDatumapisTelemetryV1Alpha1ExportPolicy;
 
       if (!data) {
-        throw new Error(`Export Policy ${name} not found`);
+        throw new NotFoundError('Export Policy', name);
       }
 
       return toExportPolicy(data);

--- a/app/resources/groups/group.service.ts
+++ b/app/resources/groups/group.service.ts
@@ -19,6 +19,7 @@ import { ControlPlaneStatus } from '@/resources/base';
 import type { ServiceOptions } from '@/resources/base/types';
 import { getOrgScopedBase } from '@/resources/base/utils';
 import { buildOrganizationNamespace } from '@/utils/common';
+import { NotFoundError } from '@/utils/errors';
 import { parseOrThrow } from '@/utils/errors/error-formatter';
 import { mapApiError } from '@/utils/errors/error-mapper';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
@@ -109,7 +110,7 @@ export function createGroupService() {
       const data = response.data as ComMiloapisIamV1Alpha1Group;
 
       if (!data) {
-        throw new Error(`Group ${name} not found`);
+        throw new NotFoundError('Group', name);
       }
 
       return toGroup(data);

--- a/app/resources/http-proxies/http-proxy.service.ts
+++ b/app/resources/http-proxies/http-proxy.service.ts
@@ -39,6 +39,7 @@ import { client } from '@/modules/control-plane/shared/client.gen';
 import { logger } from '@/modules/logger';
 import type { ServiceOptions } from '@/resources/base/types';
 import { getProjectScopedBase } from '@/resources/base/utils';
+import { NotFoundError } from '@/utils/errors';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
 export const httpProxyKeys = {
@@ -427,7 +428,7 @@ export function createHttpProxyService() {
       const data = proxyResponse.data as ComDatumapisNetworkingV1AlphaHttpProxy;
 
       if (!data) {
-        throw new Error(`HTTP Proxy ${name} not found`);
+        throw new NotFoundError('AI Edge', name);
       }
 
       const wafMode = getTrafficProtectionMode(policyResponse.data);

--- a/app/resources/notes/note.service.ts
+++ b/app/resources/notes/note.service.ts
@@ -10,6 +10,7 @@ import {
 } from '@/modules/control-plane/notes';
 import { logger } from '@/modules/logger';
 import { getProjectScopedBase } from '@/resources/base/utils';
+import { NotFoundError } from '@/utils/errors';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
 const SERVICE_NAME = 'NoteService';
@@ -57,7 +58,7 @@ export function createNoteService() {
           path: { namespace: NAMESPACE, name: noteName },
         });
         if (!response.data) {
-          throw new Error('Note not found');
+          throw new NotFoundError('Note', noteName);
         }
         const note = toNote(response.data);
         logger.service(SERVICE_NAME, 'get', {

--- a/app/resources/notifications/contact-group-membership-removal/contact-group-membership-removal.service.ts
+++ b/app/resources/notifications/contact-group-membership-removal/contact-group-membership-removal.service.ts
@@ -20,6 +20,7 @@ import {
 } from '@/modules/control-plane/notification';
 import { logger } from '@/modules/logger';
 import type { ServiceOptions } from '@/resources/base/types';
+import { NotFoundError } from '@/utils/errors';
 import { parseOrThrow } from '@/utils/errors/error-formatter';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
@@ -89,7 +90,7 @@ export function createNotificationContactGroupMembershipRemovalService() {
           });
 
         const data = response.data as ComMiloapisNotificationV1Alpha1ContactGroupMembershipRemoval;
-        if (!data) throw new Error(`ContactGroupMembershipRemoval ${name} not found`);
+        if (!data) throw new NotFoundError('Contact Group Membership Removal', name);
 
         const result = toContactGroupMembershipRemoval(data);
 

--- a/app/resources/notifications/contact-group-membership/contact-group-membership.service.ts
+++ b/app/resources/notifications/contact-group-membership/contact-group-membership.service.ts
@@ -20,6 +20,7 @@ import {
 } from '@/modules/control-plane/notification';
 import { logger } from '@/modules/logger';
 import type { ServiceOptions } from '@/resources/base/types';
+import { NotFoundError } from '@/utils/errors';
 import { parseOrThrow } from '@/utils/errors/error-formatter';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
@@ -82,7 +83,7 @@ export function createNotificationContactGroupMembershipService() {
         });
 
         const data = response.data as ComMiloapisNotificationV1Alpha1ContactGroupMembership;
-        if (!data) throw new Error(`ContactGroupMembership ${name} not found`);
+        if (!data) throw new NotFoundError('Contact Group Membership', name);
 
         const result = toContactGroupMembership(data);
 

--- a/app/resources/notifications/contact-group/contact-group.service.ts
+++ b/app/resources/notifications/contact-group/contact-group.service.ts
@@ -24,6 +24,7 @@ import {
 } from '@/modules/control-plane/notification';
 import { logger } from '@/modules/logger';
 import type { ServiceOptions } from '@/resources/base/types';
+import { NotFoundError } from '@/utils/errors';
 import { parseOrThrow } from '@/utils/errors/error-formatter';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
@@ -88,7 +89,7 @@ export function createNotificationContactGroupService() {
 
         const data = response.data as ComMiloapisNotificationV1Alpha1ContactGroup;
         if (!data) {
-          throw new Error(`ContactGroup ${name} not found`);
+          throw new NotFoundError('Contact Group', name);
         }
 
         const result = toContactGroup(data);

--- a/app/resources/notifications/contact/contact.service.ts
+++ b/app/resources/notifications/contact/contact.service.ts
@@ -24,6 +24,7 @@ import {
 } from '@/modules/control-plane/notification';
 import { logger } from '@/modules/logger';
 import type { ServiceOptions } from '@/resources/base/types';
+import { NotFoundError } from '@/utils/errors';
 import { parseOrThrow } from '@/utils/errors/error-formatter';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
@@ -88,7 +89,7 @@ export function createNotificationContactService() {
 
         const data = response.data as ComMiloapisNotificationV1Alpha1Contact;
         if (!data) {
-          throw new Error(`Contact ${name} not found`);
+          throw new NotFoundError('Contact', name);
         }
 
         const result = toContact(data);

--- a/app/resources/organizations/organization.gql-service.ts
+++ b/app/resources/organizations/organization.gql-service.ts
@@ -20,6 +20,7 @@ import type {
 } from '@/modules/graphql/generated';
 import { logger } from '@/modules/logger';
 import type { PaginationParams } from '@/resources/base/base.schema';
+import { NotFoundError } from '@/utils/errors';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
 const SERVICE_NAME = 'OrganizationGqlService';
@@ -151,7 +152,7 @@ export function createOrganizationGqlService() {
         const data = result.data?.readResourcemanagerMiloapisComV1alpha1Organization;
 
         if (!data) {
-          throw new Error(`Organization ${name} not found`);
+          throw new NotFoundError('Organization', name);
         }
 
         logger.service(SERVICE_NAME, 'get', {

--- a/app/resources/organizations/organization.service.ts
+++ b/app/resources/organizations/organization.service.ts
@@ -22,6 +22,7 @@ import { logger } from '@/modules/logger';
 import type { PaginationParams } from '@/resources/base/base.schema';
 import type { ServiceOptions } from '@/resources/base/types';
 import { getUserScopedBase } from '@/resources/base/utils';
+import { NotFoundError } from '@/utils/errors';
 import { parseOrThrow } from '@/utils/errors/error-formatter';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
@@ -119,7 +120,7 @@ export function createOrganizationService() {
       });
 
       if (!response.data) {
-        throw new Error(`Organization ${name} not found`);
+        throw new NotFoundError('Organization', name);
       }
 
       return toOrganization(response.data);

--- a/app/resources/projects/project.service.ts
+++ b/app/resources/projects/project.service.ts
@@ -18,6 +18,7 @@ import { logger } from '@/modules/logger';
 import type { PaginationParams } from '@/resources/base/base.schema';
 import type { ServiceOptions } from '@/resources/base/types';
 import { getOrgScopedBase } from '@/resources/base/utils';
+import { NotFoundError } from '@/utils/errors';
 import { parseOrThrow } from '@/utils/errors/error-formatter';
 import { mapApiError } from '@/utils/errors/error-mapper';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
@@ -98,7 +99,7 @@ export function createProjectService() {
       });
 
       if (!response.data) {
-        throw new Error(`Project ${name} not found`);
+        throw new NotFoundError('Project', name);
       }
 
       return toProject(response.data);

--- a/app/resources/secrets/secret.service.ts
+++ b/app/resources/secrets/secret.service.ts
@@ -17,6 +17,7 @@ import {
 import { logger } from '@/modules/logger';
 import type { ServiceOptions } from '@/resources/base/types';
 import { getProjectScopedBase } from '@/resources/base/utils';
+import { NotFoundError } from '@/utils/errors';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
 export const secretKeys = {
@@ -92,7 +93,7 @@ export function createSecretService() {
       const secretData = response.data as IoK8sApiCoreV1Secret;
 
       if (!secretData) {
-        throw new Error(`Secret ${name} not found`);
+        throw new NotFoundError('Secret', name);
       }
 
       return toSecret(secretData);

--- a/app/resources/service-accounts/service-account.service.ts
+++ b/app/resources/service-accounts/service-account.service.ts
@@ -31,6 +31,7 @@ import {
 } from '@/modules/control-plane/identity';
 import { logger } from '@/modules/logger';
 import { getProjectScopedBase } from '@/resources/base/utils';
+import { NotFoundError } from '@/utils/errors';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
 export const serviceAccountKeys = {
@@ -75,7 +76,7 @@ export function createServiceAccountService() {
           path: { name },
         });
         const data = response.data as ComMiloapisIamV1Alpha1ServiceAccount;
-        if (!data) throw new Error(`Service account ${name} not found`);
+        if (!data) throw new NotFoundError('Service Account', name);
         logger.service(SERVICE_NAME, 'get', {
           input: { projectId, name },
           duration: Date.now() - startTime,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -11,6 +11,7 @@ import { queryClient } from '@/modules/tanstack/query';
 import RootCSS from '@/styles/root.css?url';
 import { csrf, getToastSession } from '@/utils/cookies';
 import { env } from '@/utils/env/env.server';
+import { isUserFacingErrorStatus } from '@/utils/errors/app-error';
 import { metaObject } from '@/utils/helpers/meta.helper';
 import { combineHeaders } from '@/utils/helpers/path.helper';
 import { ConformAdapter } from '@datum-cloud/datum-ui/form/adapters/conform';
@@ -270,6 +271,7 @@ function ErrorLayout({ children }: { children: React.ReactNode }) {
 export function ErrorBoundary() {
   const error = useRouteError();
   let message = "We've encountered a problem, please try again. Sorry!";
+  let status: number | undefined;
 
   if (isRouteErrorResponse(error)) {
     if (error.statusText === 'AUTH_ERROR') {
@@ -283,15 +285,22 @@ export function ErrorBoundary() {
     } else {
       message = `${error.status} ${error.statusText}`;
     }
+    status = error.status;
   } else if (error instanceof Error) {
-    // you only want to capture non 404-errors that reach the boundary
-    Sentry.captureException(error);
+    // Skip expected user-facing statuses (401/403/404). Other 4xx reaching the
+    // boundary likely indicate a bug, so we still capture them.
+    // The `status` field on AppError survives React Router's error serialization,
+    // so this duck-typed check works during both SSR hydration and client navigation.
+    status = (error as { status?: number }).status;
+    if (!isUserFacingErrorStatus(status)) {
+      Sentry.captureException(error);
+    }
     message = error.message;
   }
 
   return (
     <ErrorLayout>
-      <GenericError message={message} />
+      <GenericError message={message} status={status} />
     </ErrorLayout>
   );
 }

--- a/app/routes/org/detail/layout.tsx
+++ b/app/routes/org/detail/layout.tsx
@@ -5,7 +5,7 @@ import { useApp } from '@/providers/app.provider';
 import { createOrganizationService } from '@/resources/organizations';
 import { paths } from '@/utils/config/paths.config';
 import { clearProjectSession, redirectWithToast, setOrgSession } from '@/utils/cookies';
-import { NotFoundError } from '@/utils/errors';
+import { NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { combineHeaders, getPathWithParams } from '@/utils/helpers/path.helper';
 import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
 import { FolderRoot, SettingsIcon, UsersIcon } from 'lucide-react';
@@ -35,7 +35,7 @@ export function shouldRevalidate({
   return defaultShouldRevalidate;
 }
 
-export const loader = async ({ params, request }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params, request }: LoaderFunctionArgs) => {
   const { orgId } = params;
 
   if (!orgId) {
@@ -63,7 +63,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
       type: 'error',
     });
   }
-};
+});
 
 export default function OrgLayout() {
   const initialOrg = useLoaderData<typeof loader>();

--- a/app/routes/org/detail/settings/policy-bindings.tsx
+++ b/app/routes/org/detail/settings/policy-bindings.tsx
@@ -10,7 +10,7 @@ import {
   useDeletePolicyBinding,
   type PolicyBinding,
 } from '@/resources/policy-bindings';
-import { BadRequestError } from '@/utils/errors';
+import { BadRequestError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Button } from '@datum-cloud/datum-ui/button';
 import { Icon } from '@datum-cloud/datum-ui/icons';
@@ -23,7 +23,7 @@ export const meta: MetaFunction = mergeMeta(() => {
   return metaObject('Roles');
 });
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { orgId } = params;
 
   if (!orgId) {
@@ -34,7 +34,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   const policyBindingService = createPolicyBindingService();
   const bindings = await policyBindingService.list(orgId);
   return bindings;
-};
+});
 
 export default function OrgPolicyBindingsPage() {
   const { orgId } = useParams();

--- a/app/routes/org/detail/settings/quotas.tsx
+++ b/app/routes/org/detail/settings/quotas.tsx
@@ -1,20 +1,21 @@
 import { QuotasTable } from '@/features/quotas/quotas-table';
 import { createAllowanceBucketService, type AllowanceBucket } from '@/resources/allowance-buckets';
 import type { Organization } from '@/resources/organizations';
+import { BadRequestError, withLoaderErrors } from '@/utils/errors';
 import { LoaderFunctionArgs, useLoaderData, useRouteLoaderData } from 'react-router';
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { orgId } = params;
 
   if (!orgId) {
-    throw new Error('Organization ID is required');
+    throw new BadRequestError('Organization ID is required');
   }
 
   // Services now use global axios client with AsyncLocalStorage
   const allowanceBucketService = createAllowanceBucketService();
   const allowanceBuckets = await allowanceBucketService.list('organization', orgId);
   return allowanceBuckets;
-};
+});
 
 export const handle = {
   breadcrumb: () => <span>Quotas</span>,

--- a/app/routes/project/detail/dns-zones/detail/layout.tsx
+++ b/app/routes/project/detail/dns-zones/detail/layout.tsx
@@ -5,7 +5,7 @@ import { createDnsZoneService, type DnsZone, useDnsZone } from '@/resources/dns-
 import { createDomainService, type Domain, useDomain } from '@/resources/domains';
 import { paths } from '@/utils/config/paths.config';
 import { redirectWithToast } from '@/utils/cookies';
-import { BadRequestError, NotFoundError } from '@/utils/errors';
+import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
@@ -28,7 +28,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ loaderData }) => {
   return metaObject(dnsZone?.domainName || 'DNS');
 });
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId, dnsZoneId } = params;
 
   if (!projectId || !dnsZoneId) {
@@ -69,7 +69,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   const dnsRecordSets = await dnsRecordService.list(projectId, dnsZoneId);
 
   return data({ dnsZone, domain, dnsRecordSets });
-};
+});
 
 export default function DnsZoneDetailLayout() {
   const { dnsZone, domain } = useLoaderData<typeof loader>();

--- a/app/routes/project/detail/dns-zones/index.tsx
+++ b/app/routes/project/detail/dns-zones/index.tsx
@@ -18,7 +18,7 @@ import {
 import { useRefreshDomainRegistration } from '@/resources/domains';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
-import { BadRequestError } from '@/utils/errors';
+import { BadRequestError, withLoaderErrors } from '@/utils/errors';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
@@ -43,7 +43,7 @@ export const meta: MetaFunction = mergeMeta(() => {
   return metaObject('DNS');
 });
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId } = params;
 
   if (!projectId) {
@@ -55,7 +55,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   const zones = await dnsZoneService.list(projectId);
 
   return data({ zones });
-};
+});
 
 interface DnsZoneWithComputed extends DnsZone {
   _computed: {

--- a/app/routes/project/detail/domains/detail/layout.tsx
+++ b/app/routes/project/detail/domains/detail/layout.tsx
@@ -3,7 +3,7 @@ import { SubLayout } from '@/layouts';
 import { createDnsZoneService, type DnsZone } from '@/resources/dns-zones';
 import { createDomainService, type Domain, useDomain } from '@/resources/domains';
 import { paths } from '@/utils/config/paths.config';
-import { BadRequestError, NotFoundError } from '@/utils/errors';
+import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
@@ -26,7 +26,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ loaderData }) => {
   return metaObject(domain?.name || 'Domain');
 });
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId, domainId } = params;
 
   if (!projectId || !domainId) {
@@ -50,7 +50,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   }
 
   return data({ domain, dnsZone });
-};
+});
 
 export default function DomainDetailLayout() {
   const { domain } = useLoaderData<typeof loader>();

--- a/app/routes/project/detail/domains/index.tsx
+++ b/app/routes/project/detail/domains/index.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/resources/domains';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
-import { BadRequestError } from '@/utils/errors';
+import { BadRequestError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Badge } from '@datum-cloud/datum-ui/badge';
@@ -68,7 +68,7 @@ export const meta: MetaFunction = mergeMeta(() => {
   return metaObject('Domains');
 });
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId } = params;
 
   if (!projectId) {
@@ -81,7 +81,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   ]);
 
   return data({ domains, dnsZones });
-};
+});
 
 export default function DomainsPage() {
   const { projectId } = useParams();

--- a/app/routes/project/detail/edge/detail/index.tsx
+++ b/app/routes/project/detail/edge/detail/index.tsx
@@ -11,6 +11,7 @@ import { MetricsProvider } from '@/modules/metrics';
 import { type HttpProxy, useHttpProxy, useHttpProxyWatch } from '@/resources/http-proxies';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
+import { NotFoundError } from '@/utils/errors';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Button } from '@datum-cloud/datum-ui/button';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
@@ -45,7 +46,7 @@ export default function HttpProxyDetailPage() {
     },
   });
 
-  if (!effectiveProxy) return null;
+  if (!effectiveProxy) throw new NotFoundError('AI Edge', proxyId);
 
   return (
     <MetricsProvider>

--- a/app/routes/project/detail/edge/detail/layout.tsx
+++ b/app/routes/project/detail/edge/detail/layout.tsx
@@ -1,5 +1,5 @@
 import { createHttpProxyService, type HttpProxy, useHttpProxy } from '@/resources/http-proxies';
-import { BadRequestError, NotFoundError } from '@/utils/errors';
+import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import {
   LoaderFunctionArgs,
@@ -19,7 +19,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ loaderData }) => {
   return metaObject(httpProxy?.name || 'Proxy');
 });
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId, proxyId } = params;
 
   if (!projectId || !proxyId) {
@@ -32,11 +32,11 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   const httpProxy = await httpProxyService.get(projectId, proxyId);
 
   if (!httpProxy) {
-    throw new NotFoundError('Proxy not found');
+    throw new NotFoundError('AI Edge', proxyId);
   }
 
   return data(httpProxy);
-};
+});
 
 export default function HttpProxyDetailLayout() {
   const { projectId, proxyId } = useParams();

--- a/app/routes/project/detail/metrics/detail/layout.tsx
+++ b/app/routes/project/detail/metrics/detail/layout.tsx
@@ -1,5 +1,5 @@
 import { createExportPolicyService, type ExportPolicy } from '@/resources/export-policies';
-import { BadRequestError, NotFoundError } from '@/utils/errors';
+import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { LoaderFunctionArgs, data, MetaFunction, Outlet } from 'react-router';
 
@@ -12,7 +12,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ loaderData }) => {
   return metaObject(exportPolicy?.name || 'ExportPolicy');
 });
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId, exportPolicyId } = params;
 
   if (!projectId || !exportPolicyId) {
@@ -25,11 +25,11 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   const exportPolicy = await exportPolicyService.get(projectId, exportPolicyId);
 
   if (!exportPolicy) {
-    throw new NotFoundError('ExportPolicy not found');
+    throw new NotFoundError('Export Policy', exportPolicyId);
   }
 
   return data(exportPolicy);
-};
+});
 
 export default function ExportPolicyDetailLayout() {
   return <Outlet />;

--- a/app/routes/project/detail/secrets/detail/layout.tsx
+++ b/app/routes/project/detail/secrets/detail/layout.tsx
@@ -1,5 +1,5 @@
 import { createSecretService, useSecret, type Secret } from '@/resources/secrets';
-import { BadRequestError } from '@/utils/errors';
+import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { LoaderFunctionArgs, MetaFunction, Outlet, useLoaderData, useParams } from 'react-router';
 
@@ -12,7 +12,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ loaderData }) => {
   return metaObject(secret?.name || 'Secret');
 });
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId, secretId } = params;
 
   if (!projectId || !secretId) {
@@ -23,8 +23,12 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   const secretService = createSecretService();
   const secret = await secretService.get(projectId, secretId);
 
+  if (!secret) {
+    throw new NotFoundError('Secret', secretId);
+  }
+
   return secret;
-};
+});
 
 export default function SecretDetailLayout() {
   const secret = useLoaderData<typeof loader>();

--- a/app/routes/project/detail/secrets/index.tsx
+++ b/app/routes/project/detail/secrets/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/resources/secrets';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
-import { BadRequestError } from '@/utils/errors';
+import { BadRequestError, withLoaderErrors } from '@/utils/errors';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Badge } from '@datum-cloud/datum-ui/badge';
 import { Button } from '@datum-cloud/datum-ui/button';
@@ -24,7 +24,7 @@ import { PlusIcon } from 'lucide-react';
 import { useMemo, useRef } from 'react';
 import { LoaderFunctionArgs, useLoaderData, useNavigate, useParams } from 'react-router';
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId } = params;
 
   if (!projectId) {
@@ -35,7 +35,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   const secretService = createSecretService();
   const secrets = await secretService.list(projectId);
   return secrets;
-};
+});
 
 export default function SecretsPage() {
   const initialData = useLoaderData<typeof loader>();

--- a/app/routes/project/detail/service-accounts/detail/layout.tsx
+++ b/app/routes/project/detail/service-accounts/detail/layout.tsx
@@ -7,7 +7,7 @@ import {
   type ServiceAccount,
 } from '@/resources/service-accounts';
 import { paths } from '@/utils/config/paths.config';
-import { BadRequestError, NotFoundError } from '@/utils/errors';
+import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
@@ -31,7 +31,7 @@ export const meta: MetaFunction<typeof loader> = mergeMeta(({ loaderData }) => {
   return metaObject(account?.displayName ?? account?.name ?? 'Service Account');
 });
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId, serviceAccountId } = params;
 
   if (!projectId || !serviceAccountId) {
@@ -46,7 +46,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
   }
 
   return account;
-};
+});
 
 export type ServiceAccountDetailContext = {
   account: ServiceAccount;

--- a/app/routes/project/detail/service-accounts/index.tsx
+++ b/app/routes/project/detail/service-accounts/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/resources/service-accounts';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
-import { BadRequestError } from '@/utils/errors';
+import { BadRequestError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Button } from '@datum-cloud/datum-ui/button';
@@ -36,7 +36,7 @@ import {
 
 export const meta: MetaFunction = mergeMeta(() => metaObject('Service Accounts'));
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId } = params;
 
   if (!projectId) {
@@ -45,7 +45,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 
   const service = createServiceAccountService();
   return service.list(projectId);
-};
+});
 
 export default function ServiceAccountsPage() {
   const initialData = useLoaderData<typeof loader>();

--- a/app/routes/project/detail/settings/quotas.tsx
+++ b/app/routes/project/detail/settings/quotas.tsx
@@ -1,24 +1,25 @@
 import { QuotasTable } from '@/features/quotas/quotas-table';
 import { useProjectContext } from '@/providers/project.provider';
 import { createAllowanceBucketService, type AllowanceBucket } from '@/resources/allowance-buckets';
+import { BadRequestError, withLoaderErrors } from '@/utils/errors';
 import { LoaderFunctionArgs, useLoaderData } from 'react-router';
 
 export const handle = {
   breadcrumb: () => <span>Quotas</span>,
 };
 
-export const loader = async ({ params }: LoaderFunctionArgs) => {
+export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId } = params;
 
   if (!projectId) {
-    throw new Error('Project ID is required');
+    throw new BadRequestError('Project ID is required');
   }
 
   // Services now use global axios client with AsyncLocalStorage
   const allowanceBucketService = createAllowanceBucketService();
   const allowanceBuckets = await allowanceBucketService.list('project', projectId);
   return allowanceBuckets;
-};
+});
 
 export default function ProjectQuotasPage() {
   const { project } = useProjectContext();

--- a/app/utils/errors/app-error.ts
+++ b/app/utils/errors/app-error.ts
@@ -1,5 +1,21 @@
 import * as Sentry from '@sentry/react-router';
 
+/**
+ * HTTP status codes that represent expected user-facing states
+ * (e.g. resource not found, permission denied, session expired).
+ *
+ * Errors with these statuses are not captured to Sentry and are rendered
+ * with a user-friendly message rather than "our team has been notified".
+ *
+ * Other 4xx codes (400, 409, 429, ...) reaching the route error boundary
+ * usually indicate a bug — those are still captured.
+ */
+export const USER_FACING_ERROR_STATUSES: ReadonlySet<number> = new Set([401, 403, 404]);
+
+export function isUserFacingErrorStatus(status: number | undefined): boolean {
+  return typeof status === 'number' && USER_FACING_ERROR_STATUSES.has(status);
+}
+
 export interface ErrorDetail {
   path: string[];
   message: string;

--- a/app/utils/errors/index.ts
+++ b/app/utils/errors/index.ts
@@ -6,6 +6,8 @@ export {
   NotFoundError,
   ConflictError,
   RateLimitError,
+  USER_FACING_ERROR_STATUSES,
+  isUserFacingErrorStatus,
   type ErrorDetail,
   type SerializedError,
   type K8sErrorDetails,
@@ -35,3 +37,5 @@ export { formatZodError, fromZodError, parseOrThrow } from './error-formatter';
 export { mapApiError } from './error-mapper';
 
 export { parseK8sMessage } from './error-parser';
+
+export { withLoaderErrors } from './loader';

--- a/app/utils/errors/loader.ts
+++ b/app/utils/errors/loader.ts
@@ -1,0 +1,48 @@
+import { AppError } from './app-error';
+
+/**
+ * Wrap a React Router loader (or action) to convert thrown `AppError` instances
+ * into `Response` objects.
+ *
+ * Why this is necessary:
+ * - React Router treats thrown `Error` instances as 500 responses and strips
+ *   custom properties (like `status` on `AppError`) during error serialization.
+ * - Thrown `Response` objects, by contrast, are recognised by
+ *   `isRouteErrorResponse(error)` and preserve both the HTTP status and the
+ *   serialized JSON body (accessible as `error.data` in the boundary).
+ *
+ * Using this wrapper ensures:
+ * - 4xx loader failures (e.g. `NotFoundError` from a service) flow through to
+ *   the route error boundary as proper `ErrorResponse`s with the correct
+ *   status code.
+ * - The `GenericError` UI can read the status and render user-facing copy
+ *   ("We couldn't find that page." for 404, "You don't have access to this."
+ *   for 403, etc.) instead of the generic 5xx fallback.
+ * - The HTTP response code on the document matches the underlying error
+ *   (404, 403, ...) rather than always being 500.
+ *
+ * Non-`AppError` throws are re-thrown unchanged so genuine unexpected errors
+ * still surface to Sentry via `handleError` / the error boundary.
+ *
+ * @example
+ *   export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
+ *     const svc = createDnsZoneService();
+ *     const zone = await svc.get(params.projectId!, params.dnsZoneId!);
+ *     if (!zone) throw new NotFoundError('DNS Zone', params.dnsZoneId);
+ *     return data(zone);
+ *   });
+ */
+export function withLoaderErrors<Args, Result>(
+  fn: (args: Args) => Promise<Result>
+): (args: Args) => Promise<Result> {
+  return async (args: Args) => {
+    try {
+      return await fn(args);
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error.toResponse();
+      }
+      throw error;
+    }
+  };
+}

--- a/app/utils/helpers/resource-labels.ts
+++ b/app/utils/helpers/resource-labels.ts
@@ -21,7 +21,7 @@ const RESOURCE_LABELS: Readonly<Record<string, string>> = Object.freeze({
   dnsrecords: 'DNS Record',
   dnsrecordsets: 'DNS Record Set',
   dnszonediscoveries: 'DNS Zone Discovery',
-  httpproxies: 'HTTP Proxy',
+  httpproxies: 'AI Edge',
   secrets: 'Secret',
   policybindings: 'Role',
   exportpolicies: 'Export Policy',

--- a/cypress/component/resource-labels.cy.ts
+++ b/cypress/component/resource-labels.cy.ts
@@ -9,8 +9,8 @@ describe('getResourceLabel', () => {
     expect(getResourceLabel('dnszones')).to.equal('DNS Zone');
   });
 
-  it('returns label for HTTP proxies', () => {
-    expect(getResourceLabel('httpproxies')).to.equal('HTTP Proxy');
+  it('returns label for HTTP proxies (AI Edge)', () => {
+    expect(getResourceLabel('httpproxies')).to.equal('AI Edge');
   });
 
   it('returns label for domains', () => {

--- a/cypress/e2e/smoke/not-found.cy.ts
+++ b/cypress/e2e/smoke/not-found.cy.ts
@@ -86,9 +86,7 @@ describe('Not found page', () => {
         const url = pathOf(projectId);
 
         // Document response must carry HTTP 404, not 500.
-        cy.request({ url, failOnStatusCode: false })
-          .its('status')
-          .should('eq', 404);
+        cy.request({ url, failOnStatusCode: false }).its('status').should('eq', 404);
 
         // Rendered page must be the 404 view, not the generic 5xx view.
         cy.visit(url, { failOnStatusCode: false });
@@ -96,10 +94,7 @@ describe('Not found page', () => {
           'contain.text',
           "We couldn't find that page."
         );
-        cy.get('[data-e2e="error-page"]').should(
-          'not.contain.text',
-          'Our team has been notified'
-        );
+        cy.get('[data-e2e="error-page"]').should('not.contain.text', 'Our team has been notified');
       });
     });
   });

--- a/cypress/e2e/smoke/not-found.cy.ts
+++ b/cypress/e2e/smoke/not-found.cy.ts
@@ -1,0 +1,106 @@
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+
+/**
+ * Regression coverage for the 404 error boundary.
+ *
+ * Loaders throwing `NotFoundError` used to surface as 500 "Whoops! Something
+ * went wrong." pages because React Router strips custom AppError fields
+ * (including `status`) when serializing errors thrown from server loaders.
+ *
+ * Wrapping each loader with `withLoaderErrors` converts `AppError` to a
+ * `Response`, which React Router treats as an `ErrorResponse` and preserves
+ * both on the HTTP status of the document and on `useRouteError().status`.
+ *
+ * This spec verifies, for representative resource types, that:
+ *   1. The document response carries HTTP 404 (not 500).
+ *   2. The rendered page is the 404 view ("We couldn't find that page."),
+ *      not the generic 5xx view ("Our team has been notified").
+ *
+ * Selectors come from `GenericError`:
+ *   [data-e2e="error-page"]         The error card.
+ *   [data-e2e="error-page-title"]   Title paragraph.
+ *   [data-error-status]             Status code as a string ('' when unset).
+ *
+ * No resources are created — each path uses a deliberately bogus ID.
+ */
+
+const MISSING_ID = 'does-not-exist-e2e-404';
+
+type Case = {
+  resource: string;
+  pathOf: (projectId: string) => string;
+};
+
+const cases: Case[] = [
+  {
+    resource: 'AI Edge',
+    pathOf: (projectId) =>
+      getPathWithParams(paths.project.detail.proxy.detail.root, {
+        projectId,
+        proxyId: MISSING_ID,
+      }),
+  },
+  {
+    resource: 'Domain',
+    pathOf: (projectId) =>
+      getPathWithParams(paths.project.detail.domains.detail.overview, {
+        projectId,
+        domainId: MISSING_ID,
+      }),
+  },
+  {
+    resource: 'DNS Zone',
+    pathOf: (projectId) =>
+      getPathWithParams(paths.project.detail.dnsZones.detail.dnsRecords, {
+        projectId,
+        dnsZoneId: MISSING_ID,
+      }),
+  },
+  {
+    resource: 'Secret',
+    pathOf: (projectId) =>
+      getPathWithParams(paths.project.detail.secrets.detail.overview, {
+        projectId,
+        secretId: MISSING_ID,
+      }),
+  },
+  {
+    resource: 'Service Account',
+    pathOf: (projectId) =>
+      getPathWithParams(paths.project.detail.serviceAccounts.detail.overview, {
+        projectId,
+        serviceAccountId: MISSING_ID,
+      }),
+  },
+];
+
+describe('Not found page', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  cases.forEach(({ resource, pathOf }) => {
+    it(`returns 404 with the not-found UI for a missing ${resource}`, () => {
+      cy.getProjectId().then((projectId) => {
+        const url = pathOf(projectId);
+
+        // Document response must carry HTTP 404, not 500.
+        cy.request({ url, failOnStatusCode: false })
+          .its('status')
+          .should('eq', 404);
+
+        // Rendered page must be the 404 view, not the generic 5xx view.
+        cy.visit(url, { failOnStatusCode: false });
+        cy.get('[data-e2e="error-page-title"]', { timeout: 10000 }).should(
+          'contain.text',
+          "We couldn't find that page."
+        );
+        cy.get('[data-e2e="error-page"]').should(
+          'not.contain.text',
+          'Our team has been notified'
+        );
+      });
+    });
+  });
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -2,6 +2,59 @@ import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import '@testing-library/cypress/add-commands';
 
+/**
+ * Stub the "ambient" authenticated-page polling that fires on every visit so
+ * the e2e suite doesn't trip the upstream IAM rate limiter for the test
+ * account. None of the smoke specs exercise these endpoints — they're noise
+ * from global header components (notification bell, watch SSE, org switcher,
+ * marker.io feedback widget).
+ *
+ * Without this, every `cy.visit` opens a fresh QueryClient + WatchManager
+ * that hammers IAM, and in CI — where specs run back-to-back against the
+ * same test account — the cumulative load returns 429s. The user-visible
+ * symptom is a "Too Many Requests" toast on whatever spec runs latest in
+ * the suite (most often the alphabetically-last `secrets.cy.ts`).
+ *
+ * Specs that genuinely exercise one of these endpoints can override the
+ * intercept locally (later `cy.intercept` calls for the same route win) or
+ * disable the helper entirely via `Cypress.env('E2E_ALLOW_AMBIENT_APIS')`.
+ */
+function stubAmbientApis(): void {
+  // Notification bell — user-scoped invitation list.
+  // Scoped tightly to `users/me/...userinvitations` so the org-scoped
+  // invitation tables (covered by `members.cy.ts`) are unaffected.
+  cy.intercept('GET', '**/users/me/**/userinvitations*', {
+    statusCode: 200,
+    body: {
+      kind: 'UserInvitationList',
+      apiVersion: 'iam.miloapis.com/v1alpha1',
+      items: [],
+    },
+  });
+
+  // Multiplexed watch SSE. We can't easily simulate a real SSE stream from
+  // `cy.intercept`, so we hold the request open longer than any test could
+  // run. The client-side WatchManager sits awaiting `fetch` and never enters
+  // its retry loop, never opens upstream K8s watches, and never reconnects.
+  cy.intercept('GET', '/api/watch/stream*', {
+    statusCode: 200,
+    headers: { 'content-type': 'text/event-stream' },
+    body: '',
+    delay: 5 * 60 * 1000,
+  });
+  cy.intercept('POST', '/api/watch/subscribe', { statusCode: 200, body: {} });
+  cy.intercept('POST', '/api/watch/unsubscribe', { statusCode: 200, body: {} });
+
+  // Marker.io feedback widget — third-party, not under test.
+  cy.intercept(/api\.marker\.io/, { statusCode: 204, body: '' });
+}
+
+beforeEach(() => {
+  if (!Cypress.env('E2E_ALLOW_AMBIENT_APIS')) {
+    stubAmbientApis();
+  }
+});
+
 Cypress.Commands.add('login', (options?: { accessToken?: string; sub?: string }) => {
   // Get accessToken and sub from options or environment variables
   cy.env(['ACCESS_TOKEN', 'SUB']).then((env) => {


### PR DESCRIPTION
## Summary

User-facing errors (401 / 403 / 404) were being captured to Sentry and rendered to users as generic 500 "Whoops! Something went wrong." pages with the unhelpful "our team has been notified" copy. This drowned legitimate alerts and gave users a worse experience whenever they hit a missing or unauthorized resource.

The root cause had two parts:

1. Sentry was capturing exceptions unconditionally in both the server-side `handleError` and the client-side `ErrorBoundary` / axios interceptor.
2. React Router strips custom `AppError` fields (including `status`) when serializing errors thrown from server loaders, so even `NotFoundError(404)` from a loader surfaced as a 500 in the browser.

This PR addresses both. A new `withLoaderErrors` wrapper converts `AppError` to a `Response` so React Router preserves the status both on the HTTP document and on `useRouteError().status`. The error boundary, `handleError`, and the axios interceptor now skip Sentry capture for `USER_FACING_ERROR_STATUSES` (401/403/404), and `GenericError` renders different copy for 404 and 403.

Key behaviors:

- 404s and 403s no longer reach Sentry; other 4xx codes (400/409/422/429/…) still do because those usually indicate a bug.
- A missing AI Edge / Domain / DNS Zone / Secret / Service Account renders "We couldn't find that page." with a 404 on the document.
- Service `.get()` fallback paths (\`if (!data) throw new Error('X not found')\`) now throw \`NotFoundError\` so the rare empty-body case produces a 404 instead of a 500.
- The \`httpproxies\` label resolves to "AI Edge" in error messages and activity logs, and the activity humanizer chooses "a" vs "an" based on the leading vowel ("Added an AI Edge").
