### PR TITLE
feat(billing): collect Stripe payment method during signup gating

### DIFF
--- a/app/modules/axios/request-context.ts
+++ b/app/modules/axios/request-context.ts
@@ -1,3 +1,4 @@
+import type { BillingAccount } from '@/resources/billing';
 import type { User } from '@/resources/users';
 import { AsyncLocalStorage } from 'async_hooks';
 
@@ -18,6 +19,14 @@ export interface RequestContext {
    * to avoid a second upstream API call on the same request.
    */
   cachedUser?: User;
+  /**
+   * Per-request BillingAccount cache. Written by fraudStatusMiddleware
+   * after looking up the user's BillingAccount for the
+   * payment-method-attached gate. `null` is a meaningful value (the
+   * lookup succeeded but the user has no BA yet); `undefined` means it
+   * hasn't been resolved this request.
+   */
+  cachedBillingAccount?: BillingAccount | null;
 }
 
 // Use globalThis to share the store across modules (axios, gqlts, etc.)

--- a/app/resources/billing/billing.schema.ts
+++ b/app/resources/billing/billing.schema.ts
@@ -1,0 +1,65 @@
+/**
+ * Domain types for the billing.miloapis.com CRDs the portal needs at signup.
+ *
+ * BillingAccount fields here are a sanitized subset of the full CR. The
+ * portal never sees raw card data; everything in `paymentMethod` has
+ * already been redacted to BIN / last4 / verification results by the
+ * milo-billing Stripe provider.
+ */
+
+export const BillingAccountPhase = {
+  Provisioning: 'Provisioning',
+  Ready: 'Ready',
+  Suspended: 'Suspended',
+  Archived: 'Archived',
+} as const;
+export type BillingAccountPhaseValue =
+  (typeof BillingAccountPhase)[keyof typeof BillingAccountPhase];
+
+/** Owner-user label on BillingAccount — must match the milo / fraud constant. */
+export const OWNER_USER_LABEL = 'iam.miloapis.com/owner-user';
+
+export interface BillingAccountPaymentMethod {
+  providerCustomerId?: string;
+  paymentMethodId?: string;
+  setupIntentId?: string;
+  brand?: string;
+  last4?: string;
+  bin?: string;
+  country?: string;
+  expMonth?: number;
+  expYear?: number;
+  avsResult?: string;
+  cvcResult?: string;
+  attachedAt?: string;
+}
+
+export interface BillingAccount {
+  name: string;
+  namespace: string;
+  phase: BillingAccountPhaseValue;
+  paymentMethodAttached: boolean;
+  paymentMethod?: BillingAccountPaymentMethod;
+}
+
+export const PaymentMethodSetupPhase = {
+  Pending: 'Pending',
+  ClientSecretReady: 'ClientSecretReady',
+  Succeeded: 'Succeeded',
+  Failed: 'Failed',
+} as const;
+export type PaymentMethodSetupPhaseValue =
+  (typeof PaymentMethodSetupPhase)[keyof typeof PaymentMethodSetupPhase];
+
+export interface PaymentMethodSetup {
+  name: string;
+  namespace: string;
+  phase: PaymentMethodSetupPhaseValue;
+  clientSecret?: string;
+  publishableKey?: string;
+  providerName?: string;
+  setupIntentId?: string;
+  setupIntentStatus?: string;
+  failureReason?: string;
+  failureMessage?: string;
+}

