### PR TITLE
fix: satisfy ManualChunksOption type for Vite 8 compatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 import { reactRouterHonoServer } from 'react-router-hono-server/dev';
+import type { ManualChunksOption } from 'rollup';
 import type { Plugin } from 'vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
@@ -110,7 +111,7 @@ export default defineConfig((config) => {
             'vendor-recharts': ['recharts'],
             'vendor-icons': ['lucide-react'],
             'vendor-streamdown': ['streamdown'], // pulls mermaid, elk, shiki — ~5MB
-          },
+          } satisfies ManualChunksOption,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Vite 8 ships a newer Rollup whose `ManualChunksOption` type no longer matches plain object literals via TS inference inside `defineConfig`
- Adds `satisfies ManualChunksOption` (imported from `rollup`) to the `manualChunks` object to resolve the overload mismatch
- Unblocks the Renovate Vite 8 upgrade PR (#1083)

## Test plan

- [x] `bun typecheck` passes
- [x] Build succeeds