### PR TITLE
refactor(sub-layout): redesign sub-nav layout for resource detail pages to horizontal tab bar

### DIFF
--- a/app/components/card-list/card-list.tsx
+++ b/app/components/card-list/card-list.tsx
@@ -133,7 +133,7 @@ function CardListRoot<TData>({
 
   return (
     <CardListContext.Provider value={ctxValue as unknown as CardListContextValue}>
-      <div className={cn('space-y-4', className)} {...rest}>
+      <div className={cn('space-y-6', className)} {...rest}>
         {children}
       </div>
     </CardListContext.Provider>
@@ -160,7 +160,7 @@ function CardListHeader({
   ...rest
 }: CardListHeaderProps) {
   return (
-    <div className={cn('flex flex-col gap-5', className)} {...rest}>
+    <div className={cn('flex flex-col gap-6', className)} {...rest}>
       <PageTitle title={title} description={description} />
       {(children || actions) && (
         <div className="flex w-full flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">

--- a/app/components/sub-navigation/sub-navigation-tabs.tsx
+++ b/app/components/sub-navigation/sub-navigation-tabs.tsx
@@ -1,6 +1,7 @@
 import { Tabs, TabsLinkTrigger, TabsList } from '@datum-cloud/datum-ui/tabs';
 import { cn } from '@datum-cloud/datum-ui/utils';
 import type { LucideIcon } from 'lucide-react';
+import { motion } from 'motion/react';
 import { useMemo } from 'react';
 import { Link, useLocation } from 'react-router';
 
@@ -47,23 +48,33 @@ export function SubNavigationTabs({ tabs, className, containerClassName }: SubNa
       <div className={cn('w-full', containerClassName)}>
         <Tabs value={activeHref}>
           <TabsList className="bg-background scrollbar-hide flex h-auto w-full justify-start gap-0 overflow-x-auto rounded-none p-0">
-            {visibleTabs.map((tab) => (
-              <TabsLinkTrigger
-                key={tab.href}
-                value={tab.href}
-                href={tab.href}
-                linkComponent={Link}
-                className={cn(
-                  'flex w-fit shrink-0 items-center gap-2 rounded-none border-b-2 border-transparent px-0',
-                  'py-2.5 md:py-2',
-                  'bg-background focus-visible:ring-0 focus-visible:outline-hidden',
-                  'data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:font-medium data-[state=active]:shadow-none',
-                  'text-foreground mx-3.5 !flex-none text-xs font-normal transition-all first:ml-0 last:mr-0'
-                )}>
-                {tab.icon && <tab.icon className="size-4" />}
-                {tab.label}
-              </TabsLinkTrigger>
-            ))}
+            {visibleTabs.map((tab) => {
+              const isActive = activeHref === tab.href;
+              return (
+                <TabsLinkTrigger
+                  key={tab.href}
+                  value={tab.href}
+                  href={tab.href}
+                  linkComponent={Link}
+                  className={cn(
+                    'relative flex w-fit shrink-0 items-center gap-2 rounded-none border-b-2 border-transparent px-0',
+                    'py-2.5 md:py-2',
+                    'bg-background focus-visible:ring-0 focus-visible:outline-hidden',
+                    'data-[state=active]:text-primary data-[state=active]:font-medium data-[state=active]:shadow-none',
+                    'text-foreground mx-3.5 !flex-none text-xs font-normal transition-colors first:ml-0 last:mr-0'
+                  )}>
+                  {tab.icon && <tab.icon className="size-4" />}
+                  {tab.label}
+                  {isActive && (
+                    <motion.span
+                      layoutId="active-tab-indicator"
+                      className="bg-primary absolute inset-x-0 bottom-0 h-0.5"
+                      transition={{ type: 'spring', stiffness: 380, damping: 30 }}
+                    />
+                  )}
+                </TabsLinkTrigger>
+              );
+            })}
           </TabsList>
         </Tabs>
       </div>

--- a/app/components/table/client.tsx
+++ b/app/components/table/client.tsx
@@ -66,7 +66,7 @@ export function TableClient<TData>(props: TableClientProps<TData>) {
       loading={props.loading}
       pageSize={props.pageSize}
       searchableColumns={props.searchableColumns}
-      className={cn('space-y-4', props.className)}>
+      className={cn('space-y-6', props.className)}>
       <PagePreserver<TData> data={props.data} />
 
       {hasToolbar && <TableToolbar<TData> {...toolbarPropsFrom(props)} />}

--- a/app/components/table/components/toolbar.tsx
+++ b/app/components/table/components/toolbar.tsx
@@ -51,11 +51,12 @@ export function TableToolbar<TData>({
   const hasHeaderRow = !!(title || description || headerExtra);
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-6">
       {hasHeaderRow && (
         <PageTitle
           title={title}
           description={description}
+          descriptionClassName="max-w-none"
           actions={headerExtra}
           className={headerExtra ? 'items-start' : undefined}
         />

--- a/app/components/table/server.tsx
+++ b/app/components/table/server.tsx
@@ -91,7 +91,7 @@ function TableServerImpl<TData, TResponse>(
       defaultFilters={props.defaultFilters}
       getRowId={props.getRowId}
       enableRowSelection={!!props.multiActions?.length}
-      className={cn('space-y-4', props.className)}>
+      className={cn('space-y-6', props.className)}>
       <ErrorBridge onError={props.onError} />
 
       {hasToolbar && <TableToolbar<TData> {...toolbarPropsFrom(props)} />}

--- a/app/features/edge/domain/domain-header-actions.tsx
+++ b/app/features/edge/domain/domain-header-actions.tsx
@@ -1,0 +1,154 @@
+import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
+import { type DnsZone } from '@/resources/dns-zones';
+import {
+  type Domain,
+  useDeleteDomain,
+  useDomain,
+  useDomainWatch,
+  useRefreshDomainRegistration,
+} from '@/resources/domains';
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+import { Button } from '@datum-cloud/datum-ui/button';
+import { Icon } from '@datum-cloud/datum-ui/icons';
+import { toast } from '@datum-cloud/datum-ui/toast';
+import { GlobeIcon, RefreshCcwIcon, TrashIcon } from 'lucide-react';
+import { useNavigate } from 'react-router';
+
+interface DomainHeaderActionsProps {
+  projectId: string;
+  domain: Domain;
+  dnsZone?: DnsZone | null;
+}
+
+export function DomainHeaderActions({ projectId, domain, dnsZone }: DomainHeaderActionsProps) {
+  const navigate = useNavigate();
+  const { confirm } = useConfirmationDialog();
+
+  // Live domain data from React Query (seeded by parent layout's useDomain call)
+  const { data: liveDomain } = useDomain(projectId, domain?.name ?? '', {
+    enabled: !!domain?.name,
+    initialData: domain,
+  });
+  // Subscribe to real-time domain updates
+  useDomainWatch(projectId, liveDomain?.name ?? domain?.name ?? '', {
+    enabled: !!(liveDomain?.name ?? domain?.name),
+  });
+
+  const effectiveDomain = liveDomain ?? domain;
+
+  const deleteDomainMutation = useDeleteDomain(projectId, {
+    onSuccess: () => {
+      navigate(
+        getPathWithParams(paths.project.detail.domains.root, {
+          projectId,
+        })
+      );
+    },
+    onError: (error) => {
+      toast.error('Domain', { description: error.message || 'Failed to delete domain' });
+    },
+  });
+
+  const refreshDomainMutation = useRefreshDomainRegistration(projectId, {
+    onSuccess: () => {
+      toast.success('Domain', {
+        description: 'The domain has been refreshed successfully',
+      });
+    },
+    onError: (error) => {
+      toast.error('Domain', {
+        description: error.message || 'Failed to refresh domain',
+      });
+    },
+  });
+
+  const handleRefreshDomain = () => {
+    if (!effectiveDomain?.name) return;
+    refreshDomainMutation.mutate(effectiveDomain.name);
+  };
+
+  const handleManageDnsZone = () => {
+    if (!effectiveDomain?.domainName) return;
+
+    if (dnsZone) {
+      navigate(
+        getPathWithParams(paths.project.detail.dnsZones.detail.root, {
+          projectId,
+          dnsZoneId: dnsZone.name ?? '',
+        })
+      );
+      return;
+    }
+
+    navigate(
+      getPathWithParams(
+        paths.project.detail.dnsZones.root,
+        {
+          projectId,
+        },
+        new URLSearchParams({
+          action: 'create',
+          domainName: effectiveDomain.domainName,
+        })
+      )
+    );
+  };
+
+  const handleDeleteDomain = async () => {
+    if (!effectiveDomain?.name) return;
+
+    await confirm({
+      title: 'Delete Domain',
+      description: (
+        <span>
+          Are you sure you want to delete&nbsp;
+          <strong>{effectiveDomain.domainName}</strong>?
+        </span>
+      ),
+      submitText: 'Delete',
+      cancelText: 'Cancel',
+      variant: 'destructive',
+      showConfirmInput: false,
+      onSubmit: async () => {
+        deleteDomainMutation.mutate(effectiveDomain.name);
+      },
+    });
+  };
+
+  if (!effectiveDomain?.name) return null;
+
+  return (
+    <div className="flex w-full items-center gap-2 sm:w-auto">
+      <Button
+        type="secondary"
+        theme="outline"
+        size="small"
+        loading={refreshDomainMutation.isPending}
+        onClick={handleRefreshDomain}
+        aria-label="Refresh domain">
+        <Icon icon={RefreshCcwIcon} size={14} />
+        <span className="hidden sm:inline">Refresh</span>
+      </Button>
+      <Button
+        type="secondary"
+        theme="outline"
+        size="small"
+        className="flex-1 sm:flex-initial"
+        onClick={handleManageDnsZone}>
+        <Icon icon={GlobeIcon} size={14} />
+        Manage DNS Zone
+      </Button>
+      <Button
+        type="danger"
+        theme="outline"
+        size="small"
+        loading={deleteDomainMutation.isPending}
+        onClick={handleDeleteDomain}
+        aria-label="Delete domain">
+        <Icon icon={TrashIcon} size={14} />
+        <span className="hidden sm:inline">Delete</span>
+      </Button>
+    </div>
+  );
+}

--- a/app/features/edge/proxy/proxy-header-actions.tsx
+++ b/app/features/edge/proxy/proxy-header-actions.tsx
@@ -1,0 +1,56 @@
+import { useDeleteProxy } from '@/features/edge/proxy/hooks/use-delete-proxy';
+import { type HttpProxy, useHttpProxy, useHttpProxyWatch } from '@/resources/http-proxies';
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+import { Button } from '@datum-cloud/datum-ui/button';
+import { Icon } from '@datum-cloud/datum-ui/icons';
+import { toast } from '@datum-cloud/datum-ui/toast';
+import { Trash2Icon } from 'lucide-react';
+import { useNavigate } from 'react-router';
+
+interface ProxyHeaderActionsProps {
+  projectId: string;
+  proxy: HttpProxy;
+}
+
+export function ProxyHeaderActions({ projectId, proxy }: ProxyHeaderActionsProps) {
+  const navigate = useNavigate();
+
+  // Live proxy data from React Query (seeded by parent layout's useHttpProxy call)
+  const { data: liveProxy } = useHttpProxy(projectId, proxy?.name ?? '', {
+    enabled: !!proxy?.name,
+    initialData: proxy,
+  });
+  // Subscribe to real-time proxy updates
+  useHttpProxyWatch(projectId, liveProxy?.name ?? proxy?.name ?? '', {
+    enabled: !!(liveProxy?.name ?? proxy?.name),
+  });
+
+  const effectiveProxy = liveProxy ?? proxy;
+
+  const { confirmDelete, isPending: isDeleting } = useDeleteProxy(projectId, {
+    onSuccess: () => {
+      navigate(getPathWithParams(paths.project.detail.proxy.root, { projectId }));
+    },
+    onError: (error) => {
+      toast.error(error.message || 'Failed to delete proxy');
+    },
+  });
+
+  if (!effectiveProxy?.name) return null;
+
+  return (
+    <div className="flex w-full items-center gap-2 sm:w-auto">
+      <Button
+        type="danger"
+        theme="outline"
+        size="small"
+        loading={isDeleting}
+        onClick={() => confirmDelete(effectiveProxy)}
+        aria-label="Delete AI Edge">
+        <Icon icon={Trash2Icon} size={14} />
+        <span className="hidden sm:inline">Delete</span>
+      </Button>
+    </div>
+  );
+}

--- a/app/features/edge/proxy/proxy-origins-dialog.tsx
+++ b/app/features/edge/proxy/proxy-origins-dialog.tsx
@@ -103,7 +103,11 @@ export const ProxyOriginsDialog = forwardRef<ProxyOriginsDialogRef, ProxyOrigins
             name="endpointHost"
             label="Origin"
             required>
-            <ProtocolEndpointInput autoFocus onIPChange={setIsIPOrigin} onProtocolChange={setProtocol} />
+            <ProtocolEndpointInput
+              autoFocus
+              onIPChange={setIsIPOrigin}
+              onProtocolChange={setProtocol}
+            />
           </Form.Field>
 
           {isIPOrigin && <ProxyTlsField required={protocol === 'https'} />}

--- a/app/features/service-account/service-account-header-actions.tsx
+++ b/app/features/service-account/service-account-header-actions.tsx
@@ -1,0 +1,46 @@
+import { useUpdateServiceAccount, type ServiceAccount } from '@/resources/service-accounts';
+import { Button } from '@datum-cloud/datum-ui/button';
+import { Icon } from '@datum-cloud/datum-ui/icons';
+import { toast } from '@datum-cloud/datum-ui/toast';
+import { PowerIcon, PowerOffIcon } from 'lucide-react';
+
+interface ServiceAccountHeaderActionsProps {
+  projectId: string;
+  serviceAccountId: string;
+  account: ServiceAccount;
+}
+
+export function ServiceAccountHeaderActions({
+  projectId,
+  serviceAccountId,
+  account,
+}: ServiceAccountHeaderActionsProps) {
+  const toggleMutation = useUpdateServiceAccount(projectId, serviceAccountId, {
+    onSuccess: () => {
+      toast.success('Service account updated');
+    },
+    onError: (error) => {
+      toast.error('Error', { description: error.message });
+    },
+  });
+
+  const isActive = account.status === 'Active';
+
+  const handleToggle = () => {
+    toggleMutation.mutate({
+      status: isActive ? 'Disabled' : 'Active',
+    });
+  };
+
+  return (
+    <Button
+      type="secondary"
+      theme="outline"
+      size="small"
+      loading={toggleMutation.isPending}
+      onClick={handleToggle}>
+      <Icon icon={isActive ? PowerOffIcon : PowerIcon} size={14} />
+      {isActive ? 'Disable' : 'Enable'}
+    </Button>
+  );
+}

--- a/app/layouts/dashboard.layout.tsx
+++ b/app/layouts/dashboard.layout.tsx
@@ -65,6 +65,7 @@ export function DashboardLayout({
   sidebarLoading = false,
   switcherLoading = false,
   bottomBar,
+  defaultSidebarOpen,
 }: {
   children: React.ReactNode;
   navItems: NavItem[];
@@ -83,6 +84,8 @@ export function DashboardLayout({
   switcherLoading?: boolean;
   /** Optional bar rendered at the bottom of the layout */
   bottomBar?: React.ReactNode;
+  /** Initial sidebar state. Falls back to expanded on desktop, collapsed on tablet. */
+  defaultSidebarOpen?: boolean;
 }) {
   const { pathname } = useLocation();
   const [searchParams] = useSearchParams();
@@ -101,7 +104,7 @@ export function DashboardLayout({
 
       {/* Sidebar + Content area below header - flex-1 min-h-0 so only this area scrolls on mobile */}
       <SidebarProvider
-        defaultOpen={!isTablet}
+        defaultOpen={defaultSidebarOpen ?? !isTablet}
         expandOnHover={isTablet}
         expandBehavior={expandBehavior}
         showBackdrop={showBackdrop}

--- a/app/layouts/sub/sub.layout.tsx
+++ b/app/layouts/sub/sub.layout.tsx
@@ -1,95 +1,31 @@
 import { SubLayoutProps } from './sub.types';
-import { ContentWrapper } from '@/components/content-wrapper';
-import { SubNavigationTabs, type SubNavigationTab } from '@/components/sub-navigation';
-import { useBreakpoint } from '@/hooks/use-breakpoint';
-import { type NavItem, NavMenu } from '@datum-cloud/datum-ui/app-navigation';
-import { useSidebar } from '@datum-cloud/datum-ui/sidebar';
+import { SubNavigationTabs } from '@/components/sub-navigation';
+import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { cn } from '@datum-cloud/datum-ui/utils';
-import { useLayoutEffect, useMemo } from 'react';
-import { Link, useLocation } from 'react-router';
-
-function toSubNavTabs(navItems: NavItem[]): SubNavigationTab[] {
-  return navItems
-    .filter((item) => item.href != null)
-    .map((item) => ({
-      label: item.title,
-      href: item.href!,
-      icon: item.icon,
-      hidden: item.hidden,
-    }));
-}
 
 export function SubLayout({
   children,
   navItems,
-  sidebarHeader,
+  title,
+  status,
+  actions,
   className,
   containerClassName,
   contentClassName,
 }: SubLayoutProps) {
-  const { setHasSubLayout } = useSidebar();
-  const { pathname } = useLocation();
-  const breakpoint = useBreakpoint();
-  const isDesktop = breakpoint === 'desktop';
-  const subNavTabs = useMemo(() => toSubNavTabs(navItems), [navItems]);
+  const hasPageTitle = title != null || status != null || actions != null;
 
-  // Always register SubLayout — it handles its own ContentWrapper for all breakpoints.
-  // This prevents DashboardLayout from wrapping content in a second ContentWrapper,
-  // and avoids hydration-triggered remount loops when isDesktop flips from SSR default.
-  useLayoutEffect(() => {
-    setHasSubLayout(true);
-    return () => setHasSubLayout(false);
-  }, [setHasSubLayout]);
-
-  // Mobile/Tablet: horizontal tabs above content, stacked vertically
-  if (!isDesktop) {
-    return (
-      <div className={cn('flex h-full w-full flex-col', className)}>
-        <div className="border-sidebar-border border-b">
-          <SubNavigationTabs tabs={subNavTabs} containerClassName="px-3.5" />
-        </div>
-        <main className="min-h-0 flex-1 overflow-y-auto">
-          <ContentWrapper
-            containerClassName={cn('overflow-y-auto', containerClassName)}
-            contentClassName={contentClassName}>
-            {children}
-          </ContentWrapper>
-        </main>
-      </div>
-    );
-  }
-
-  // Desktop: inner sidebar + content side by side
   return (
-    <div className={cn('flex h-full w-full flex-row', className)}>
-      <aside
-        className={cn(
-          'bg-sidebar border-sidebar-border shrink-0 overflow-y-auto px-3.5 py-5',
-          'h-full min-w-56 border-r'
-        )}>
-        <div className="flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden">
-          <div className="flex flex-1 flex-col items-start justify-start">
-            <div className="flex flex-col">
-              {sidebarHeader && <div className="px-2 pb-0">{sidebarHeader}</div>}
-              <NavMenu
-                items={navItems}
-                className="px-0 py-3.5"
-                itemClassName="text-xs h-6"
-                disableTooltip
-                currentPath={pathname}
-                linkComponent={Link}
-              />
-            </div>
-          </div>
+    <div className={cn('flex h-full flex-1 flex-col', className)}>
+      <div className="flex flex-col gap-6">
+        {hasPageTitle && <PageTitle title={title} description={status} actions={actions} />}
+        <div className="border-border -mx-4 border-b px-4 md:-mx-9 md:px-9">
+          <SubNavigationTabs tabs={navItems} />
         </div>
-      </aside>
-      <main className="h-full min-h-0 flex-1 overflow-y-auto">
-        <ContentWrapper
-          containerClassName={cn('overflow-y-auto', containerClassName)}
-          contentClassName={contentClassName}>
-          {children}
-        </ContentWrapper>
-      </main>
+      </div>
+      <div className={cn('mt-6 h-full w-full', containerClassName)}>
+        <div className={cn('flex h-full flex-1 flex-col', contentClassName)}>{children}</div>
+      </div>
     </div>
   );
 }

--- a/app/layouts/sub/sub.types.ts
+++ b/app/layouts/sub/sub.types.ts
@@ -1,10 +1,17 @@
-import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
+import { type SubNavigationTab } from '@/components/sub-navigation';
 import { ReactNode } from 'react';
 
 export interface SubLayoutProps {
   children: ReactNode;
-  navItems: NavItem[];
-  sidebarHeader?: string | ReactNode;
+  navItems: SubNavigationTab[];
+
+  /** Page title, rendered via `<PageTitle>`. */
+  title?: string;
+  /** Description rendered below the title via `<PageTitle>`'s description slot. */
+  status?: ReactNode;
+  /** Header-level actions, rendered via `<PageTitle>`'s actions slot. */
+  actions?: ReactNode;
+
   className?: string;
   containerClassName?: string;
   contentClassName?: string;

--- a/app/routes/account/settings/layout.tsx
+++ b/app/routes/account/settings/layout.tsx
@@ -1,8 +1,7 @@
 import { BackButton } from '@/components/back-button';
-import { SubNavigationTabs, type SubNavigationTab } from '@/components/sub-navigation';
-import { DashboardLayout } from '@/layouts';
+import { type SubNavigationTab } from '@/components/sub-navigation';
+import { DashboardLayout, SubLayout } from '@/layouts';
 import { paths } from '@/utils/config/paths.config';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { Outlet } from 'react-router';
 
 export default function AccountSettingsLayout() {
@@ -32,15 +31,9 @@ export default function AccountSettingsLayout() {
     <DashboardLayout navItems={[]} sidebarCollapsible="none" contentClassName="w-full">
       <div className="mx-auto flex w-full flex-col gap-4 md:max-w-[1200px]">
         <BackButton to={paths.home}>Back to Dashboard</BackButton>
-        <div className="flex h-full flex-1 flex-col gap-8">
-          <PageTitle title="Account Settings" />
-          <SubNavigationTabs tabs={navItems} />
-          <div className="h-full w-full pt-2">
-            <div className="flex h-full flex-1 flex-col">
-              <Outlet />
-            </div>
-          </div>
-        </div>
+        <SubLayout title="Account Settings" navItems={navItems}>
+          <Outlet />
+        </SubLayout>
       </div>
     </DashboardLayout>
   );

--- a/app/routes/org/detail/settings/layout.tsx
+++ b/app/routes/org/detail/settings/layout.tsx
@@ -1,8 +1,8 @@
-import { SubNavigationTabs, type SubNavigationTab } from '@/components/sub-navigation';
+import { type SubNavigationTab } from '@/components/sub-navigation';
+import { SubLayout } from '@/layouts';
 import type { Organization } from '@/resources/organizations';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useMemo } from 'react';
 import { Outlet, useRouteLoaderData } from 'react-router';
 
@@ -43,14 +43,8 @@ export default function OrgSettingsLayout() {
   }, [org]);
 
   return (
-    <div className="flex h-full flex-1 flex-col gap-8">
-      <PageTitle title="Organization Settings" />
-      <SubNavigationTabs tabs={navItems} />
-      <div className="h-full w-full pt-2">
-        <div className="flex h-full flex-1 flex-col">
-          <Outlet />
-        </div>
-      </div>
-    </div>
+    <SubLayout title="Organization Settings" navItems={navItems}>
+      <Outlet />
+    </SubLayout>
   );
 }

--- a/app/routes/org/detail/team/list-layout.tsx
+++ b/app/routes/org/detail/team/list-layout.tsx
@@ -1,7 +1,7 @@
-import { SubNavigationTabs, type SubNavigationTab } from '@/components/sub-navigation';
+import { type SubNavigationTab } from '@/components/sub-navigation';
+import { SubLayout } from '@/layouts';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useMemo } from 'react';
 import { Outlet, useParams } from 'react-router';
 
@@ -17,14 +17,8 @@ export default function TeamListLayout() {
   );
 
   return (
-    <div className="flex h-full flex-1 flex-col gap-8">
-      <PageTitle title="Team" />
-      <SubNavigationTabs tabs={navItems} />
-      <div className="h-full w-full pt-2">
-        <div className="flex h-full flex-1 flex-col">
-          <Outlet />
-        </div>
-      </div>
-    </div>
+    <SubLayout title="Team" navItems={navItems}>
+      <Outlet />
+    </SubLayout>
   );
 }

--- a/app/routes/project/detail/dns-zones/detail/activity.tsx
+++ b/app/routes/project/detail/dns-zones/detail/activity.tsx
@@ -1,7 +1,6 @@
 import { ResourceActivityFeed, useProjectActivityClient } from '@/features/activity';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useParams } from 'react-router';
 import type { MetaFunction } from 'react-router';
 
@@ -17,9 +16,6 @@ export default function DnsZoneActivityPage() {
 
   return (
     <Row type="flex" gutter={[24, 24]}>
-      <Col span={24}>
-        <PageTitle title="Activity" />
-      </Col>
       <Col span={24}>
         <ResourceActivityFeed
           client={client}

--- a/app/routes/project/detail/dns-zones/detail/dns-records.tsx
+++ b/app/routes/project/detail/dns-zones/detail/dns-records.tsx
@@ -411,7 +411,6 @@ export default function DnsRecordsPage() {
           />
         )}
         tableTitle={{
-          title: 'DNS Records',
           actions: (
             <div className="flex w-full items-center gap-2 sm:w-auto sm:gap-3">
               <DnsRecordImportAction
@@ -471,7 +470,6 @@ export default function DnsRecordsPage() {
               />
             )}
             tableTitle={{
-              title: 'DNS Records',
               actions: (
                 <div className="flex w-full items-center gap-2 sm:w-auto sm:gap-3">
                   <DnsRecordImportAction

--- a/app/routes/project/detail/dns-zones/detail/layout.tsx
+++ b/app/routes/project/detail/dns-zones/detail/layout.tsx
@@ -1,4 +1,4 @@
-import { BackButton } from '@/components/back-button';
+import { type SubNavigationTab } from '@/components/sub-navigation';
 import { SubLayout } from '@/layouts';
 import { createDnsRecordService } from '@/resources/dns-records';
 import { createDnsZoneService, type DnsZone, useDnsZone } from '@/resources/dns-zones';
@@ -8,7 +8,6 @@ import { redirectWithToast } from '@/utils/cookies';
 import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
 import { useMemo } from 'react';
 import {
   LoaderFunctionArgs,
@@ -89,66 +88,48 @@ export default function DnsZoneDetailLayout() {
     initialDataUpdatedAt: Date.now(),
   });
 
-  const navItems: NavItem[] = useMemo(() => {
+  const navItems: SubNavigationTab[] = useMemo(() => {
     return [
       /* {
-        title: 'Overview',
+        label: 'Overview',
         href: getPathWithParams(paths.project.detail.dnsZones.detail.overview, {
           projectId,
           dnsZoneId: dnsZone?.name ?? '',
         }),
-        type: 'link',
       }, */
       {
-        title: 'DNS Records',
+        label: 'DNS Records',
         href: getPathWithParams(paths.project.detail.dnsZones.detail.dnsRecords, {
           projectId,
           dnsZoneId: dnsZone?.name ?? '',
         }),
-        type: 'link',
       },
       {
-        title: 'Nameservers',
+        label: 'Nameservers',
         href: getPathWithParams(paths.project.detail.dnsZones.detail.nameservers, {
           projectId,
           dnsZoneId: dnsZone?.name ?? '',
         }),
-        type: 'link',
       },
       {
-        title: 'Activity',
+        label: 'Activity',
         href: getPathWithParams(paths.project.detail.dnsZones.detail.activity, {
           projectId,
           dnsZoneId: dnsZone?.name ?? '',
         }),
-        type: 'link',
       },
       {
-        title: 'Settings',
+        label: 'Settings',
         href: getPathWithParams(paths.project.detail.dnsZones.detail.settings, {
           projectId,
           dnsZoneId: dnsZone?.name ?? '',
         }),
-        type: 'link',
       },
     ];
   }, [projectId, dnsZone]);
 
   return (
-    <SubLayout
-      sidebarHeader={
-        <div className="flex flex-col gap-5.5">
-          <BackButton
-            className="hidden md:flex"
-            to={getPathWithParams(paths.project.detail.dnsZones.root, {
-              projectId,
-            })}>
-            Back to DNS
-          </BackButton>
-          <span className="text-primary text-sm font-semibold">Manage Zone</span>
-        </div>
-      }
-      navItems={navItems}>
+    <SubLayout title={dnsZone?.domainName} navItems={navItems}>
       <Outlet />
     </SubLayout>
   );

--- a/app/routes/project/detail/dns-zones/detail/nameservers.tsx
+++ b/app/routes/project/detail/dns-zones/detail/nameservers.tsx
@@ -43,7 +43,6 @@ export default function DnsZoneNameserversPage() {
     <Row gutter={[0, 32]}>
       <Col span={24}>
         <NameserverTable
-          title="Nameservers"
           titleActions={
             domain?.name && (
               <RefreshNameserversButton

--- a/app/routes/project/detail/dns-zones/detail/overview.tsx
+++ b/app/routes/project/detail/dns-zones/detail/overview.tsx
@@ -12,7 +12,6 @@ import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { LinkButton } from '@datum-cloud/datum-ui/button';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
 import { Icon } from '@datum-cloud/datum-ui/icons';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { PencilIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { Link, useParams, useRouteLoaderData } from 'react-router';
@@ -46,9 +45,6 @@ export default function DnsZoneOverviewPage() {
 
   return (
     <Row gutter={[0, 28]}>
-      <Col span={24}>
-        <PageTitle title={dnsZone?.domainName ?? 'DNS Zone'} />
-      </Col>
       <Col span={24}>
         {dnsSetupStatus.hasAnySetup ? (
           <DnsRecordCard

--- a/app/routes/project/detail/dns-zones/detail/settings.tsx
+++ b/app/routes/project/detail/dns-zones/detail/settings.tsx
@@ -6,7 +6,6 @@ import { useDeleteDnsZone } from '@/resources/dns-zones';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useNavigate, useParams, useRouteLoaderData } from 'react-router';
 
 export const handle = {
@@ -53,8 +52,6 @@ export default function DnsZoneSettingsPage() {
 
   return (
     <div className="flex w-full flex-col gap-8">
-      <PageTitle title="Settings" />
-
       <Row gutter={[0, 24]}>
         <Col span={24}>
           <h3 className="mb-4 text-base font-medium">Zone Description</h3>

--- a/app/routes/project/detail/domains/detail/activity.tsx
+++ b/app/routes/project/detail/domains/detail/activity.tsx
@@ -1,7 +1,6 @@
 import { ResourceActivityFeed, useProjectActivityClient } from '@/features/activity';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useParams } from 'react-router';
 import type { MetaFunction } from 'react-router';
 
@@ -17,9 +16,6 @@ export default function DomainActivityPage() {
 
   return (
     <Row type="flex" gutter={[24, 24]}>
-      <Col span={24}>
-        <PageTitle title="Activity" />
-      </Col>
       <Col span={24}>
         <ResourceActivityFeed
           client={client}

--- a/app/routes/project/detail/domains/detail/layout.tsx
+++ b/app/routes/project/detail/domains/detail/layout.tsx
@@ -1,4 +1,5 @@
-import { BackButton } from '@/components/back-button';
+import { type SubNavigationTab } from '@/components/sub-navigation';
+import { DomainHeaderActions } from '@/features/edge/domain/domain-header-actions';
 import { SubLayout } from '@/layouts';
 import { createDnsZoneService, type DnsZone } from '@/resources/dns-zones';
 import { createDomainService, type Domain, useDomain } from '@/resources/domains';
@@ -6,7 +7,6 @@ import { paths } from '@/utils/config/paths.config';
 import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
 import { useMemo } from 'react';
 import {
   LoaderFunctionArgs,
@@ -53,7 +53,7 @@ export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) =>
 });
 
 export default function DomainDetailLayout() {
-  const { domain } = useLoaderData<typeof loader>();
+  const { domain, dnsZone } = useLoaderData<typeof loader>();
   const { projectId, domainId } = useParams();
 
   // Seed cache synchronously with SSR data so child routes read it without skeleton flash
@@ -62,48 +62,39 @@ export default function DomainDetailLayout() {
     initialDataUpdatedAt: Date.now(),
   });
 
-  const navItems: NavItem[] = useMemo(() => {
+  const navItems: SubNavigationTab[] = useMemo(() => {
     return [
       {
-        title: 'Overview',
+        label: 'Overview',
         href: getPathWithParams(paths.project.detail.domains.detail.overview, {
           projectId,
           domainId: domain?.name ?? '',
         }),
-        type: 'link',
       },
       {
-        title: 'Activity',
+        label: 'Activity',
         href: getPathWithParams(paths.project.detail.domains.detail.activity, {
           projectId,
           domainId: domain?.name ?? '',
         }),
-        type: 'link',
       },
       {
-        title: 'Settings',
+        label: 'Settings',
         href: getPathWithParams(paths.project.detail.domains.detail.settings, {
           projectId,
           domainId: domain?.name ?? '',
         }),
-        type: 'link',
       },
     ];
   }, [projectId, domain]);
 
   return (
     <SubLayout
-      sidebarHeader={
-        <div className="flex flex-col gap-5.5">
-          <BackButton
-            className="hidden md:flex"
-            to={getPathWithParams(paths.project.detail.domains.root, {
-              projectId,
-            })}>
-            Back to Domains
-          </BackButton>
-          <span className="text-primary text-sm font-semibold">Manage Domain</span>
-        </div>
+      title={domain?.domainName}
+      actions={
+        domain && (
+          <DomainHeaderActions projectId={projectId ?? ''} domain={domain} dnsZone={dnsZone} />
+        )
       }
       navItems={navItems}>
       <Outlet />

--- a/app/routes/project/detail/domains/detail/overview.tsx
+++ b/app/routes/project/detail/domains/detail/overview.tsx
@@ -1,30 +1,17 @@
-import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
 import { DomainGeneralCard } from '@/features/edge/domain/overview/general-card';
 import { QuickSetupCard } from '@/features/edge/domain/overview/quick-setup-card';
 import { DomainVerificationCard } from '@/features/edge/domain/overview/verification-card';
 import { NotesSection } from '@/features/notes';
 import { ControlPlaneStatus } from '@/resources/base';
-import {
-  useDeleteDomain,
-  useDomain,
-  useDomainWatch,
-  useRefreshDomainRegistration,
-} from '@/resources/domains';
-import { paths } from '@/utils/config/paths.config';
+import { useDomain, useDomainWatch } from '@/resources/domains';
 import { dataWithToast } from '@/utils/cookies';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
-import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { Button } from '@datum-cloud/datum-ui/button';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { Icon } from '@datum-cloud/datum-ui/icons';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { toast } from '@datum-cloud/datum-ui/toast';
-import { RefreshCcwIcon, GlobeIcon, TrashIcon } from 'lucide-react';
 import { useMemo, useRef, useEffect } from 'react';
 import {
   LoaderFunctionArgs,
   data,
-  useNavigate,
   useParams,
   useRouteLoaderData,
   useSearchParams,
@@ -51,9 +38,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 export default function DomainOverviewPage() {
   const { domain, dnsZone } = useRouteLoaderData('domain-detail');
   const { projectId } = useParams();
-  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { confirm } = useConfirmationDialog();
 
   // Get live domain data from React Query
   const { data: liveDomain } = useDomain(projectId ?? '', domain?.name ?? '', {
@@ -67,85 +52,6 @@ export default function DomainOverviewPage() {
 
   // Prefer live data from React Query, fall back to SSR loader data
   const effectiveDomain = liveDomain ?? domain;
-
-  const deleteDomainMutation = useDeleteDomain(projectId ?? '', {
-    onSuccess: () => {
-      navigate(
-        getPathWithParams(paths.project.detail.domains.root, {
-          projectId,
-        })
-      );
-    },
-    onError: (error) => {
-      toast.error('Domain', { description: error.message || 'Failed to delete domain' });
-    },
-  });
-
-  const refreshDomainMutation = useRefreshDomainRegistration(projectId ?? '', {
-    onSuccess: () => {
-      toast.success('Domain', {
-        description: 'The domain has been refreshed successfully',
-      });
-    },
-    onError: (error) => {
-      toast.error('Domain', {
-        description: error.message || 'Failed to refresh domain',
-      });
-    },
-  });
-
-  const handleRefreshDomain = () => {
-    if (!effectiveDomain?.name) return;
-    refreshDomainMutation.mutate(effectiveDomain.name);
-  };
-
-  const handleManageDnsZone = () => {
-    if (!effectiveDomain?.domainName) return;
-
-    if (dnsZone) {
-      navigate(
-        getPathWithParams(paths.project.detail.dnsZones.detail.root, {
-          projectId,
-          dnsZoneId: dnsZone.name ?? '',
-        })
-      );
-      return;
-    }
-
-    navigate(
-      getPathWithParams(
-        paths.project.detail.dnsZones.root,
-        {
-          projectId,
-        },
-        new URLSearchParams({
-          action: 'create',
-          domainName: effectiveDomain.domainName,
-        })
-      )
-    );
-  };
-
-  const handleDeleteDomain = async () => {
-    if (!effectiveDomain?.name) return;
-
-    await confirm({
-      title: 'Delete Domain',
-      description: (
-        <span>
-          Are you sure you want to delete&nbsp;
-          <strong>{effectiveDomain.domainName}</strong>?
-        </span>
-      ),
-      submitText: 'Delete',
-      cancelText: 'Cancel',
-      variant: 'destructive',
-      showConfirmInput: false,
-      onSubmit: async () => {
-        deleteDomainMutation.mutate(effectiveDomain.name);
-      },
-    });
-  };
 
   // Track previous status for transition detection
   const previousStatusRef = useRef<ControlPlaneStatus | null>(null);
@@ -184,44 +90,6 @@ export default function DomainOverviewPage() {
 
   return (
     <Row gutter={[24, 32]}>
-      <Col span={24}>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <PageTitle title={effectiveDomain?.domainName ?? 'Domain'} />
-          {effectiveDomain?.name && (
-            <div className="flex w-full items-center gap-2 sm:w-auto">
-              <Button
-                type="secondary"
-                theme="outline"
-                size="small"
-                loading={refreshDomainMutation.isPending}
-                onClick={handleRefreshDomain}
-                aria-label="Refresh domain">
-                <Icon icon={RefreshCcwIcon} size={14} />
-                <span className="hidden sm:inline">Refresh</span>
-              </Button>
-              <Button
-                type="secondary"
-                theme="outline"
-                size="small"
-                className="flex-1 sm:flex-initial"
-                onClick={handleManageDnsZone}>
-                <Icon icon={GlobeIcon} size={14} />
-                Manage DNS Zone
-              </Button>
-              <Button
-                type="danger"
-                theme="outline"
-                size="small"
-                loading={deleteDomainMutation.isPending}
-                onClick={handleDeleteDomain}
-                aria-label="Delete domain">
-                <Icon icon={TrashIcon} size={14} />
-                <span className="hidden sm:inline">Delete</span>
-              </Button>
-            </div>
-          )}
-        </div>
-      </Col>
       <Col span={24}>
         <DomainGeneralCard domain={effectiveDomain} dnsZone={dnsZone} projectId={projectId} />
       </Col>

--- a/app/routes/project/detail/domains/detail/settings.tsx
+++ b/app/routes/project/detail/domains/detail/settings.tsx
@@ -5,7 +5,6 @@ import { useDeleteDomain } from '@/resources/domains';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { useNavigate, useParams, useRouteLoaderData } from 'react-router';
 
@@ -55,9 +54,6 @@ export default function DomainSettingsPage() {
 
   return (
     <Row gutter={[24, 32]}>
-      <Col span={24}>
-        <PageTitle title="Settings" />
-      </Col>
       <Col span={24}>
         <h3 className="mb-4 text-base font-medium">Coming Soon</h3>
         <ComingSoonFeatureCard

--- a/app/routes/project/detail/edge/detail/activity.tsx
+++ b/app/routes/project/detail/edge/detail/activity.tsx
@@ -1,7 +1,6 @@
 import { ResourceActivityFeed, useProjectActivityClient } from '@/features/activity';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useParams } from 'react-router';
 import type { MetaFunction } from 'react-router';
 
@@ -17,9 +16,6 @@ export default function ProxyActivityPage() {
 
   return (
     <Row type="flex" gutter={[24, 24]}>
-      <Col span={24}>
-        <PageTitle title="Activity" />
-      </Col>
       <Col span={24}>
         <ResourceActivityFeed
           client={client}

--- a/app/routes/project/detail/edge/detail/layout.tsx
+++ b/app/routes/project/detail/edge/detail/layout.tsx
@@ -1,11 +1,11 @@
-import { BackButton } from '@/components/back-button';
+import { type SubNavigationTab } from '@/components/sub-navigation';
+import { ProxyHeaderActions } from '@/features/edge/proxy/proxy-header-actions';
 import { SubLayout } from '@/layouts';
 import { createHttpProxyService, type HttpProxy, useHttpProxy } from '@/resources/http-proxies';
 import { paths } from '@/utils/config/paths.config';
 import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
 import { useMemo } from 'react';
 import {
   LoaderFunctionArgs,
@@ -54,42 +54,30 @@ export default function HttpProxyDetailLayout() {
     initialDataUpdatedAt: Date.now(),
   });
 
-  const navItems: NavItem[] = useMemo(() => {
+  const navItems: SubNavigationTab[] = useMemo(() => {
     const id = proxyId ?? httpProxy?.name ?? '';
     return [
       {
-        title: 'Overview',
+        label: 'Overview',
         href: getPathWithParams(paths.project.detail.proxy.detail.overview, {
           projectId,
           proxyId: id,
         }),
-        type: 'link',
       },
       {
-        title: 'Activity',
+        label: 'Activity',
         href: getPathWithParams(paths.project.detail.proxy.detail.activity, {
           projectId,
           proxyId: id,
         }),
-        type: 'link',
       },
     ];
   }, [projectId, proxyId, httpProxy?.name]);
 
   return (
     <SubLayout
-      sidebarHeader={
-        <div className="flex flex-col gap-5.5">
-          <BackButton
-            className="hidden md:flex"
-            to={getPathWithParams(paths.project.detail.proxy.root, {
-              projectId,
-            })}>
-            Back to AI Edge
-          </BackButton>
-          <span className="text-primary text-sm font-semibold">Manage AI Edge</span>
-        </div>
-      }
+      title={httpProxy?.name}
+      actions={httpProxy && <ProxyHeaderActions projectId={projectId ?? ''} proxy={httpProxy} />}
       navItems={navItems}>
       <Outlet />
     </SubLayout>

--- a/app/routes/project/detail/edge/detail/overview.tsx
+++ b/app/routes/project/detail/edge/detail/overview.tsx
@@ -13,16 +13,14 @@ import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
 import { NotFoundError } from '@/utils/errors';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { Button } from '@datum-cloud/datum-ui/button';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
 import { Icon } from '@datum-cloud/datum-ui/icons';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { toast } from '@datum-cloud/datum-ui/toast';
-import { ChartSplineIcon, Trash2Icon } from 'lucide-react';
+import { ChartSplineIcon } from 'lucide-react';
 import { useNavigate, useParams, useRouteLoaderData } from 'react-router';
 
-export default function HttpProxyDetailPage() {
+export default function HttpProxyOverviewPage() {
   const loaderData = useRouteLoaderData('proxy-detail') as HttpProxy | undefined;
   const { projectId, proxyId } = useParams();
   const navigate = useNavigate();
@@ -51,20 +49,6 @@ export default function HttpProxyDetailPage() {
   return (
     <MetricsProvider>
       <Row type="flex" gutter={[24, 32]}>
-        <Col span={24}>
-          <div className="flex items-center justify-between">
-            <PageTitle title={effectiveProxy.chosenName ?? effectiveProxy.name ?? 'AI Edge'} />
-            <Button
-              type="danger"
-              theme="outline"
-              size="small"
-              loading={isDeleting}
-              onClick={() => confirmDelete(effectiveProxy)}>
-              <Icon icon={Trash2Icon} size={14} />
-              Delete
-            </Button>
-          </div>
-        </Col>
         <Col span={24} lg={12}>
           <HttpProxyGeneralCard proxy={effectiveProxy} />
         </Col>

--- a/app/routes/project/detail/layout.tsx
+++ b/app/routes/project/detail/layout.tsx
@@ -356,6 +356,7 @@ export default function ProjectLayout() {
       <DashboardLayout
         navItems={navItems}
         sidebarCollapsible="icon"
+        defaultSidebarOpen={false}
         currentProject={currentProject}
         currentOrg={currentOrg}
         expandBehavior="push"

--- a/app/routes/project/detail/metrics/detail/activity.tsx
+++ b/app/routes/project/detail/metrics/detail/activity.tsx
@@ -1,7 +1,6 @@
 import { ResourceActivityFeed, useProjectActivityClient } from '@/features/activity';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useParams } from 'react-router';
 import type { MetaFunction } from 'react-router';
 
@@ -17,9 +16,6 @@ export default function ExportPolicyActivityPage() {
 
   return (
     <Row type="flex" gutter={[24, 24]}>
-      <Col span={24}>
-        <PageTitle title="Activity" />
-      </Col>
       <Col span={24}>
         <ResourceActivityFeed
           client={client}

--- a/app/routes/project/detail/metrics/detail/layout.tsx
+++ b/app/routes/project/detail/metrics/detail/layout.tsx
@@ -1,4 +1,4 @@
-import { BackButton } from '@/components/back-button';
+import { type SubNavigationTab } from '@/components/sub-navigation';
 import { SubLayout } from '@/layouts';
 import {
   createExportPolicyService,
@@ -9,7 +9,6 @@ import { paths } from '@/utils/config/paths.config';
 import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
 import { useMemo } from 'react';
 import {
   LoaderFunctionArgs,
@@ -58,51 +57,35 @@ export default function ExportPolicyDetailLayout() {
     initialDataUpdatedAt: Date.now(),
   });
 
-  const navItems: NavItem[] = useMemo(() => {
+  const navItems: SubNavigationTab[] = useMemo(() => {
     const id = exportPolicyId ?? exportPolicy?.name ?? '';
     return [
       {
-        title: 'Overview',
+        label: 'Overview',
         href: getPathWithParams(paths.project.detail.metrics.detail.overview, {
           projectId,
           exportPolicyId: id,
         }),
-        type: 'link',
       },
       {
-        title: 'Activity',
+        label: 'Activity',
         href: getPathWithParams(paths.project.detail.metrics.detail.activity, {
           projectId,
           exportPolicyId: id,
         }),
-        type: 'link',
       },
       {
-        title: 'Settings',
+        label: 'Settings',
         href: getPathWithParams(paths.project.detail.metrics.detail.settings, {
           projectId,
           exportPolicyId: id,
         }),
-        type: 'link',
       },
     ];
   }, [projectId, exportPolicyId, exportPolicy?.name]);
 
   return (
-    <SubLayout
-      sidebarHeader={
-        <div className="flex flex-col gap-5.5">
-          <BackButton
-            className="hidden md:flex"
-            to={getPathWithParams(paths.project.detail.metrics.root, {
-              projectId,
-            })}>
-            Back to Export Policies
-          </BackButton>
-          <span className="text-primary text-sm font-semibold">Manage Export Policy</span>
-        </div>
-      }
-      navItems={navItems}>
+    <SubLayout title={exportPolicy?.name ?? 'Export Policy'} navItems={navItems}>
       <Outlet />
     </SubLayout>
   );

--- a/app/routes/project/detail/metrics/detail/overview.tsx
+++ b/app/routes/project/detail/metrics/detail/overview.tsx
@@ -6,7 +6,6 @@ import { WorkloadSourcesTable } from '@/features/metric/export-policies/sources-
 import { IExportPolicyControlResponse } from '@/resources/export-policies';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { MetaFunction, useRouteLoaderData } from 'react-router';
 
 export const handle = {
@@ -25,11 +24,6 @@ export default function ExportPolicyOverview() {
 
   return (
     <div className="mx-auto w-full">
-      <Row gutter={[24, 32]}>
-        <Col span={24}>
-          <PageTitle title={exportPolicy?.name ?? 'Export Policy'} />
-        </Col>
-      </Row>
       <Row type="flex" gutter={[24, 32]}>
         <Col
           span={24}

--- a/app/routes/project/detail/metrics/index.tsx
+++ b/app/routes/project/detail/metrics/index.tsx
@@ -171,7 +171,6 @@ export default function ExportPoliciesPage() {
     <Table.Client
       columns={columns}
       data={policies ?? []}
-      title="Export Policies"
       description="Send telemetry data from your Datum infrastructure to external monitoring platforms like Grafana Cloud."
       search="Search"
       onRowClick={(row) => {

--- a/app/routes/project/detail/metrics/layout.tsx
+++ b/app/routes/project/detail/metrics/layout.tsx
@@ -1,8 +1,8 @@
+import { type SubNavigationTab } from '@/components/sub-navigation';
 import { SubLayout } from '@/layouts';
 import { ProjectLayoutLoaderData } from '@/routes/project/detail/layout';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
 import { useMemo } from 'react';
 import { Outlet, useParams } from 'react-router';
 
@@ -18,34 +18,25 @@ export const handle = {
 export default function Layout() {
   const { projectId } = useParams();
 
-  const navItems: NavItem[] = useMemo(() => {
+  const navItems: SubNavigationTab[] = useMemo(() => {
     return [
       {
-        title: 'Create an Export Policy',
+        label: 'Create an Export Policy',
         href: getPathWithParams(paths.project.detail.metrics.new, {
           projectId,
         }),
-        type: 'link',
       },
       {
-        title: 'Your Export Policies',
+        label: 'Your Export Policies',
         href: getPathWithParams(paths.project.detail.metrics.root, {
           projectId,
         }),
-        type: 'link',
-        excludePaths: [
-          getPathWithParams(paths.project.detail.metrics.new, {
-            projectId,
-          }),
-        ],
       },
     ];
   }, [projectId]);
 
   return (
-    <SubLayout
-      sidebarHeader={<span className="text-primary text-sm font-semibold">Metrics</span>}
-      navItems={navItems}>
+    <SubLayout title="Export Policies" navItems={navItems}>
       <Outlet />
     </SubLayout>
   );

--- a/app/routes/project/detail/metrics/new.tsx
+++ b/app/routes/project/detail/metrics/new.tsx
@@ -2,17 +2,12 @@ import { ExportPolicyComingSoonCard } from '@/features/metric/export-policies/ca
 import { ExportPolicyGrafanaCard } from '@/features/metric/export-policies/card/grafana-card';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useEffect, useRef } from 'react';
 import { MetaFunction, useParams, useSearchParams } from 'react-router';
 
 export const meta: MetaFunction = mergeMeta(() => {
   return metaObject('Create an Export Policy');
 });
-
-export const handle = {
-  breadcrumb: () => <span>Create an Export Policy</span>,
-};
 
 export default function ExportPoliciesNewPage() {
   const { projectId } = useParams();
@@ -35,8 +30,6 @@ export default function ExportPoliciesNewPage() {
 
   return (
     <div className="flex w-full flex-col gap-8">
-      <PageTitle title="Create an Export Policy" />
-
       <Row gutter={[16, 16]}>
         <Col xs={24} md={12} className="w-full md:h-full">
           <ExportPolicyGrafanaCard

--- a/app/routes/project/detail/secrets/detail/activity.tsx
+++ b/app/routes/project/detail/secrets/detail/activity.tsx
@@ -1,7 +1,6 @@
 import { ResourceActivityFeed, useProjectActivityClient } from '@/features/activity';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useParams } from 'react-router';
 import type { MetaFunction } from 'react-router';
 
@@ -17,9 +16,6 @@ export default function SecretActivityPage() {
 
   return (
     <Row type="flex" gutter={[24, 24]}>
-      <Col span={24}>
-        <PageTitle title="Activity" />
-      </Col>
       <Col span={24}>
         <ResourceActivityFeed
           client={client}

--- a/app/routes/project/detail/secrets/detail/layout.tsx
+++ b/app/routes/project/detail/secrets/detail/layout.tsx
@@ -1,11 +1,10 @@
-import { BackButton } from '@/components/back-button';
+import { type SubNavigationTab } from '@/components/sub-navigation';
 import { SubLayout } from '@/layouts';
 import { createSecretService, useSecret, type Secret } from '@/resources/secrets';
 import { paths } from '@/utils/config/paths.config';
 import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
 import { useMemo } from 'react';
 import { LoaderFunctionArgs, MetaFunction, Outlet, useLoaderData, useParams } from 'react-router';
 
@@ -46,43 +45,28 @@ export default function SecretDetailLayout() {
     initialDataUpdatedAt: Date.now(),
   });
 
-  const navItems: NavItem[] = useMemo(() => {
+  const navItems: SubNavigationTab[] = useMemo(() => {
     const id = secretId ?? secret?.name ?? '';
     return [
       {
-        title: 'Overview',
+        label: 'Overview',
         href: getPathWithParams(paths.project.detail.secrets.detail.overview, {
           projectId,
           secretId: id,
         }),
-        type: 'link',
       },
       {
-        title: 'Activity',
+        label: 'Activity',
         href: getPathWithParams(paths.project.detail.secrets.detail.activity, {
           projectId,
           secretId: id,
         }),
-        type: 'link',
       },
     ];
   }, [projectId, secretId, secret?.name]);
 
   return (
-    <SubLayout
-      sidebarHeader={
-        <div className="flex flex-col gap-5.5">
-          <BackButton
-            className="hidden md:flex"
-            to={getPathWithParams(paths.project.detail.secrets.root, {
-              projectId,
-            })}>
-            Back to Secrets
-          </BackButton>
-          <span className="text-primary text-sm font-semibold">Manage Secret</span>
-        </div>
-      }
-      navItems={navItems}>
+    <SubLayout title={secret?.name} navItems={navItems}>
       <Outlet />
     </SubLayout>
   );

--- a/app/routes/project/detail/secrets/detail/overview.tsx
+++ b/app/routes/project/detail/secrets/detail/overview.tsx
@@ -4,7 +4,6 @@ import { SecretDangerCard } from '@/features/secret/form/overview/danger-card';
 import { SecretGeneralCard } from '@/features/secret/form/overview/general-card';
 import { useSecret } from '@/resources/secrets';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useParams, useRouteLoaderData } from 'react-router';
 
 export default function EditSecret() {
@@ -22,9 +21,6 @@ export default function EditSecret() {
   return (
     <div className="mx-auto w-full">
       <Row gutter={[24, 32]}>
-        <Col span={24}>
-          <PageTitle title={secret?.name ?? 'Secret'} />
-        </Col>
         <Col span={24}>
           <SecretGeneralCard secret={(secret ?? {}) as any} />
         </Col>

--- a/app/routes/project/detail/service-accounts/detail/activity.tsx
+++ b/app/routes/project/detail/service-accounts/detail/activity.tsx
@@ -1,7 +1,6 @@
 import { ResourceActivityFeed, useProjectActivityClient } from '@/features/activity';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useParams } from 'react-router';
 import type { MetaFunction } from 'react-router';
 
@@ -17,9 +16,6 @@ export default function ServiceAccountActivityPage() {
 
   return (
     <Row type="flex" gutter={[24, 24]}>
-      <Col span={24}>
-        <PageTitle title="Activity" />
-      </Col>
       <Col span={24}>
         <ResourceActivityFeed
           client={client}

--- a/app/routes/project/detail/service-accounts/detail/keys.tsx
+++ b/app/routes/project/detail/service-accounts/detail/keys.tsx
@@ -20,7 +20,6 @@ import { Badge } from '@datum-cloud/datum-ui/badge';
 import { Button } from '@datum-cloud/datum-ui/button';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
 import { Icon } from '@datum-cloud/datum-ui/icons';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { ColumnDef } from '@tanstack/react-table';
 import { AlertCircleIcon, Loader2Icon, PlusIcon } from 'lucide-react';
@@ -167,10 +166,6 @@ export default function ServiceAccountKeysPage() {
 
   return (
     <Row type="flex" gutter={[24, 24]}>
-      <Col span={24}>
-        <PageTitle title="Keys" />
-      </Col>
-
       {newCredentials && serviceAccount && (
         <Col span={24}>
           <KeyRevealPanel

--- a/app/routes/project/detail/service-accounts/detail/layout.tsx
+++ b/app/routes/project/detail/service-accounts/detail/layout.tsx
@@ -1,4 +1,5 @@
-import { BackButton } from '@/components/back-button';
+import { type SubNavigationTab } from '@/components/sub-navigation';
+import { ServiceAccountHeaderActions } from '@/features/service-account/service-account-header-actions';
 import { SubLayout } from '@/layouts';
 import {
   createServiceAccountService,
@@ -10,7 +11,6 @@ import { paths } from '@/utils/config/paths.config';
 import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -90,48 +90,43 @@ export default function ServiceAccountDetailLayout() {
     prevLiveRef.current = liveAccount;
   }, [liveAccount, isDeleting, navigate, projectId]);
 
-  const navItems: NavItem[] = useMemo(() => {
+  const navItems: SubNavigationTab[] = useMemo(() => {
     const id = serviceAccountId ?? account.name;
     return [
       {
-        title: 'Overview',
+        label: 'Overview',
         href: getPathWithParams(paths.project.detail.serviceAccounts.detail.overview, {
           projectId,
           serviceAccountId: id,
         }),
-        type: 'link',
       },
       {
-        title: 'Keys',
+        label: 'Keys',
         href: getPathWithParams(paths.project.detail.serviceAccounts.detail.keys, {
           projectId,
           serviceAccountId: id,
         }),
-        type: 'link',
       },
       {
-        title: 'Roles',
+        label: 'Roles',
         href: getPathWithParams(paths.project.detail.serviceAccounts.detail.policyBindings, {
           projectId,
           serviceAccountId: id,
         }),
-        type: 'link',
       },
       {
-        title: 'Activity',
+        label: 'Activity',
         href: getPathWithParams(paths.project.detail.serviceAccounts.detail.activity, {
           projectId,
           serviceAccountId: id,
         }),
-        type: 'link',
       },
       {
-        title: 'Settings',
+        label: 'Settings',
         href: getPathWithParams(paths.project.detail.serviceAccounts.detail.settings, {
           projectId,
           serviceAccountId: id,
         }),
-        type: 'link',
       },
     ];
   }, [projectId, serviceAccountId, account.name]);
@@ -144,15 +139,15 @@ export default function ServiceAccountDetailLayout() {
 
   return (
     <SubLayout
-      sidebarHeader={
-        <div className="flex flex-col gap-5.5">
-          <BackButton
-            className="hidden md:flex"
-            to={getPathWithParams(paths.project.detail.serviceAccounts.root, { projectId })}>
-            Back to Service Accounts
-          </BackButton>
-          <span className="text-primary text-sm font-semibold">Manage Service Account</span>
-        </div>
+      title={account?.displayName ?? account?.name}
+      actions={
+        account && (
+          <ServiceAccountHeaderActions
+            projectId={projectId ?? ''}
+            serviceAccountId={serviceAccountId ?? ''}
+            account={account}
+          />
+        )
       }
       navItems={navItems}>
       <Outlet context={outletContext} />

--- a/app/routes/project/detail/service-accounts/detail/overview.tsx
+++ b/app/routes/project/detail/service-accounts/detail/overview.tsx
@@ -4,18 +4,14 @@ import { BadgeStatus } from '@/components/badge/badge-status';
 import { DateTime } from '@/components/date-time';
 import { List, type ListItem } from '@/components/list/list';
 import { NoteCard } from '@/components/note-card/note-card';
-import { useUpdateServiceAccount } from '@/resources/service-accounts';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
-import { Button } from '@datum-cloud/datum-ui/button';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
 import { Icon } from '@datum-cloud/datum-ui/icons';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
-import { toast } from '@datum-cloud/datum-ui/toast';
-import { InfoIcon, PowerIcon, PowerOffIcon } from 'lucide-react';
+import { InfoIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import type { MetaFunction } from 'react-router';
-import { useOutletContext, useParams } from 'react-router';
+import { useOutletContext } from 'react-router';
 
 export const handle = {
   breadcrumb: () => <span>Overview</span>,
@@ -24,25 +20,7 @@ export const handle = {
 export const meta: MetaFunction = mergeMeta(() => metaObject('Overview'));
 
 export default function ServiceAccountOverviewPage() {
-  const { projectId, serviceAccountId } = useParams();
   const { account } = useOutletContext<ServiceAccountDetailContext>();
-
-  const toggleMutation = useUpdateServiceAccount(projectId ?? '', serviceAccountId ?? '', {
-    onSuccess: () => {
-      toast.success('Service account updated');
-    },
-    onError: (error) => {
-      toast.error('Error', { description: error.message });
-    },
-  });
-
-  const handleToggle = () => {
-    toggleMutation.mutate({
-      status: account.status === 'Active' ? 'Disabled' : 'Active',
-    });
-  };
-
-  const isActive = account.status === 'Active';
 
   const listItems: ListItem[] = useMemo(() => {
     return [
@@ -71,25 +49,10 @@ export default function ServiceAccountOverviewPage() {
         content: account.updatedAt ? <DateTime date={account.updatedAt} /> : '—',
       },
     ];
-  }, [account, isActive]);
+  }, [account]);
 
   return (
     <Row type="flex" gutter={[24, 32]}>
-      <Col span={24}>
-        <div className="flex items-center justify-between gap-4">
-          <PageTitle title={account.displayName ?? account.name} />
-          <Button
-            type="secondary"
-            theme="outline"
-            size="small"
-            loading={toggleMutation.isPending}
-            onClick={handleToggle}>
-            <Icon icon={isActive ? PowerOffIcon : PowerIcon} size={14} />
-            {isActive ? 'Disable' : 'Enable'}
-          </Button>
-        </div>
-      </Col>
-
       <Col span={24}>
         <Card className="w-full overflow-hidden rounded-xl px-3 py-4 shadow-none sm:pt-6 sm:pb-4">
           <CardContent className="p-0 sm:px-6 sm:pb-4">

--- a/app/routes/project/detail/service-accounts/detail/policy-bindings.tsx
+++ b/app/routes/project/detail/service-accounts/detail/policy-bindings.tsx
@@ -16,7 +16,6 @@ import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Button } from '@datum-cloud/datum-ui/button';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
 import { Icon } from '@datum-cloud/datum-ui/icons';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { ShieldIcon } from 'lucide-react';
 import { useCallback, useMemo, useRef } from 'react';
@@ -87,9 +86,6 @@ export default function ServiceAccountPolicyBindingsPage() {
 
   return (
     <Row type="flex" gutter={[24, 24]}>
-      <Col span={24}>
-        <PageTitle title="Roles" />
-      </Col>
       <Col span={24}>
         <PolicyBindingTable
           bindings={bindings}

--- a/app/routes/project/detail/service-accounts/detail/settings.tsx
+++ b/app/routes/project/detail/service-accounts/detail/settings.tsx
@@ -7,7 +7,6 @@ import { paths } from '@/utils/config/paths.config';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import type { MetaFunction } from 'react-router';
 import { useNavigate, useOutletContext, useParams } from 'react-router';
@@ -63,10 +62,6 @@ export default function ServiceAccountSettingsPage() {
 
   return (
     <Row type="flex" gutter={[24, 24]}>
-      <Col span={24}>
-        <PageTitle title="Settings" />
-      </Col>
-
       <Col span={24}>
         <h3 className="mb-4 text-base font-medium">Display Name</h3>
         <DisplayNameFormCard projectId={projectId ?? ''} defaultValue={account} />

--- a/app/routes/project/detail/service-accounts/index.tsx
+++ b/app/routes/project/detail/service-accounts/index.tsx
@@ -188,7 +188,6 @@ export default function ServiceAccountsPage() {
       <Table.Client
         columns={columns}
         data={data}
-        title="Service Accounts"
         description="Service accounts give non-human workloads a cryptographic identity to authenticate with Datum APIs — no shared passwords or long-lived tokens."
         search="Search"
         onRowClick={(row) =>

--- a/app/routes/project/detail/service-accounts/listing-layout.tsx
+++ b/app/routes/project/detail/service-accounts/listing-layout.tsx
@@ -1,41 +1,32 @@
+import { type SubNavigationTab } from '@/components/sub-navigation';
 import { SubLayout } from '@/layouts';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { NavItem } from '@datum-cloud/datum-ui/app-navigation';
 import { useMemo } from 'react';
 import { Outlet, useParams } from 'react-router';
 
 export default function ServiceAccountsListingLayout() {
   const { projectId } = useParams();
 
-  const navItems: NavItem[] = useMemo(() => {
+  const navItems: SubNavigationTab[] = useMemo(() => {
     return [
       {
-        title: 'Create a Service Account',
+        label: 'Create a Service Account',
         href: getPathWithParams(paths.project.detail.serviceAccounts.new, {
           projectId,
         }),
-        type: 'link',
       },
       {
-        title: 'Your Service Accounts',
+        label: 'Your Service Accounts',
         href: getPathWithParams(paths.project.detail.serviceAccounts.root, {
           projectId,
         }),
-        type: 'link',
-        excludePaths: [
-          getPathWithParams(paths.project.detail.serviceAccounts.new, {
-            projectId,
-          }),
-        ],
       },
     ];
   }, [projectId]);
 
   return (
-    <SubLayout
-      sidebarHeader={<span className="text-primary text-sm font-semibold">Service Accounts</span>}
-      navItems={navItems}>
+    <SubLayout title="Service Accounts" navItems={navItems}>
       <Outlet />
     </SubLayout>
   );

--- a/app/routes/project/detail/service-accounts/new.tsx
+++ b/app/routes/project/detail/service-accounts/new.tsx
@@ -10,13 +10,8 @@ import { paths } from '@/utils/config/paths.config';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useEffect, useRef, useState } from 'react';
 import { MetaFunction, useNavigate, useParams, useSearchParams } from 'react-router';
-
-export const handle = {
-  breadcrumb: () => <span>Create a Service Account</span>,
-};
 
 export const meta: MetaFunction = mergeMeta(() => metaObject('Create a Service Account'));
 
@@ -68,8 +63,6 @@ export default function ServiceAccountsNewPage() {
 
   return (
     <div className="flex w-full flex-col gap-8">
-      <PageTitle title="Create a Service Account" />
-
       <Row gutter={[16, 16]}>
         <Col xs={24} md={12} className="w-full md:h-full">
           <CiCdCard onCreate={() => openWith('cicd')} />

--- a/app/routes/project/detail/settings/layout.tsx
+++ b/app/routes/project/detail/settings/layout.tsx
@@ -1,9 +1,9 @@
-import { SubNavigationTabs, type SubNavigationTab } from '@/components/sub-navigation';
+import { type SubNavigationTab } from '@/components/sub-navigation';
+import { SubLayout } from '@/layouts';
 import { useProjectContext } from '@/providers/project.provider';
 import { ProjectLayoutLoaderData } from '@/routes/project/detail/layout';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { PageTitle } from '@datum-cloud/datum-ui/page-title';
 import { useMemo } from 'react';
 import { Outlet } from 'react-router';
 
@@ -41,14 +41,8 @@ export default function ProjectSettingsLayout() {
   }, [project]);
 
   return (
-    <div className="flex h-full flex-1 flex-col gap-8">
-      <PageTitle title="Project Settings" />
-      <SubNavigationTabs tabs={navItems} />
-      <div className="h-full w-full pt-2">
-        <div className="flex h-full flex-1 flex-col">
-          <Outlet />
-        </div>
-      </div>
-    </div>
+    <SubLayout title="Project Settings" navItems={navItems}>
+      <Outlet />
+    </SubLayout>
   );
 }


### PR DESCRIPTION
Redesigns the sub-navigation layout for resource detail pages, replacing the vertical sidebar nav with a horizontal tab bar. Consolidates the same shared layout across settings pages.

## Changes

### Sub-layout component
- Collapses `<SubLayout>` to a single horizontal-tab render path (drops the desktop inner-sidebar branch)
- Uses `<PageTitle>` + `<SubNavigationTabs>` stacked in a flex column — matches the project/org/account settings layout shape
- Props: `title`, `status`, `actions`, `navItems` (typed as `SubNavigationTab[]`)

### Resource detail pages migrated
- DNS Zones, Domains, Secrets, HTTP Proxies, Service Accounts, Export Policies (detail layouts)
- Service Accounts list shell, Export Policies list shell

### Overview tab cleanup
- Drops the duplicate resource-name `<PageTitle>` from each Overview (now lives in the layout header)
- Lifts header actions into `<SubLayout actions={...}>` via dedicated `*-header-actions.tsx` feature components:
  - Domains: Refresh / Manage DNS Zone / Delete (`features/edge/domain/domain-header-actions.tsx`)
  - HTTP Proxies: Delete (`features/edge/proxy/proxy-header-actions.tsx`)
  - Service Accounts: Enable/Disable (`features/service-account/service-account-header-actions.tsx`)

### Settings layouts consolidated
Project, organization, and account settings layouts now use the same `<SubLayout>` component. Account settings keeps its outer `<DashboardLayout>` + `<BackButton to={paths.home}>Back to Dashboard</BackButton>` chrome.

### Misc
- Canonicalizes `SubNavigationTab[]` as the nav item type across all callsites (drops the `NavItem[]` → `SubNavigationTab[]` mapper)
- Drops redundant Settings page titles from sub-pages with substantive cards

## Preview
<img width="1659" height="946" alt="Screenshot 2026-05-18 at 07 07 41" src="https://github.com/user-attachments/assets/f42d883c-3a09-4969-8445-a46f6fb4c29c" />
<img width="1659" height="946" alt="Screenshot 2026-05-18 at 07 07 57" src="https://github.com/user-attachments/assets/694603ed-f798-41ef-aba9-4478ff9ad986" />



Ref: https://github.com/datum-cloud/enhancements/issues/717