--- a/app/resources/billing/billing.service.ts
+++ b/app/resources/billing/billing.service.ts
@@ -1,0 +1,191 @@
+import {
+  BillingAccount,
+  BillingAccountPhaseValue,
+  OWNER_USER_LABEL,
+  PaymentMethodSetup,
+  PaymentMethodSetupPhaseValue,
+} from './billing.schema';
+import { client } from '@/modules/control-plane/shared/client.gen';
+import { logger } from '@/modules/logger';
+import { mapApiError, NotFoundError } from '@/utils/errors';
+
+const SERVICE_NAME = 'BillingService';
+
+const BILLING_GROUP = 'billing.miloapis.com';
+const BILLING_VERSION = 'v1alpha1';
+
+interface RawBillingAccount {
+  metadata: { name: string; namespace: string };
+  status?: {
+    phase?: BillingAccountPhaseValue;
+    paymentMethod?: BillingAccount['paymentMethod'];
+    conditions?: Array<{ type: string; status: 'True' | 'False' | 'Unknown' }>;
+  };
+}
+
+interface RawBillingAccountList {
+  items: RawBillingAccount[];
+}
+
+interface RawPaymentMethodSetup {
+  metadata: { name: string; namespace: string };
+  spec: { billingAccountRef: { name: string }; returnURL?: string };
+  status?: {
+    phase?: PaymentMethodSetupPhaseValue;
+    clientSecret?: string;
+    publishableKey?: string;
+    providerName?: string;
+    setupIntentId?: string;
+    setupIntentStatus?: string;
+    failureReason?: string;
+    failureMessage?: string;
+  };
+}
+
+function toBillingAccount(raw: RawBillingAccount): BillingAccount {
+  const conditions = raw.status?.conditions ?? [];
+  const paymentMethodAttached = conditions.some(
+    (c) => c.type === 'PaymentMethodAttached' && c.status === 'True'
+  );
+  return {
+    name: raw.metadata.name,
+    namespace: raw.metadata.namespace,
+    phase: raw.status?.phase ?? 'Provisioning',
+    paymentMethodAttached,
+    paymentMethod: raw.status?.paymentMethod,
+  };
+}
+
+function toPaymentMethodSetup(raw: RawPaymentMethodSetup): PaymentMethodSetup {
+  return {
+    name: raw.metadata.name,
+    namespace: raw.metadata.namespace,
+    phase: raw.status?.phase ?? 'Pending',
+    clientSecret: raw.status?.clientSecret,
+    publishableKey: raw.status?.publishableKey,
+    providerName: raw.status?.providerName,
+    setupIntentId: raw.status?.setupIntentId,
+    setupIntentStatus: raw.status?.setupIntentStatus,
+    failureReason: raw.status?.failureReason,
+    failureMessage: raw.status?.failureMessage,
+  };
+}
+
+/**
+ * BillingService is a thin wrapper around the milo K8s API for the
+ * billing.miloapis.com CRDs the signup flow needs. Everything goes through
+ * the existing apiserver connection — no service-specific HTTP client.
+ *
+ * The PaymentMethodSetup CRD is brand new and not yet present in the
+ * generated billing SDK (`@/modules/control-plane/billing`). Once the SDK
+ * is regenerated those calls should be migrated; for now we hit the API
+ * paths directly to unblock the signup flow.
+ */
+export function createBillingService() {
+  return {
+    /**
+     * Return the BillingAccount owned by the given user, or null if none
+     * exists yet (signup race — the auto-billing-account controller may
+     * not have created it before the first /verifying poll).
+     */
+    async getBillingAccountForUser(userId: string): Promise<BillingAccount | null> {
+      const startTime = Date.now();
+      try {
+        const response = await client.get({
+          url: `/apis/${BILLING_GROUP}/${BILLING_VERSION}/billingaccounts`,
+          query: {
+            labelSelector: `${OWNER_USER_LABEL}=${userId}`,
+          },
+          responseType: 'json',
+        });
+
+        const list = response.data as RawBillingAccountList;
+        const accounts = (list.items ?? []).map(toBillingAccount);
+
+        logger.service(SERVICE_NAME, 'getBillingAccountForUser', {
+          input: { userId },
+          duration: Date.now() - startTime,
+        });
+
+        if (accounts.length === 0) return null;
+        // Prefer an account with payment-method-attached if multiple
+        // exist; otherwise return the first.
+        return accounts.find((a) => a.paymentMethodAttached) ?? accounts[0];
+      } catch (error) {
+        logger.error(`${SERVICE_NAME}.getBillingAccountForUser failed`, error as Error);
+        throw mapApiError(error);
+      }
+    },
+
+    /**
+     * Look up a specific BillingAccount by namespace/name.
+     */
+    async getBillingAccount(namespace: string, name: string): Promise<BillingAccount> {
+      try {
+        const response = await client.get({
+          url: `/apis/${BILLING_GROUP}/${BILLING_VERSION}/namespaces/${namespace}/billingaccounts/${name}`,
+          responseType: 'json',
+        });
+        return toBillingAccount(response.data as RawBillingAccount);
+      } catch (error) {
+        throw mapApiError(error);
+      }
+    },
+
+    /**
+     * Create a PaymentMethodSetup for the given BillingAccount. The
+     * milo-billing controller will fill in `.status.clientSecret` once
+     * it has minted a Stripe SetupIntent.
+     */
+    async createPaymentMethodSetup(
+      billingAccount: Pick<BillingAccount, 'name' | 'namespace'>,
+      opts: { returnURL?: string } = {}
+    ): Promise<PaymentMethodSetup> {
+      const startTime = Date.now();
+      try {
+        const body = {
+          apiVersion: `${BILLING_GROUP}/${BILLING_VERSION}`,
+          kind: 'PaymentMethodSetup',
+          metadata: { generateName: 'pms-' },
+          spec: {
+            billingAccountRef: { name: billingAccount.name },
+            ...(opts.returnURL ? { returnURL: opts.returnURL } : {}),
+          },
+        };
+        const response = await client.post({
+          url: `/apis/${BILLING_GROUP}/${BILLING_VERSION}/namespaces/${billingAccount.namespace}/paymentmethodsetups`,
+          body,
+          responseType: 'json',
+        });
+
+        logger.service(SERVICE_NAME, 'createPaymentMethodSetup', {
+          input: { billingAccount: billingAccount.name },
+          duration: Date.now() - startTime,
+        });
+
+        return toPaymentMethodSetup(response.data as RawPaymentMethodSetup);
+      } catch (error) {
+        logger.error(`${SERVICE_NAME}.createPaymentMethodSetup failed`, error as Error);
+        throw mapApiError(error);
+      }
+    },
+
+    /**
+     * Read a PaymentMethodSetup by namespace/name.
+     */
+    async getPaymentMethodSetup(namespace: string, name: string): Promise<PaymentMethodSetup> {
+      try {
+        const response = await client.get({
+          url: `/apis/${BILLING_GROUP}/${BILLING_VERSION}/namespaces/${namespace}/paymentmethodsetups/${name}`,
+          responseType: 'json',
+        });
+        return toPaymentMethodSetup(response.data as RawPaymentMethodSetup);
+      } catch (error) {
+        if (error instanceof NotFoundError) throw error;
+        throw mapApiError(error);
+      }
+    },
+  };
+}
+
+export type BillingService = ReturnType<typeof createBillingService>;

