### PR TITLE
chore: sentry.prod SENTRY_DSN

### DIFF
--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: PROMETHEUS_URL
               value: http://vmsingle-datum-resource-metrics.datum-system.svc.cluster.local:8429
             - name: SENTRY_DSN
-              value: https://4d5f4f8662ce4fc06c4ab38ca694bd1f@sentry.staging.env.datum.net/3
+              value: https://5577e0a8a54d023d2c51092ee68041b3@sentry.prod.env.datum.net/5
           envFrom:
             - secretRef:
                 name: cloud-portal


### PR DESCRIPTION
Replace sentry.staging SENTRY_DSN w/ sentry.prod's. Cloud-portal appears to be app #5 in prod sentry, vs app #3 in staging.

We were [hanging for 120 seconds](https://github.com/datum-cloud/cloud-portal/actions/runs/26114519694/job/76801225621?pr=1250#step:7:1142) on sentry.staging and any rate it's deprecated. 

ref https://github.com/datum-cloud/infra/issues/1609