--- a/app/resources/billing/index.ts
+++ b/app/resources/billing/index.ts
@@ -1,0 +1,2 @@
+export * from './billing.schema';
+export * from './billing.service';

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -222,6 +222,9 @@ export default [
   route('verifying', 'routes/fraud/verifying.tsx'),
   route('account-under-review', 'routes/fraud/account-under-review.tsx'),
   route('account-suspended', 'routes/fraud/account-suspended.tsx'),
+  // Billing setup — card collection that runs BEFORE fraud verification. See
+  // app/utils/middlewares/fraud-status.middleware.ts for the gating logic.
+  route('billing-setup', 'routes/billing/setup.tsx'),
   // Global Routes
   route('logout', 'routes/auth/logout.tsx', { id: 'logout' }),
 

--- a/app/routes/billing/setup.tsx
+++ b/app/routes/billing/setup.tsx
@@ -1,0 +1,222 @@
+import BlankLayout from '@/layouts/blank.layout';
+import { createBillingService, type PaymentMethodSetup } from '@/resources/billing';
+import { paths } from '@/utils/config/paths.config';
+import { getSession } from '@/utils/cookies';
+import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
+import { Card, CardContent } from '@datum-cloud/datum-ui/card';
+import { Elements, PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js';
+import { loadStripe, type Stripe } from '@stripe/stripe-js';
+import { useEffect, useMemo, useState } from 'react';
+import { Link, LoaderFunctionArgs, MetaFunction, redirect, useLoaderData } from 'react-router';
+
+export const meta: MetaFunction = mergeMeta(() => {
+  return metaObject('Set up payment');
+});
+
+/**
+ * Server-side wait for the milo-billing controller to mint a Stripe
+ * SetupIntent and write its clientSecret onto the PaymentMethodSetup
+ * status. Bounded so a stuck reconciler surfaces an error to the user
+ * rather than hanging the request.
+ */
+async function waitForClientSecret(
+  service: ReturnType<typeof createBillingService>,
+  namespace: string,
+  name: string,
+  { attempts = 20, intervalMs = 500 } = {}
+): Promise<PaymentMethodSetup> {
+  for (let i = 0; i < attempts; i++) {
+    const setup = await service.getPaymentMethodSetup(namespace, name);
+    if (setup.phase === 'Failed') return setup;
+    if (setup.clientSecret && setup.publishableKey) return setup;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  return service.getPaymentMethodSetup(namespace, name);
+}
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await getSession(request);
+  if (!session?.sub) {
+    return redirect(paths.auth.logOut);
+  }
+
+  const service = createBillingService();
+  const account = await service.getBillingAccountForUser(session.sub);
+
+  if (!account) {
+    // Auto-billing-account controller hasn't created the BA yet; bounce
+    // to /verifying which polls until it shows up.
+    return redirect(paths.fraud.verifying);
+  }
+
+  if (account.paymentMethodAttached) {
+    return redirect(paths.fraud.verifying);
+  }
+
+  // Always create a fresh PaymentMethodSetup. SetupIntents are short-lived
+  // and one-shot; reusing across page loads risks expired client secrets.
+  const created = await service.createPaymentMethodSetup(account, {
+    returnURL: new URL(paths.fraud.verifying, new URL(request.url).origin).toString(),
+  });
+
+  const ready = await waitForClientSecret(service, created.namespace, created.name);
+
+  if (ready.phase === 'Failed' || !ready.clientSecret || !ready.publishableKey) {
+    return {
+      error:
+        ready.failureMessage ??
+        'We could not start a payment setup. Please refresh the page or contact support.',
+      clientSecret: null as string | null,
+      publishableKey: null as string | null,
+    };
+  }
+
+  return {
+    error: null as string | null,
+    clientSecret: ready.clientSecret,
+    publishableKey: ready.publishableKey,
+  };
+};
+
+/**
+ * Stripe.js instance is created once per publishable key, outside the
+ * component tree. Recreating it on every render breaks Stripe Elements.
+ */
+const stripeJsCache = new Map<string, Promise<Stripe | null>>();
+function getStripe(publishableKey: string): Promise<Stripe | null> {
+  const cached = stripeJsCache.get(publishableKey);
+  if (cached) return cached;
+  const fresh = loadStripe(publishableKey);
+  stripeJsCache.set(publishableKey, fresh);
+  return fresh;
+}
+
+export default function BillingSetupPage() {
+  const data = useLoaderData<typeof loader>();
+  const stripePromise = useMemo(
+    () => (data.publishableKey ? getStripe(data.publishableKey) : null),
+    [data.publishableKey]
+  );
+
+  if (data.error || !data.clientSecret || !data.publishableKey || !stripePromise) {
+    return (
+      <BlankLayout>
+        <Card className="bg-card text-foreground z-10 w-full max-w-full rounded-xl border p-3 sm:max-w-sm sm:p-4 md:p-6 lg:p-8 xl:p-11">
+          <CardContent className="p-0">
+            <h2 className="mb-3 text-center text-xl font-medium">
+              Couldn&apos;t start payment setup
+            </h2>
+            <p className="text-center text-[14px] leading-5 font-normal">
+              {data.error ?? 'Something went wrong. Please try again.'}
+            </p>
+            <div className="mt-6 text-center">
+              <Link
+                to={paths.auth.logOut}
+                className="dark:text-foreground dark:hover:text-foreground text-[14px] text-gray-600 underline hover:text-gray-900">
+                Log out
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </BlankLayout>
+    );
+  }
+
+  return (
+    <BlankLayout>
+      <Card className="bg-card text-foreground z-10 w-full max-w-full rounded-xl border p-3 sm:max-w-md sm:p-4 md:p-6 lg:p-8 xl:p-11">
+        <CardContent className="p-0">
+          <h2 className="mb-2 text-center text-xl font-medium">Add a payment method</h2>
+          <p className="mb-6 text-center text-[14px] leading-5 font-normal">
+            We collect a card to verify your account before granting access. You won&apos;t be
+            charged until you start consuming a paid service.
+          </p>
+          <Elements
+            stripe={stripePromise}
+            options={{ clientSecret: data.clientSecret!, appearance: { theme: 'stripe' } }}>
+            <CheckoutForm />
+          </Elements>
+          <div className="mt-6 text-center">
+            <Link
+              to={paths.auth.logOut}
+              className="dark:text-foreground dark:hover:text-foreground text-[14px] text-gray-600 underline hover:text-gray-900">
+              Log out
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </BlankLayout>
+  );
+}
+
+function CheckoutForm() {
+  const stripe = useStripe();
+  const elements = useElements();
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Surface mounted-readiness so the submit button is disabled until the
+  // PaymentElement has finished bootstrapping.
+  const [elementReady, setElementReady] = useState(false);
+  useEffect(() => {
+    if (!elements) return;
+    const pe = elements.getElement('payment');
+    if (!pe) return;
+    const onReady = () => setElementReady(true);
+    pe.on('ready', onReady);
+    return () => {
+      pe.off('ready', onReady);
+    };
+  }, [elements]);
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!stripe || !elements) return;
+    setSubmitting(true);
+    setError(null);
+
+    const result = await stripe.confirmSetup({
+      elements,
+      confirmParams: {
+        return_url:
+          typeof window !== 'undefined'
+            ? new URL(paths.fraud.verifying, window.location.origin).toString()
+            : paths.fraud.verifying,
+      },
+    });
+
+    if (result.error) {
+      setError(
+        result.error.message ??
+          'We could not confirm the card. Please check the details and try again.'
+      );
+      setSubmitting(false);
+      return;
+    }
+
+    // The browser is redirected to return_url for 3DS-confirmed flows; for
+    // non-redirect flows we navigate explicitly so the verifying page picks
+    // up the webhook-driven status change.
+    if (typeof window !== 'undefined') {
+      window.location.replace(paths.fraud.verifying);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <PaymentElement />
+      {error ? (
+        <p className="text-destructive text-sm" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <button
+        type="submit"
+        disabled={!stripe || !elements || !elementReady || submitting}
+        className="bg-primary text-primary-foreground hover:bg-primary/90 w-full rounded-md px-4 py-2 text-sm font-medium disabled:opacity-60">
+        {submitting ? 'Submitting…' : 'Continue'}
+      </button>
+    </form>
+  );
+}

--- a/app/routes/fraud/verifying.tsx
+++ b/app/routes/fraud/verifying.tsx
@@ -26,13 +26,27 @@ export default function VerifyingPage() {
       if (stopped) return;
 
       try {
-        const response = await fetch(paths.fraud.statusApi);
+        // Fire both probes in parallel — the fraud check is the
+        // terminal gate but the billing check can bounce the user back
+        // to /billing-setup if the BA exists without a card.
+        const [fraudResp, billingResp] = await Promise.all([
+          fetch(paths.fraud.statusApi),
+          fetch(paths.billing.statusApi).catch(() => null),
+        ]);
 
-        if (!response.ok) {
+        if (billingResp && billingResp.ok) {
+          const billing = await billingResp.json();
+          if (billing.status === 'needs-payment-method') {
+            window.location.replace(paths.billing.setup);
+            return;
+          }
+        }
+
+        if (!fraudResp.ok) {
           return;
         }
 
-        const result = await response.json();
+        const result = await fraudResp.json();
 
         if (result.status === 'completed') {
           const decision = result.decision;
@@ -89,7 +103,8 @@ export default function VerifyingPage() {
           </div>
           <h2 className="mb-3 text-center text-xl font-medium">Verifying your account</h2>
           <p className="text-center text-[14px] leading-5 font-normal">
-            We&apos;re running a quick security check. This usually takes less than 30 seconds.
+            We&apos;re finalising your payment setup and running a quick security check. This
+            usually takes less than 30 seconds.
           </p>
           <div className="mt-6 text-center">
             <Link

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -1,4 +1,5 @@
 import { assistantRoutes } from './assistant';
+import { billingStatusRoutes } from './billing-status';
 import { cloudvalidRoutes } from './cloudvalid';
 import { fraudStatusRoutes } from './fraud-status';
 import { grafanaRoutes } from './grafana';
@@ -36,6 +37,7 @@ export function createApiApp() {
 
   // Routes
   api.route('/fraud-status', fraudStatusRoutes);
+  api.route('/billing-status', billingStatusRoutes);
   api.route('/proxy', proxyRoutes);
   api.route('/graphql', graphqlRoutes);
   api.route('/cloudvalid', cloudvalidRoutes);

--- a/app/server/routes/billing-status.ts
+++ b/app/server/routes/billing-status.ts
@@ -1,0 +1,39 @@
+import type { Variables } from '../types';
+import { createBillingService } from '@/resources/billing';
+import { Hono } from 'hono';
+
+const billingStatus = new Hono<{ Variables: Variables }>();
+
+/**
+ * GET /api/billing-status
+ *
+ * Lightweight polling endpoint used by /verifying to detect a webhook-driven
+ * BillingAccount state change without waiting for the page to be re-loaded.
+ *
+ * Returns:
+ * - 200 { status: 'not-found' }                 — no BillingAccount yet
+ *                                                 (auto-billing-account
+ *                                                 controller still racing)
+ * - 200 { status: 'needs-payment-method' }      — BA exists but no card
+ *                                                 attached; client should
+ *                                                 redirect to /billing-setup
+ * - 200 { status: 'attached', phase: '…' }      — payment method attached
+ */
+billingStatus.get('/', async (c) => {
+  const session = c.get('session')!;
+
+  try {
+    const billing = await createBillingService().getBillingAccountForUser(session.sub!);
+    if (!billing) {
+      return c.json({ status: 'not-found' });
+    }
+    if (!billing.paymentMethodAttached) {
+      return c.json({ status: 'needs-payment-method' });
+    }
+    return c.json({ status: 'attached', phase: billing.phase });
+  } catch {
+    return c.json({ status: 'not-found' });
+  }
+});
+
+export { billingStatus as billingStatusRoutes };

--- a/app/utils/config/paths.config.ts
+++ b/app/utils/config/paths.config.ts
@@ -17,6 +17,10 @@ export const paths = {
     accountSuspended: '/account-suspended',
     statusApi: '/api/fraud-status',
   },
+  billing: {
+    setup: '/billing-setup',
+    statusApi: '/api/billing-status',
+  },
   invitationAccept: '/invitation/:invitationId/accept',
   account: {
     root: '/account',

--- a/app/utils/middlewares/fraud-status.middleware.ts
+++ b/app/utils/middlewares/fraud-status.middleware.ts
@@ -1,5 +1,6 @@
 import { type MiddlewareContext, type NextFunction } from './middleware';
 import { getRequestContext } from '@/modules/axios/request-context';
+import { createBillingService } from '@/resources/billing';
 import { createUserService } from '@/resources/users';
 import { RegistrationApproval } from '@/resources/users/user.schema';
 import { paths } from '@/utils/config/paths.config';
@@ -10,7 +11,8 @@ import { redirect } from 'react-router';
 /**
  * Fraud status middleware that gates access based on user.status fields set by
  * the fraud operator via Milo IAM resources (UserDeactivation, PlatformAccessApproval,
- * PlatformAccessRejection).
+ * PlatformAccessRejection) AND on the BillingAccount payment-method-attached
+ * condition set by the milo-billing Stripe webhook.
  *
  * Algorithm:
  * 1. Read session; if no sub, call next() (let authMiddleware handle)
@@ -19,7 +21,8 @@ import { redirect } from 'react-router';
  * 4. state === 'Inactive'                  → /account-suspended
  * 5. registrationApproval === 'Approved'   → if nameReviewRequired and not on onboarding complete-profile → redirect there; else next()
  * 6. registrationApproval === 'Rejected'   → /account-under-review
- * 7. Pending or undefined                  → /verifying
+ * 7. BillingAccount present and paymentMethodAttached=false → /billing-setup
+ * 8. Otherwise (Pending fraud, or BA still provisioning) → /verifying
  */
 export async function fraudStatusMiddleware(
   ctx: MiddlewareContext,
@@ -29,6 +32,11 @@ export async function fraudStatusMiddleware(
 
   // Short-circuit for the logout route so users can always sign out.
   if (new URL(request.url).pathname === paths.auth.logOut) {
+    return next();
+  }
+  // /billing-setup runs its own auth + billing-account lookup; bouncing
+  // back to this middleware would create a redirect loop.
+  if (new URL(request.url).pathname === paths.billing.setup) {
     return next();
   }
 
@@ -82,7 +90,30 @@ export async function fraudStatusMiddleware(
       return redirect(paths.fraud.accountUnderReview);
     }
 
-    // Pending or undefined — evaluation still in progress
+    // Approval is Pending. Decide between /billing-setup and /verifying
+    // based on the BillingAccount state. Failure here is non-fatal: fall
+    // back to /verifying so the user sees a spinner rather than an
+    // error page while the billing API hiccups.
+    try {
+      const billing = await createBillingService().getBillingAccountForUser(session.sub);
+      if (reqCtx) {
+        reqCtx.cachedBillingAccount = billing ?? null;
+      }
+      if (billing && !billing.paymentMethodAttached) {
+        return redirect(paths.billing.setup);
+      }
+    } catch (billingError) {
+      // 403 on a brand-new user usually means OpenFGA hasn't propagated
+      // the user's billing permissions yet. Send them to /verifying so
+      // the polling loop waits for it to land.
+      if (billingError instanceof AuthorizationError || billingError instanceof NotFoundError) {
+        return redirect(paths.fraud.verifying);
+      }
+      // Any other error: fall through to /verifying. The verifying page
+      // also reads the BA status and will redirect to /billing-setup as
+      // soon as one appears.
+    }
+
     return redirect(paths.fraud.verifying);
   } catch {
     // Fail-open on unexpected errors

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,8 @@
         "@sentry/react-router": "^10.49.0",
         "@stepperize/react": "^6.1.0",
         "@streamdown/code": "^1.1.1",
+        "@stripe/react-stripe-js": "^3.0.0",
+        "@stripe/stripe-js": "^5.0.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/react-query": "^5.99.2",
@@ -956,6 +958,10 @@
     "@stepperize/react": ["@stepperize/react@6.1.0", "", { "dependencies": { "@stepperize/core": "2.1.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ywTt0OQDoBKcdzeBK9V1hTsMAQ+zAoIF/au9fcATspdGWfYr/z+mDGZm2cA2rzMJF79J+fUbjZPb+7Js4PtKBA=="],
 
     "@streamdown/code": ["@streamdown/code@1.1.1", "", { "dependencies": { "shiki": "^3.19.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-i7HTNuDgZWb+VdrNVOam9gQhIc5MSSDXKWXgbUrn/4vSRaSMM+Rtl10MQj4wLWPNpF7p80waJsAqFP8HZfb0Jg=="],
+
+    "@stripe/react-stripe-js": ["@stripe/react-stripe-js@3.10.0", "", { "dependencies": { "prop-types": "^15.7.2" }, "peerDependencies": { "@stripe/stripe-js": ">=1.44.1 <8.0.0", "react": ">=16.8.0 <20.0.0", "react-dom": ">=16.8.0 <20.0.0" } }, "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg=="],
+
+    "@stripe/stripe-js": ["@stripe/stripe-js@5.10.0", "", {}, "sha512-PTigkxMdMUP6B5ISS7jMqJAKhgrhZwjprDqR1eATtFfh0OpKVNp110xiH+goeVdrJ29/4LeZJR4FaHHWstsu0A=="],
 
     "@tabby_ai/hijri-converter": ["@tabby_ai/hijri-converter@1.0.5", "", {}, "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "@ai-sdk/anthropic": "^3.0.71",
     "@ai-sdk/react": "^3.0.170",
     "@conform-to/react": "1.19.2",
+    "@stripe/react-stripe-js": "^3.0.0",
+    "@stripe/stripe-js": "^5.0.0",
     "@conform-to/zod": "1.19.2",
     "@datum-cloud/activity-ui": "^0.5.0",
     "@datum-cloud/datum-ui": "^0.10.0",


### PR DESCRIPTION
## Summary
- New `/billing-setup` route renders Stripe Elements. The loader creates a `PaymentMethodSetup` CR against the existing milo K8s API and waits for the controller to populate `clientSecret`.
- `fraud-status` middleware inserts a needs-payment-method branch ahead of the verifying redirect.
- `/verifying` parallel-polls `/api/billing-status` and bounces back to `/billing-setup` if the BillingAccount loses (or never had) an attached payment method.
- `app/resources/billing/` provides typed wrappers — no new env vars or service-specific HTTP clients; everything goes through the existing apiserver connection.

## Why
Pairs with the `milo-os/billing` and `datum-cloud/fraud` PRs: collect a card before granting platform access so MaxMind sees the full signal (BIN, AVS, CVC) and the platform has a confirmed payment method on file.

## Note
Bun lockfile updated for `@stripe/react-stripe-js` + `@stripe/stripe-js`. Run `bun install` after pulling.