### PR TITLE
feat(rbac): gate AI Edge (project HTTP proxies) — list, detail, edits, WAF, delete

### DIFF
--- a/app/features/edge/proxy/metrics/proxy-sparkline.tsx
+++ b/app/features/edge/proxy/metrics/proxy-sparkline.tsx
@@ -3,6 +3,7 @@ import { usePrometheusAPIQuery } from '@/modules/metrics/hooks';
 import { transformForRecharts, type FormattedMetricData } from '@/modules/prometheus';
 import { ChartContainer, ChartTooltip, type ChartConfig } from '@datum-cloud/datum-ui/chart';
 import { SpinnerIcon } from '@datum-cloud/datum-ui/icons';
+import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
 import { useMemo } from 'react';
 import { Area, AreaChart, ResponsiveContainer } from 'recharts';
 
@@ -73,6 +74,16 @@ export function ProxySparkline({ projectId, proxyId }: ProxySparklineProps) {
     return (
       <div className="flex h-8 w-full min-w-[200px] items-center justify-center px-1.5">
         <SpinnerIcon size="sm" />
+      </div>
+    );
+  }
+
+  if (error?.statusCode === 403 || error?.statusCode === 401) {
+    return (
+      <div className="flex h-8 w-full min-w-[200px] items-center justify-center px-1.5">
+        <Tooltip message="You don't have permission to view metrics">
+          <span className="text-muted-foreground text-xs">&mdash;</span>
+        </Tooltip>
       </div>
     );
   }

--- a/app/features/edge/proxy/overview/config-card.tsx
+++ b/app/features/edge/proxy/overview/config-card.tsx
@@ -14,6 +14,7 @@ import {
   type ProxyHostHeaderDialogRef,
 } from '@/features/edge/proxy/proxy-host-header-dialog';
 import { ProxyWafDialog, type ProxyWafDialogRef } from '@/features/edge/proxy/proxy-waf-dialog';
+import { usePermission } from '@/modules/rbac';
 import { ControlPlaneStatus } from '@/resources/base';
 import { useConnector, useConnectorWatch } from '@/resources/connectors';
 import {
@@ -52,6 +53,37 @@ export const HttpProxyConfigCard = ({
 
   useConnectorWatch(projectId ?? '', proxy.connector?.name);
 
+  const { hasPermission: canEdit } = usePermission('httpproxies', 'patch', {
+    group: 'networking.datumapis.com',
+    namespace: 'default',
+    scope: 'project',
+  });
+  const { hasPermission: canEditWaf } = usePermission('trafficprotectionpolicies', 'patch', {
+    group: 'networking.datumapis.com',
+    namespace: 'default',
+    scope: 'project',
+  });
+
+  const renderEditButton = (allowed: boolean, deniedReason: string, onClick: () => void) => {
+    const button = (
+      <button
+        type="button"
+        className="text-muted-foreground hover:text-foreground transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={!allowed}
+        onClick={onClick}>
+        <Icon icon={PencilIcon} size={12} />
+      </button>
+    );
+
+    if (allowed) return button;
+
+    return (
+      <Tooltip message={deniedReason} side="bottom">
+        {button}
+      </Tooltip>
+    );
+  };
+
   const listItems: ListItem[] = useMemo(() => {
     if (!proxy) return [];
 
@@ -61,14 +93,12 @@ export const HttpProxyConfigCard = ({
         content: (
           <div className="flex items-center gap-1.5">
             <span className="text-sm">{proxy.chosenName || proxy.name}</span>
-            {projectId && (
-              <button
-                type="button"
-                className="text-muted-foreground hover:text-foreground transition-colors"
-                onClick={() => displayNameDialogRef.current?.show(proxy)}>
-                <Icon icon={PencilIcon} size={12} />
-              </button>
-            )}
+            {projectId &&
+              renderEditButton(
+                canEdit,
+                "You don't have permission to edit this AI Edge",
+                () => displayNameDialogRef.current?.show(proxy)
+              )}
           </div>
         ),
       },
@@ -84,14 +114,12 @@ export const HttpProxyConfigCard = ({
                 &mdash;
               </span>
             )}
-            {projectId && (
-              <button
-                type="button"
-                className="text-muted-foreground hover:text-foreground transition-colors"
-                onClick={() => hostHeaderDialogRef.current?.show(proxy)}>
-                <Icon icon={PencilIcon} size={12} />
-              </button>
-            )}
+            {projectId &&
+              renderEditButton(
+                canEdit,
+                "You don't have permission to edit this AI Edge",
+                () => hostHeaderDialogRef.current?.show(proxy)
+              )}
           </div>
         ),
       },
@@ -119,28 +147,24 @@ export const HttpProxyConfigCard = ({
               <Badge type="quaternary" theme="outline" className="rounded-xl text-xs font-normal">
                 {formatWafProtectionDisplay(proxy)}
               </Badge>
-              {projectId && (
-                <button
-                  type="button"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  onClick={() => wafDialogRef.current?.show(proxy)}>
-                  <Icon icon={PencilIcon} size={12} />
-                </button>
-              )}
+              {projectId &&
+                renderEditButton(
+                  canEditWaf,
+                  "You don't have permission to edit WAF protection",
+                  () => wafDialogRef.current?.show(proxy)
+                )}
             </div>
           ) : (
             <div className="flex items-center gap-1.5">
               <Badge type="quaternary" theme="outline" className="rounded-xl text-xs font-normal">
                 Disabled
               </Badge>
-              {projectId && (
-                <button
-                  type="button"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  onClick={() => wafDialogRef.current?.show(proxy)}>
-                  <Icon icon={PencilIcon} size={12} />
-                </button>
-              )}
+              {projectId &&
+                renderEditButton(
+                  canEditWaf,
+                  "You don't have permission to edit WAF protection",
+                  () => wafDialogRef.current?.show(proxy)
+                )}
             </div>
           ),
       },
@@ -226,19 +250,18 @@ export const HttpProxyConfigCard = ({
                     : 'Enabled'
                   : 'Disabled'}
               </Badge>
-              {projectId && (
-                <button
-                  type="button"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  onClick={() => basicAuthDialogRef.current?.show(proxy)}>
-                  <Icon icon={PencilIcon} size={12} />
-                </button>
-              )}
+              {projectId &&
+                renderEditButton(
+                  canEdit,
+                  "You don't have permission to edit this AI Edge",
+                  () => basicAuthDialogRef.current?.show(proxy)
+                )}
             </div>
           ),
       },
     ];
-  }, [proxy, projectId, updateMutation]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [proxy, projectId, updateMutation, canEdit, canEditWaf]);
 
   const connectorBlock = useMemo(() => {
     if (!proxy.connector) return null;

--- a/app/features/edge/proxy/overview/config-card.tsx
+++ b/app/features/edge/proxy/overview/config-card.tsx
@@ -37,9 +37,13 @@ import { useMemo, useRef } from 'react';
 export const HttpProxyConfigCard = ({
   proxy,
   projectId,
+  canViewWaf = true,
+  wafPending = false,
 }: {
   proxy: HttpProxy;
   projectId?: string;
+  canViewWaf?: boolean;
+  wafPending?: boolean;
 }) => {
   const displayNameDialogRef = useRef<ProxyDisplayNameDialogRef>(null);
   const wafDialogRef = useRef<ProxyWafDialogRef>(null);
@@ -135,34 +139,40 @@ export const HttpProxyConfigCard = ({
             </Tooltip>
           </div>
         ),
-        content:
-          proxy.trafficProtectionMode !== 'Disabled' ||
+        content: wafPending ? (
+          <Skeleton className="h-6 w-24 rounded-xl" />
+        ) : !canViewWaf ? (
+          <Tooltip message="You don't have permission to view WAF protection" side="bottom">
+            <Badge
+              type="quaternary"
+              theme="outline"
+              className="text-muted-foreground rounded-xl text-xs font-normal">
+              &mdash;
+            </Badge>
+          </Tooltip>
+        ) : proxy.trafficProtectionMode !== 'Disabled' ||
           proxy.paranoiaLevels?.blocking !== undefined ||
           proxy.paranoiaLevels?.detection !== undefined ? (
-            <div className="flex items-center gap-1.5">
-              <Badge type="quaternary" theme="outline" className="rounded-xl text-xs font-normal">
-                {formatWafProtectionDisplay(proxy)}
-              </Badge>
-              {projectId &&
-                renderEditButton(
-                  canEditWaf,
-                  "You don't have permission to edit WAF protection",
-                  () => wafDialogRef.current?.show(proxy)
-                )}
-            </div>
-          ) : (
-            <div className="flex items-center gap-1.5">
-              <Badge type="quaternary" theme="outline" className="rounded-xl text-xs font-normal">
-                Disabled
-              </Badge>
-              {projectId &&
-                renderEditButton(
-                  canEditWaf,
-                  "You don't have permission to edit WAF protection",
-                  () => wafDialogRef.current?.show(proxy)
-                )}
-            </div>
-          ),
+          <div className="flex items-center gap-1.5">
+            <Badge type="quaternary" theme="outline" className="rounded-xl text-xs font-normal">
+              {formatWafProtectionDisplay(proxy)}
+            </Badge>
+            {projectId &&
+              renderEditButton(canEditWaf, "You don't have permission to edit WAF protection", () =>
+                wafDialogRef.current?.show(proxy)
+              )}
+          </div>
+        ) : (
+          <div className="flex items-center gap-1.5">
+            <Badge type="quaternary" theme="outline" className="rounded-xl text-xs font-normal">
+              Disabled
+            </Badge>
+            {projectId &&
+              renderEditButton(canEditWaf, "You don't have permission to edit WAF protection", () =>
+                wafDialogRef.current?.show(proxy)
+              )}
+          </div>
+        ),
       },
       {
         label: (
@@ -254,7 +264,7 @@ export const HttpProxyConfigCard = ({
           ),
       },
     ];
-  }, [proxy, projectId, updateMutation, canEdit, canEditWaf]);
+  }, [proxy, projectId, updateMutation, canEdit, canEditWaf, canViewWaf, wafPending]);
 
   const connectorBlock = useMemo(() => {
     if (!proxy.connector) return null;

--- a/app/features/edge/proxy/overview/config-card.tsx
+++ b/app/features/edge/proxy/overview/config-card.tsx
@@ -94,10 +94,8 @@ export const HttpProxyConfigCard = ({
           <div className="flex items-center gap-1.5">
             <span className="text-sm">{proxy.chosenName || proxy.name}</span>
             {projectId &&
-              renderEditButton(
-                canEdit,
-                "You don't have permission to edit this AI Edge",
-                () => displayNameDialogRef.current?.show(proxy)
+              renderEditButton(canEdit, "You don't have permission to edit this AI Edge", () =>
+                displayNameDialogRef.current?.show(proxy)
               )}
           </div>
         ),
@@ -115,10 +113,8 @@ export const HttpProxyConfigCard = ({
               </span>
             )}
             {projectId &&
-              renderEditButton(
-                canEdit,
-                "You don't have permission to edit this AI Edge",
-                () => hostHeaderDialogRef.current?.show(proxy)
+              renderEditButton(canEdit, "You don't have permission to edit this AI Edge", () =>
+                hostHeaderDialogRef.current?.show(proxy)
               )}
           </div>
         ),
@@ -251,16 +247,13 @@ export const HttpProxyConfigCard = ({
                   : 'Disabled'}
               </Badge>
               {projectId &&
-                renderEditButton(
-                  canEdit,
-                  "You don't have permission to edit this AI Edge",
-                  () => basicAuthDialogRef.current?.show(proxy)
+                renderEditButton(canEdit, "You don't have permission to edit this AI Edge", () =>
+                  basicAuthDialogRef.current?.show(proxy)
                 )}
             </div>
           ),
       },
     ];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [proxy, projectId, updateMutation, canEdit, canEditWaf]);
 
   const connectorBlock = useMemo(() => {

--- a/app/features/edge/proxy/overview/hostnames-card.tsx
+++ b/app/features/edge/proxy/overview/hostnames-card.tsx
@@ -1,6 +1,7 @@
 import { ProxyHostnamesConfigDialog } from '@/features/edge/proxy/proxy-hostnames-dialog';
 import type { ProxyHostnamesConfigDialogRef } from '@/features/edge/proxy/proxy-hostnames-dialog';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { PermissionButton } from '@/modules/rbac';
 import {
   type HttpProxy,
   getCertificateReadyCondition,
@@ -53,7 +54,13 @@ export const HttpProxyHostnamesCard = ({
         <div className="flex items-center gap-2.5">
           <Icon icon={GlobeIcon} size={20} className="text-secondary stroke-2" />
           <span className="text-base font-semibold">Custom Hostnames</span>
-          <Button
+          <PermissionButton
+            resource="httpproxies"
+            verb="patch"
+            group="networking.datumapis.com"
+            namespace="default"
+            scope="project"
+            deniedReason="You don't have permission to edit this AI Edge"
             type="primary"
             theme="solid"
             size="xs"
@@ -66,7 +73,7 @@ export const HttpProxyHostnamesCard = ({
             disabled={disabled}>
             <Icon icon={PencilIcon} size={12} />
             Edit hostnames
-          </Button>
+          </PermissionButton>
         </div>
 
         {proxy?.tlsHostname && (

--- a/app/features/edge/proxy/overview/origins-card.tsx
+++ b/app/features/edge/proxy/overview/origins-card.tsx
@@ -3,6 +3,7 @@ import {
   type ProxyOriginsDialogRef,
 } from '@/features/edge/proxy/proxy-origins-dialog';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { PermissionButton } from '@/modules/rbac';
 import { type HttpProxy } from '@/resources/http-proxies';
 import { Button } from '@datum-cloud/datum-ui/button';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
@@ -39,7 +40,13 @@ export const HttpProxyOriginsCard = ({
           <Icon icon={ServerIcon} size={20} className="text-secondary stroke-2" />
           <span className="text-base font-semibold">Origin</span>
           {proxy && projectId && (
-            <Button
+            <PermissionButton
+              resource="httpproxies"
+              verb="patch"
+              group="networking.datumapis.com"
+              namespace="default"
+              scope="project"
+              deniedReason="You don't have permission to edit this AI Edge"
               type="primary"
               theme="solid"
               size="xs"
@@ -47,7 +54,7 @@ export const HttpProxyOriginsCard = ({
               onClick={() => originsDialogRef.current?.show(proxy)}>
               <Icon icon={PencilIcon} size={12} />
               Edit origin
-            </Button>
+            </PermissionButton>
           )}
         </div>
         {origins.length > 0 ? (

--- a/app/features/edge/proxy/proxy-header-actions.tsx
+++ b/app/features/edge/proxy/proxy-header-actions.tsx
@@ -1,8 +1,8 @@
 import { useDeleteProxy } from '@/features/edge/proxy/hooks/use-delete-proxy';
+import { PermissionButton } from '@/modules/rbac';
 import { type HttpProxy, useHttpProxy, useHttpProxyWatch } from '@/resources/http-proxies';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { Button } from '@datum-cloud/datum-ui/button';
 import { Icon } from '@datum-cloud/datum-ui/icons';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { Trash2Icon } from 'lucide-react';
@@ -41,7 +41,13 @@ export function ProxyHeaderActions({ projectId, proxy }: ProxyHeaderActionsProps
 
   return (
     <div className="flex w-full items-center gap-2 sm:w-auto">
-      <Button
+      <PermissionButton
+        resource="httpproxies"
+        verb="delete"
+        group="networking.datumapis.com"
+        namespace="default"
+        scope="project"
+        deniedReason="You don't have permission to delete this AI Edge"
         type="danger"
         theme="outline"
         size="small"
@@ -50,7 +56,7 @@ export function ProxyHeaderActions({ projectId, proxy }: ProxyHeaderActionsProps
         aria-label="Delete AI Edge">
         <Icon icon={Trash2Icon} size={14} />
         <span className="hidden sm:inline">Delete</span>
-      </Button>
+      </PermissionButton>
     </div>
   );
 }

--- a/app/modules/metrics/components/base-metric.tsx
+++ b/app/modules/metrics/components/base-metric.tsx
@@ -71,6 +71,17 @@ export function BaseMetric({
     }
 
     if (error) {
+      // Permission/auth failures get a muted, non-alarming message — a viewer
+      // without telemetry access shouldn't see a red error banner.
+      if (error.statusCode === 403 || error.statusCode === 401) {
+        return (
+          <div
+            className="text-muted-foreground flex w-full items-center justify-center p-4 text-sm"
+            style={containerStyle}>
+            You don&apos;t have permission to view these metrics
+          </div>
+        );
+      }
       return (
         <div className="w-full p-4" style={containerStyle}>
           <Alert variant="destructive">

--- a/app/modules/metrics/hooks/usePrometheusApi.ts
+++ b/app/modules/metrics/hooks/usePrometheusApi.ts
@@ -128,7 +128,11 @@ export function usePrometheusAPIQuery<T>(
     staleTime: 30000, // 30 seconds
     gcTime: 300000, // 5 minutes
     retry: (failureCount: number, error: PrometheusError) => {
-      if (error.type === 'query') return false;
+      // Permission/auth failures (403/401) and malformed queries won't change on
+      // retry — fail fast instead of hammering the telemetry endpoint.
+      if (error.type === 'query' || error.statusCode === 403 || error.statusCode === 401) {
+        return false;
+      }
       return failureCount < 3;
     },
     retryDelay: (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 30000),

--- a/app/modules/rbac/hooks/useCheckQuery.ts
+++ b/app/modules/rbac/hooks/useCheckQuery.ts
@@ -17,6 +17,10 @@ export interface CheckQueryParams {
   /** Override the organization id from context. */
   organizationId?: string;
   enabled?: boolean;
+  /** Override the default staleTime (ms). Pass 0 to always treat as stale. */
+  staleTime?: number;
+  /** Override refetch-on-mount. Use 'always' to re-validate gates on every mount. */
+  refetchOnMount?: boolean | 'always';
 }
 
 /**
@@ -26,7 +30,17 @@ export interface CheckQueryParams {
  */
 export function useCheckQuery(params: CheckQueryParams) {
   const ctx = usePermissions();
-  const { resource, verb, group = '', namespace, name, scope, enabled = true } = params;
+  const {
+    resource,
+    verb,
+    group = '',
+    namespace,
+    name,
+    scope,
+    enabled = true,
+    staleTime = STALE_TIME,
+    refetchOnMount,
+  } = params;
 
   const organizationId = params.organizationId ?? ctx.organizationId;
   const projectId = params.projectId ?? ctx.projectId;
@@ -59,7 +73,8 @@ export function useCheckQuery(params: CheckQueryParams) {
       });
     },
     enabled: enabled && !!organizationId,
-    staleTime: STALE_TIME,
+    staleTime,
+    refetchOnMount,
     retry: 1,
   });
 

--- a/app/modules/rbac/hooks/usePermission.ts
+++ b/app/modules/rbac/hooks/usePermission.ts
@@ -12,11 +12,16 @@ export interface UsePermissionOptions {
    * Enable/disable the query. Default: true.
    */
   enabled?: boolean;
+  /** Override the default staleTime (ms). Pass 0 to always treat as stale. */
+  staleTime?: number;
+  /** Override refetch-on-mount. Use 'always' to re-validate the gate on every mount. */
+  refetchOnMount?: boolean | 'always';
 }
 
 export interface UsePermissionResult {
   hasPermission: boolean;
   isLoading: boolean;
+  isFetching: boolean;
   isError: boolean;
   error: Error | null;
   refetch: () => void;
@@ -32,7 +37,16 @@ export function usePermission(
   verb: PermissionVerb,
   options: UsePermissionOptions = {}
 ): UsePermissionResult {
-  const { namespace, name, group = '', scope, projectId, enabled = true } = options;
+  const {
+    namespace,
+    name,
+    group = '',
+    scope,
+    projectId,
+    enabled = true,
+    staleTime,
+    refetchOnMount,
+  } = options;
 
   const query = useCheckQuery({
     resource,
@@ -43,11 +57,14 @@ export function usePermission(
     scope,
     projectId,
     enabled,
+    staleTime,
+    refetchOnMount,
   });
 
   return {
     hasPermission: query.data ? query.data.allowed && !query.data.denied : false,
     isLoading: query.isLoading,
+    isFetching: query.isFetching,
     isError: query.isError,
     error: query.error as Error | null,
     refetch: query.refetch,

--- a/app/resources/http-proxies/http-proxy.queries.ts
+++ b/app/resources/http-proxies/http-proxy.queries.ts
@@ -1,5 +1,10 @@
 import type { HttpProxy, CreateHttpProxyInput, UpdateHttpProxyInput } from './http-proxy.schema';
-import { createHttpProxyService, httpProxyKeys } from './http-proxy.service';
+import {
+  createHttpProxyService,
+  httpProxyKeys,
+  type TrafficProtectionMaps,
+  type TrafficProtectionView,
+} from './http-proxy.service';
 import {
   useQuery,
   useMutation,
@@ -52,6 +57,40 @@ export function useHttpProxy(
   });
 }
 
+/**
+ * WAF (TrafficProtectionPolicy) modes for a project, keyed by proxy name.
+ * Decoupled from the proxy list and gated by `enabled` so callers without
+ * `trafficprotectionpolicies` view permission never trigger the request.
+ */
+export function useTrafficProtectionPolicies(
+  projectId: string,
+  options?: Omit<UseQueryOptions<TrafficProtectionMaps>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery({
+    queryKey: httpProxyKeys.wafList(projectId),
+    queryFn: () => createHttpProxyService().listTrafficProtectionPolicies(projectId),
+    enabled: !!projectId,
+    ...options,
+  });
+}
+
+/**
+ * WAF (TrafficProtectionPolicy) view for a single proxy. Gated by `enabled` so
+ * callers without view permission never trigger the request.
+ */
+export function useTrafficProtectionPolicy(
+  projectId: string,
+  name: string,
+  options?: Omit<UseQueryOptions<TrafficProtectionView | null>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery({
+    queryKey: httpProxyKeys.wafDetail(projectId, name),
+    queryFn: () => createHttpProxyService().getTrafficProtectionPolicy(projectId, name),
+    enabled: !!projectId && !!name,
+    ...options,
+  });
+}
+
 export function useCreateHttpProxy(
   projectId: string,
   options?: UseMutationOptions<HttpProxy, Error, CreateHttpProxyInput>
@@ -66,6 +105,7 @@ export function useCreateHttpProxy(
       const [newHttpProxy] = args;
       queryClient.setQueryData(httpProxyKeys.detail(projectId, newHttpProxy.name), newHttpProxy);
       queryClient.invalidateQueries({ queryKey: httpProxyKeys.list(projectId) });
+      queryClient.invalidateQueries({ queryKey: httpProxyKeys.wafList(projectId) });
 
       options?.onSuccess?.(...args);
     },
@@ -79,7 +119,11 @@ export function useUpdateHttpProxy(
     HttpProxy,
     Error,
     UpdateHttpProxyInput,
-    { previous: HttpProxy | undefined }
+    {
+      previous: HttpProxy | undefined;
+      previousWaf?: TrafficProtectionView | null;
+      touchesWaf?: boolean;
+    }
   >
 ) {
   const queryClient = useQueryClient();
@@ -105,14 +149,6 @@ export function useUpdateHttpProxy(
           ...(input.hostnames !== undefined && { hostnames: input.hostnames }),
           ...(input.tlsHostname !== undefined && { tlsHostname: input.tlsHostname }),
           ...(input.chosenName !== undefined && { chosenName: input.chosenName }),
-          ...(input.removeTrafficProtection && {
-            trafficProtectionMode: undefined,
-            paranoiaLevels: undefined,
-          }),
-          ...(input.trafficProtectionMode !== undefined && {
-            trafficProtectionMode: input.trafficProtectionMode,
-          }),
-          ...(input.paranoiaLevels !== undefined && { paranoiaLevels: input.paranoiaLevels }),
           ...(input.enableHttpRedirect !== undefined && {
             enableHttpRedirect: input.enableHttpRedirect,
           }),
@@ -123,17 +159,49 @@ export function useUpdateHttpProxy(
           }),
         };
       });
-      return { previous };
+
+      // WAF lives in its own (permission-gated) cache now — update it separately.
+      let previousWaf: TrafficProtectionView | null | undefined;
+      const touchesWaf =
+        input.removeTrafficProtection ||
+        input.trafficProtectionMode !== undefined ||
+        input.paranoiaLevels !== undefined;
+      if (touchesWaf) {
+        await queryClient.cancelQueries({ queryKey: httpProxyKeys.wafDetail(projectId, name) });
+        previousWaf = queryClient.getQueryData<TrafficProtectionView | null>(
+          httpProxyKeys.wafDetail(projectId, name)
+        );
+        queryClient.setQueryData<TrafficProtectionView | null>(
+          httpProxyKeys.wafDetail(projectId, name),
+          (old) => {
+            if (input.removeTrafficProtection)
+              return { mode: undefined, paranoiaLevels: undefined };
+            return {
+              mode: input.trafficProtectionMode ?? old?.mode,
+              paranoiaLevels: input.paranoiaLevels ?? old?.paranoiaLevels,
+            };
+          }
+        );
+      }
+      return { previous, previousWaf, touchesWaf };
     },
     onError: (err, _input, context, mutationContext) => {
       if (context?.previous != null) {
         queryClient.setQueryData(httpProxyKeys.detail(projectId, name), context.previous);
+      }
+      if (context?.touchesWaf) {
+        queryClient.setQueryData(
+          httpProxyKeys.wafDetail(projectId, name),
+          context.previousWaf ?? null
+        );
       }
       options?.onError?.(err, _input, context, mutationContext);
     },
     onSuccess: async (...args) => {
       await queryClient.invalidateQueries({ queryKey: httpProxyKeys.detail(projectId, name) });
       queryClient.invalidateQueries({ queryKey: httpProxyKeys.list(projectId) });
+      queryClient.invalidateQueries({ queryKey: httpProxyKeys.wafDetail(projectId, name) });
+      queryClient.invalidateQueries({ queryKey: httpProxyKeys.wafList(projectId) });
 
       options?.onSuccess?.(...args);
     },
@@ -154,6 +222,8 @@ export function useDeleteHttpProxy(
       await queryClient.cancelQueries({ queryKey: httpProxyKeys.detail(projectId, name) });
       // Invalidate list so it refetches without the deleted item
       queryClient.invalidateQueries({ queryKey: httpProxyKeys.list(projectId) });
+      queryClient.removeQueries({ queryKey: httpProxyKeys.wafDetail(projectId, name) });
+      queryClient.invalidateQueries({ queryKey: httpProxyKeys.wafList(projectId) });
 
       options?.onSuccess?.(...args);
     },

--- a/app/resources/http-proxies/http-proxy.service.ts
+++ b/app/resources/http-proxies/http-proxy.service.ts
@@ -49,7 +49,23 @@ export const httpProxyKeys = {
   details: () => [...httpProxyKeys.all, 'detail'] as const,
   detail: (projectId: string, name: string) =>
     [...httpProxyKeys.details(), projectId, name] as const,
+  // WAF (TrafficProtectionPolicy) is fetched separately from the proxy so the
+  // request can be gated behind `trafficprotectionpolicies` view permission.
+  waf: () => [...httpProxyKeys.all, 'waf'] as const,
+  wafList: (projectId: string) => [...httpProxyKeys.waf(), 'list', projectId] as const,
+  wafDetail: (projectId: string, name: string) =>
+    [...httpProxyKeys.waf(), 'detail', projectId, name] as const,
 };
+
+/** WAF (TrafficProtectionPolicy) view data, keyed by proxy name for list merges. */
+export interface TrafficProtectionView {
+  mode?: TrafficProtectionMode;
+  paranoiaLevels?: { blocking?: number; detection?: number };
+}
+export interface TrafficProtectionMaps {
+  modeByName: Map<string, TrafficProtectionMode>;
+  paranoiaByName: Map<string, { blocking?: number; detection?: number }>;
+}
 
 const SERVICE_NAME = 'HttpProxyService';
 
@@ -93,15 +109,15 @@ export function createHttpProxyService() {
       const baseURL = getProjectScopedBase(projectId);
       const path = { namespace: 'default' as const };
 
-      const [proxyResponse, policyResponse, securityPoliciesResponse] = await Promise.all([
+      // WAF (TrafficProtectionPolicy) is intentionally NOT fetched here — it is
+      // loaded by a separate permission-gated query (listTrafficProtectionPolicies)
+      // so users without trafficprotectionpolicies access never trigger that request.
+      const [proxyResponse, securityPoliciesResponse] = await Promise.all([
         listNetworkingDatumapisComV1AlphaNamespacedHttpProxy({ baseURL, path, query }),
-        listNetworkingDatumapisComV1AlphaNamespacedTrafficProtectionPolicy({ baseURL, path }),
         this.listSecurityPolicies(baseURL, 'default').catch(() => ({ data: null })),
       ]);
 
       const proxyData = proxyResponse.data as ComDatumapisNetworkingV1AlphaHttpProxyList;
-      const modeMap = toTrafficProtectionModeMap(policyResponse.data);
-      const paranoiaLevelsMap = toParanoiaLevelsMap(policyResponse.data);
 
       const basicAuthByName = new Map<
         string,
@@ -117,10 +133,63 @@ export function createHttpProxyService() {
       }
 
       return toHttpProxyList(proxyData?.items ?? [], undefined, {
-        trafficProtectionModeByName: modeMap,
-        paranoiaLevelsByName: paranoiaLevelsMap,
         basicAuthByName,
       }).items;
+    },
+
+    /**
+     * List WAF (TrafficProtectionPolicy) modes for a project, keyed by proxy name.
+     * Decoupled from the proxy list so it can be gated behind view permission.
+     * Errors are surfaced (not swallowed) so callers can distinguish "couldn't
+     * read WAF" (show "—") from "no WAF policy" (show "Disabled"). The decoupled
+     * query isolates this failure from the proxy list.
+     */
+    async listTrafficProtectionPolicies(projectId: string): Promise<TrafficProtectionMaps> {
+      try {
+        const baseURL = getProjectScopedBase(projectId);
+        const response = await listNetworkingDatumapisComV1AlphaNamespacedTrafficProtectionPolicy({
+          baseURL,
+          path: { namespace: 'default' },
+        });
+        const list = response.data;
+        return {
+          modeByName: toTrafficProtectionModeMap(list),
+          paranoiaByName: toParanoiaLevelsMap(list),
+        };
+      } catch (error) {
+        logger.error(`${SERVICE_NAME}.listTrafficProtectionPolicies failed`, error as Error);
+        throw mapApiError(error);
+      }
+    },
+
+    /**
+     * Read a single proxy's WAF (TrafficProtectionPolicy) view. Decoupled from the
+     * proxy fetch so it can be gated behind view permission. A genuine 404 (no
+     * policy) resolves to an empty view; other errors are surfaced so callers can
+     * distinguish "couldn't read WAF" (show "—") from "no WAF policy" ("Disabled").
+     */
+    async getTrafficProtectionPolicy(
+      projectId: string,
+      name: string
+    ): Promise<TrafficProtectionView> {
+      try {
+        const baseURL = getProjectScopedBase(projectId);
+        const response = await readNetworkingDatumapisComV1AlphaNamespacedTrafficProtectionPolicy({
+          baseURL,
+          path: { namespace: 'default', name },
+        });
+        return {
+          mode: getTrafficProtectionMode(response.data),
+          paranoiaLevels: getParanoiaLevels(response.data),
+        };
+      } catch (error) {
+        // No policy for this proxy is a normal "WAF disabled" state, not an error.
+        if (this.getErrorStatus(error) === 404) {
+          return { mode: undefined, paranoiaLevels: undefined };
+        }
+        logger.error(`${SERVICE_NAME}.getTrafficProtectionPolicy failed`, error as Error);
+        throw mapApiError(error);
+      }
     },
 
     async createTrafficProtectionPolicy(
@@ -414,16 +483,13 @@ export function createHttpProxyService() {
       const baseURL = getProjectScopedBase(projectId);
       const path = { namespace: 'default' as const, name };
 
-      const [proxyResponse, policyResponse, securityPolicyResponse, secretResponse] =
-        await Promise.all([
-          readNetworkingDatumapisComV1AlphaNamespacedHttpProxy({ baseURL, path }),
-          readNetworkingDatumapisComV1AlphaNamespacedTrafficProtectionPolicy({
-            baseURL,
-            path,
-          }).catch(() => ({ data: null })),
-          this.readSecurityPolicy(baseURL, 'default', name).catch(() => ({ data: null })),
-          this.readBasicAuthSecret(baseURL, 'default', name).catch(() => ({ data: null })),
-        ]);
+      // WAF (TrafficProtectionPolicy) is intentionally NOT fetched here — it is
+      // loaded by a separate permission-gated query (getTrafficProtectionPolicy).
+      const [proxyResponse, securityPolicyResponse, secretResponse] = await Promise.all([
+        readNetworkingDatumapisComV1AlphaNamespacedHttpProxy({ baseURL, path }),
+        this.readSecurityPolicy(baseURL, 'default', name).catch(() => ({ data: null })),
+        this.readBasicAuthSecret(baseURL, 'default', name).catch(() => ({ data: null })),
+      ]);
 
       const data = proxyResponse.data as ComDatumapisNetworkingV1AlphaHttpProxy;
 
@@ -431,11 +497,9 @@ export function createHttpProxyService() {
         throw new NotFoundError('AI Edge', name);
       }
 
-      const wafMode = getTrafficProtectionMode(policyResponse.data);
-      const paranoiaLevels = getParanoiaLevels(policyResponse.data);
       const usernames = parseHtpasswdUsernames(secretResponse.data);
       const basicAuth = getBasicAuthState(securityPolicyResponse.data, usernames);
-      return toHttpProxy(data, { trafficProtectionMode: wafMode, paranoiaLevels, basicAuth });
+      return toHttpProxy(data, { basicAuth });
     },
 
     /**

--- a/app/resources/http-proxies/http-proxy.watch.ts
+++ b/app/resources/http-proxies/http-proxy.watch.ts
@@ -31,10 +31,6 @@ export function useHttpProxiesWatch(projectId: string, options?: { enabled?: boo
             item.name === newItem.name
               ? {
                   ...newItem,
-                  ...(existingItem.trafficProtectionMode !== undefined && {
-                    trafficProtectionMode: existingItem.trafficProtectionMode,
-                    paranoiaLevels: existingItem.paranoiaLevels,
-                  }),
                   ...(existingItem.enableHttpRedirect !== undefined && {
                     enableHttpRedirect: existingItem.enableHttpRedirect,
                   }),
@@ -78,16 +74,13 @@ export function useHttpProxyWatch(
     transform: (item) => toHttpProxy(item as ComDatumapisNetworkingV1AlphaHttpProxy),
     enabled: options?.enabled ?? true,
     updateSingleCache: (oldData, newItem) => {
-      // Preserve fields that watch events may omit or send partially (WAF from separate policy,
-      // enableHttpRedirect derived from spec.rules which may be missing in partial watch payloads)
+      // Preserve fields that watch events may omit or send partially
+      // (enableHttpRedirect derived from spec.rules, basic-auth from a separate policy).
+      // WAF is no longer carried on the proxy object — it has its own query/cache.
       if (!oldData) return newItem;
 
       return {
         ...newItem,
-        ...(oldData.trafficProtectionMode !== undefined && {
-          trafficProtectionMode: oldData.trafficProtectionMode,
-          paranoiaLevels: oldData.paranoiaLevels,
-        }),
         ...(oldData.enableHttpRedirect !== undefined && {
           enableHttpRedirect: oldData.enableHttpRedirect,
         }),

--- a/app/resources/http-proxies/index.ts
+++ b/app/resources/http-proxies/index.ts
@@ -34,13 +34,21 @@ export {
 } from './http-proxy.adapter';
 
 // Service exports
-export { createHttpProxyService, httpProxyKeys, type HttpProxyService } from './http-proxy.service';
+export {
+  createHttpProxyService,
+  httpProxyKeys,
+  type HttpProxyService,
+  type TrafficProtectionView,
+  type TrafficProtectionMaps,
+} from './http-proxy.service';
 
 // Query hooks exports
 export {
   useHttpProxies,
   useHttpProxiesByConnector,
   useHttpProxy,
+  useTrafficProtectionPolicies,
+  useTrafficProtectionPolicy,
   useCreateHttpProxy,
   useUpdateHttpProxy,
   useDeleteHttpProxy,

--- a/app/routes/org/detail/team/index.tsx
+++ b/app/routes/org/detail/team/index.tsx
@@ -1,3 +1,4 @@
+import { ChipsOverflow } from '@/components/chips-overflow';
 import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
 import { ProfileIdentity } from '@/components/profile-identity';
 import { RestrictedState } from '@/components/restricted-state/restricted-state';
@@ -10,6 +11,7 @@ import { buildOrganizationNamespace } from '@/utils/common';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
+import { toTitleCase } from '@/utils/helpers/text.helper';
 import { Badge } from '@datum-cloud/datum-ui/badge';
 import { Icon } from '@datum-cloud/datum-ui/icons';
 import { toast } from '@datum-cloud/datum-ui/toast';
@@ -321,6 +323,18 @@ export default function OrgTeamPage() {
             </div>
           );
         },
+      },
+      {
+        header: 'Roles',
+        accessorKey: 'roles',
+        cell: ({ row }) =>
+          (row.original.roles ?? [])?.length > 0 ? (
+            <ChipsOverflow
+              items={(row.original.roles ?? [])?.map((role) => toTitleCase(role.name))}
+              maxVisible={2}
+              theme="outline"
+            />
+          ) : null,
       },
       createActionsColumn<ITeamMember>((row) => [
         // Resend invitation (for pending invites only)

--- a/app/routes/project/detail/edge/detail/layout.tsx
+++ b/app/routes/project/detail/edge/detail/layout.tsx
@@ -1,6 +1,8 @@
+import { RestrictedState } from '@/components/restricted-state/restricted-state';
 import { type SubNavigationTab } from '@/components/sub-navigation';
 import { ProxyHeaderActions } from '@/features/edge/proxy/proxy-header-actions';
 import { SubLayout } from '@/layouts';
+import { gateRouteAccess } from '@/modules/rbac/server/check-permission';
 import { createHttpProxyService, type HttpProxy, useHttpProxy } from '@/resources/http-proxies';
 import { paths } from '@/utils/config/paths.config';
 import { BadRequestError, NotFoundError, withLoaderErrors } from '@/utils/errors';
@@ -16,20 +18,41 @@ import {
   useParams,
 } from 'react-router';
 
+type LayoutLoaderData = { restricted: true } | { restricted: false; proxy: HttpProxy };
+
 export const handle = {
-  breadcrumb: (loaderData: HttpProxy) => <span>{loaderData?.name}</span>,
+  breadcrumb: (loaderData: LayoutLoaderData | undefined) => {
+    const name = loaderData && !loaderData.restricted ? loaderData.proxy?.name : undefined;
+    return <span>{name ?? 'AI Edge'}</span>;
+  },
 };
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ loaderData }) => {
-  const httpProxy = loaderData as HttpProxy;
-  return metaObject(httpProxy?.name || 'Proxy');
+  const name = loaderData && !loaderData.restricted ? loaderData.proxy?.name : undefined;
+  return metaObject(name || 'Proxy');
 });
 
-export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
+const _loader = async ({ params }: LoaderFunctionArgs) => {
   const { projectId, proxyId } = params;
 
   if (!projectId || !proxyId) {
     throw new BadRequestError('Project ID and proxy ID are required');
+  }
+
+  // Access gate first — skip the proxy fetch if the user can't view it.
+  // For project-scoped checks the control-plane base is resolved from
+  // `projectId`; the first arg (organizationId) is unused for this scope.
+  const canView = await gateRouteAccess(projectId, {
+    resource: 'httpproxies',
+    verb: 'get',
+    group: 'networking.datumapis.com',
+    namespace: 'default',
+    scope: 'project',
+    projectId,
+  });
+
+  if (!canView) {
+    return data({ restricted: true as const });
   }
 
   // Services now use global axios client with AsyncLocalStorage
@@ -41,21 +64,37 @@ export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) =>
     throw new NotFoundError('AI Edge', proxyId);
   }
 
-  return data(httpProxy);
-});
+  return data({ restricted: false as const, proxy: httpProxy });
+};
+
+export const loader = withLoaderErrors(_loader);
 
 export default function HttpProxyDetailLayout() {
+  const loaderData = useLoaderData<typeof loader>();
+
+  if (loaderData.restricted) {
+    return (
+      <RestrictedState
+        title="Access restricted"
+        message="You don't have permission to view this AI Edge."
+      />
+    );
+  }
+
+  return <HttpProxyDetailLayoutInner proxy={loaderData.proxy} />;
+}
+
+function HttpProxyDetailLayoutInner({ proxy }: { proxy: HttpProxy }) {
   const { projectId, proxyId } = useParams();
-  const httpProxy = useLoaderData<typeof loader>();
 
   // Seed cache synchronously with SSR data (eliminates skeleton flash on first render)
   useHttpProxy(projectId ?? '', proxyId ?? '', {
-    initialData: httpProxy,
+    initialData: proxy,
     initialDataUpdatedAt: Date.now(),
   });
 
   const navItems: SubNavigationTab[] = useMemo(() => {
-    const id = proxyId ?? httpProxy?.name ?? '';
+    const id = proxyId ?? proxy?.name ?? '';
     return [
       {
         label: 'Overview',
@@ -72,12 +111,12 @@ export default function HttpProxyDetailLayout() {
         }),
       },
     ];
-  }, [projectId, proxyId, httpProxy?.name]);
+  }, [projectId, proxyId, proxy?.name]);
 
   return (
     <SubLayout
-      title={httpProxy.chosenName || httpProxy?.name}
-      actions={httpProxy && <ProxyHeaderActions projectId={projectId ?? ''} proxy={httpProxy} />}
+      title={proxy.chosenName || proxy?.name}
+      actions={proxy && <ProxyHeaderActions projectId={projectId ?? ''} proxy={proxy} />}
       navItems={navItems}>
       <Outlet />
     </SubLayout>

--- a/app/routes/project/detail/edge/detail/overview.tsx
+++ b/app/routes/project/detail/edge/detail/overview.tsx
@@ -10,7 +10,12 @@ import { HttpProxyHostnamesCard } from '@/features/edge/proxy/overview/hostnames
 import { HttpProxyOriginsCard } from '@/features/edge/proxy/overview/origins-card';
 import { MetricsProvider } from '@/modules/metrics';
 import { usePermission } from '@/modules/rbac';
-import { type HttpProxy, useHttpProxy, useHttpProxyWatch } from '@/resources/http-proxies';
+import {
+  type HttpProxy,
+  useHttpProxy,
+  useHttpProxyWatch,
+  useTrafficProtectionPolicy,
+} from '@/resources/http-proxies';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
 import { NotFoundError } from '@/utils/errors';
@@ -21,6 +26,7 @@ import { Icon } from '@datum-cloud/datum-ui/icons';
 import { LoaderOverlay } from '@datum-cloud/datum-ui/loader-overlay';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { ChartSplineIcon } from 'lucide-react';
+import { useMemo } from 'react';
 import { useNavigate, useParams, useRouteLoaderData } from 'react-router';
 
 export default function HttpProxyOverviewPage() {
@@ -42,7 +48,47 @@ export default function HttpProxyOverviewPage() {
     { group: 'networking.datumapis.com', namespace: 'default', scope: 'project' }
   );
 
-  const effectiveProxy = httpProxy ?? loaderData;
+  // WAF view permission is re-validated on every mount (staleTime 0) so the gate
+  // never renders from a stale cached result.
+  const {
+    hasPermission: canViewWaf,
+    isLoading: wafPermLoading,
+    isFetching: wafPermFetching,
+  } = usePermission('trafficprotectionpolicies', 'get', {
+    group: 'networking.datumapis.com',
+    namespace: 'default',
+    scope: 'project',
+    staleTime: 0,
+    refetchOnMount: 'always',
+  });
+
+  // WAF is fetched separately and only when viewable, then merged onto the proxy
+  // so child cards/metrics keep reading `trafficProtectionMode` unchanged.
+  const {
+    data: waf,
+    isError: wafError,
+    isLoading: wafDataLoading,
+    isFetching: wafDataFetching,
+  } = useTrafficProtectionPolicy(projectId ?? '', proxyId ?? '', {
+    staleTime: 0,
+    refetchOnMount: 'always',
+    enabled: canViewWaf,
+    retry: false,
+  });
+
+  // Still resolving permission or WAF data (including mount re-validation) — let
+  // the card show a skeleton instead of a possibly-stale verdict.
+  const wafPending =
+    wafPermLoading || wafPermFetching || (canViewWaf && (wafDataLoading || wafDataFetching));
+
+  const baseProxy = httpProxy ?? loaderData;
+  const effectiveProxy = useMemo<HttpProxy | undefined>(
+    () =>
+      baseProxy
+        ? { ...baseProxy, trafficProtectionMode: waf?.mode, paranoiaLevels: waf?.paranoiaLevels }
+        : baseProxy,
+    [baseProxy, waf]
+  );
 
   const { confirmDelete, isPending: isDeleting } = useDeleteProxy(projectId ?? '', {
     onSuccess: () => {
@@ -62,7 +108,12 @@ export default function HttpProxyOverviewPage() {
           <HttpProxyGeneralCard proxy={effectiveProxy} />
         </Col>
         <Col span={24} lg={12}>
-          <HttpProxyConfigCard proxy={effectiveProxy} projectId={projectId} />
+          <HttpProxyConfigCard
+            proxy={effectiveProxy}
+            projectId={projectId}
+            canViewWaf={canViewWaf && !wafError}
+            wafPending={wafPending}
+          />
         </Col>
         <Col span={24} lg={12}>
           <HttpProxyHostnamesCard proxy={effectiveProxy} projectId={projectId} />

--- a/app/routes/project/detail/edge/detail/overview.tsx
+++ b/app/routes/project/detail/edge/detail/overview.tsx
@@ -1,4 +1,5 @@
 import { DangerCard } from '@/components/danger-card/danger-card';
+import { RestrictedOverlay } from '@/components/restricted-overlay/restricted-overlay';
 import { useDeleteProxy } from '@/features/edge/proxy/hooks/use-delete-proxy';
 import { HttpProxyEdgeRequests } from '@/features/edge/proxy/metrics/edge-requests';
 import { HttpProxyWafEvents } from '@/features/edge/proxy/metrics/waf-events';
@@ -8,6 +9,7 @@ import { HttpProxyGeneralCard } from '@/features/edge/proxy/overview/general-car
 import { HttpProxyHostnamesCard } from '@/features/edge/proxy/overview/hostnames-card';
 import { HttpProxyOriginsCard } from '@/features/edge/proxy/overview/origins-card';
 import { MetricsProvider } from '@/modules/metrics';
+import { usePermission } from '@/modules/rbac';
 import { type HttpProxy, useHttpProxy, useHttpProxyWatch } from '@/resources/http-proxies';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
@@ -16,6 +18,7 @@ import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
 import { Icon } from '@datum-cloud/datum-ui/icons';
+import { LoaderOverlay } from '@datum-cloud/datum-ui/loader-overlay';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { ChartSplineIcon } from 'lucide-react';
 import { useNavigate, useParams, useRouteLoaderData } from 'react-router';
@@ -32,6 +35,12 @@ export default function HttpProxyOverviewPage() {
   });
 
   useHttpProxyWatch(projectId ?? '', proxyId ?? '');
+
+  const { hasPermission: canDelete, isLoading: deleteLoading } = usePermission(
+    'httpproxies',
+    'delete',
+    { group: 'networking.datumapis.com', namespace: 'default', scope: 'project' }
+  );
 
   const effectiveProxy = httpProxy ?? loaderData;
 
@@ -93,7 +102,15 @@ export default function HttpProxyOverviewPage() {
             loading={isDeleting}
             onDelete={() => confirmDelete(effectiveProxy)}
             data-e2e="delete-ai-edge-button"
-          />
+            actionHidden={deleteLoading || !canDelete}>
+            {deleteLoading ? (
+              <LoaderOverlay />
+            ) : (
+              !canDelete && (
+                <RestrictedOverlay message="You don't have permission to delete this AI Edge" />
+              )
+            )}
+          </DangerCard>
         </Col>
       </Row>
     </MetricsProvider>

--- a/app/routes/project/detail/edge/index.tsx
+++ b/app/routes/project/detail/edge/index.tsx
@@ -9,12 +9,13 @@ import {
   HttpProxyFormDialog,
   type HttpProxyFormDialogRef,
 } from '@/features/edge/proxy/proxy-form-dialog';
-import { usePermissionCheck, PermissionButton } from '@/modules/rbac';
+import { usePermissionCheck, usePermission, PermissionButton } from '@/modules/rbac';
 import { ControlPlaneStatus } from '@/resources/base';
 import {
   type HttpProxy,
   useHttpProxies,
   useHttpProxiesWatch,
+  useTrafficProtectionPolicies,
   formatWafProtectionDisplay,
   getCertificatesReadyCondition,
   getCertificatesReadyDisplay,
@@ -26,7 +27,7 @@ import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helpe
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Badge } from '@datum-cloud/datum-ui/badge';
-import { Icon } from '@datum-cloud/datum-ui/icons';
+import { Icon, SpinnerIcon } from '@datum-cloud/datum-ui/icons';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
 import { ColumnDef } from '@tanstack/react-table';
@@ -69,9 +70,29 @@ export default function HttpProxyPage() {
       scope: 'project',
     },
   ]);
-  const canList = permissions['httpproxies:list']?.allowed ?? false;
-  const canCreate = permissions['httpproxies:create']?.allowed ?? false;
-  const canDelete = permissions['httpproxies:delete']?.allowed ?? false;
+  const { canList, canCreate, canDelete } = useMemo(
+    () => ({
+      canList: permissions['httpproxies:list']?.allowed ?? false,
+      canCreate: permissions['httpproxies:create']?.allowed ?? false,
+      canDelete: permissions['httpproxies:delete']?.allowed ?? false,
+    }),
+    [permissions]
+  );
+
+  // WAF view permission is checked on its own and re-validated on every mount
+  // (staleTime 0) so the gate never renders a verdict from a stale cached result.
+  const {
+    hasPermission: canViewWaf,
+    isLoading: wafPermLoading,
+    isFetching: wafPermFetching,
+  } = usePermission('trafficprotectionpolicies', 'list', {
+    group: 'networking.datumapis.com',
+    namespace: 'default',
+    scope: 'project',
+    enabled: canList,
+    staleTime: 0,
+    refetchOnMount: 'always',
+  });
 
   useHttpProxiesWatch(projectId, { enabled: canList });
 
@@ -80,6 +101,26 @@ export default function HttpProxyPage() {
     staleTime: QUERY_STALE_TIME,
     enabled: canList,
   });
+
+  // WAF modes are fetched separately, only when viewable, and re-validated on
+  // mount so a stale cached map can't drive a wrong "Disabled".
+  const {
+    data: wafMaps,
+    isError: wafError,
+    isLoading: wafLoading,
+    isFetching: wafFetching,
+  } = useTrafficProtectionPolicies(projectId, {
+    staleTime: 0,
+    refetchOnMount: 'always',
+    enabled: canList && canViewWaf,
+    retry: false,
+  });
+  // While the permission check or the WAF fetch is in flight (including mount
+  // re-validation) we don't yet know the verdict — show a spinner instead of
+  // guessing. Only treat "Disabled" as trustworthy once WAF data has loaded.
+  const wafPending =
+    wafPermLoading || wafPermFetching || (canViewWaf && (wafLoading || wafFetching));
+  const wafReady = canViewWaf && !wafError && !wafLoading && !!wafMaps;
 
   const proxyFormRef = useRef<HttpProxyFormDialogRef>(null);
 
@@ -206,12 +247,49 @@ export default function HttpProxyPage() {
         accessorKey: 'trafficProtectionMode',
         meta: { tooltip: 'What level of WAF protection is applied to this Edge' },
         cell: ({ row }) => {
+          // Still resolving permissions or WAF data — show a spinner, not a verdict.
+          if (wafPending) {
+            return (
+              <div className="flex items-center px-1">
+                <SpinnerIcon size="sm" />
+              </div>
+            );
+          }
+          if (!canViewWaf) {
+            return (
+              <Tooltip message="You don't have permission to view WAF protection">
+                <Badge
+                  type="quaternary"
+                  theme="outline"
+                  className="text-muted-foreground rounded-xl text-xs font-normal">
+                  &mdash;
+                </Badge>
+              </Tooltip>
+            );
+          }
+          // WAF fetch failed — don't imply "Disabled".
+          if (!wafReady) {
+            return (
+              <Badge
+                type="quaternary"
+                theme="outline"
+                className="text-muted-foreground rounded-xl text-xs font-normal">
+                &mdash;
+              </Badge>
+            );
+          }
+          const name = row.original.name;
+          const proxyWithWaf: HttpProxy = {
+            ...row.original,
+            trafficProtectionMode: wafMaps.modeByName.get(name),
+            paranoiaLevels: wafMaps.paranoiaByName.get(name),
+          };
           return (
             <Badge
               type="quaternary"
               theme="outline"
               className="rounded-xl text-xs font-normal capitalize">
-              {formatWafProtectionDisplay(row.original)}
+              {formatWafProtectionDisplay(proxyWithWaf)}
             </Badge>
           );
         },
@@ -244,7 +322,7 @@ export default function HttpProxyPage() {
         },
       ]),
     ],
-    [projectId, navigate, confirmDelete, canDelete]
+    [projectId, navigate, confirmDelete, canDelete, canViewWaf, wafPending, wafReady, wafMaps]
   );
 
   if (!permLoading && !canList) {

--- a/app/routes/project/detail/edge/index.tsx
+++ b/app/routes/project/detail/edge/index.tsx
@@ -1,6 +1,7 @@
 import { BadgeCopy } from '@/components/badge/badge-copy';
 import { BadgeStatus } from '@/components/badge/badge-status';
 import { DateTime } from '@/components/date-time';
+import { RestrictedState } from '@/components/restricted-state/restricted-state';
 import { createActionsColumn, Table } from '@/components/table';
 import { useDeleteProxy } from '@/features/edge/proxy/hooks/use-delete-proxy';
 import { ProxySparkline } from '@/features/edge/proxy/metrics/proxy-sparkline';
@@ -8,6 +9,7 @@ import {
   HttpProxyFormDialog,
   type HttpProxyFormDialogRef,
 } from '@/features/edge/proxy/proxy-form-dialog';
+import { usePermissionCheck, PermissionButton } from '@/modules/rbac';
 import { ControlPlaneStatus } from '@/resources/base';
 import {
   type HttpProxy,
@@ -24,7 +26,6 @@ import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helpe
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Badge } from '@datum-cloud/datum-ui/badge';
-import { Button } from '@datum-cloud/datum-ui/button';
 import { Icon } from '@datum-cloud/datum-ui/icons';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
@@ -45,11 +46,39 @@ export default function HttpProxyPage() {
   }
   const navigate = useNavigate();
 
-  useHttpProxiesWatch(projectId);
+  const { permissions, isLoading: permLoading } = usePermissionCheck([
+    {
+      resource: 'httpproxies',
+      verb: 'list',
+      group: 'networking.datumapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+    {
+      resource: 'httpproxies',
+      verb: 'create',
+      group: 'networking.datumapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+    {
+      resource: 'httpproxies',
+      verb: 'delete',
+      group: 'networking.datumapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+  ]);
+  const canList = permissions['httpproxies:list']?.allowed ?? false;
+  const canCreate = permissions['httpproxies:create']?.allowed ?? false;
+  const canDelete = permissions['httpproxies:delete']?.allowed ?? false;
+
+  useHttpProxiesWatch(projectId, { enabled: canList });
 
   const { data, isPending } = useHttpProxies(projectId, {
     refetchOnMount: false,
     staleTime: QUERY_STALE_TIME,
+    enabled: canList,
   });
 
   const proxyFormRef = useRef<HttpProxyFormDialogRef>(null);
@@ -210,12 +239,22 @@ export default function HttpProxyPage() {
         {
           label: 'Delete',
           variant: 'destructive',
+          hidden: () => !canDelete,
           onClick: (row) => confirmDelete(row),
         },
       ]),
     ],
-    [projectId, navigate, confirmDelete]
+    [projectId, navigate, confirmDelete, canDelete]
   );
+
+  if (!permLoading && !canList) {
+    return (
+      <RestrictedState
+        title="Access restricted"
+        message="You don't have permission to view AI Edge."
+      />
+    );
+  }
 
   return (
     <>
@@ -235,19 +274,27 @@ export default function HttpProxyPage() {
         description="Give every agent or app a global edge to absorb attacks, interact with the broader internet, and safely route traffic to backend services."
         search="Search"
         empty={{
-          title: "let's add an AI Edge to get you started",
-          actions: [
-            {
-              type: 'button',
-              label: 'New',
-              onClick: () => proxyFormRef.current?.show(),
-              icon: <Icon icon={PlusIcon} className="size-3" />,
-            },
-          ],
+          title: canCreate ? "let's add an AI Edge to get you started" : 'No AI Edge yet',
+          actions: canCreate
+            ? [
+                {
+                  type: 'button',
+                  label: 'New',
+                  onClick: () => proxyFormRef.current?.show(),
+                  icon: <Icon icon={PlusIcon} className="size-3" />,
+                },
+              ]
+            : [],
         }}
         actions={[
-          <Button
+          <PermissionButton
             key="create-edge"
+            resource="httpproxies"
+            verb="create"
+            group="networking.datumapis.com"
+            namespace="default"
+            scope="project"
+            deniedReason="You don't have permission to create an AI Edge"
             type="primary"
             theme="solid"
             size="small"
@@ -256,7 +303,7 @@ export default function HttpProxyPage() {
             onClick={() => proxyFormRef.current?.show()}>
             <Icon icon={PlusIcon} className="size-4" />
             New
-          </Button>,
+          </PermissionButton>,
         ]}
       />
 

--- a/app/utils/helpers/text.helper.ts
+++ b/app/utils/helpers/text.helper.ts
@@ -33,15 +33,15 @@ export function getInitials(name: string): string {
 }
 
 /**
- * Converts a string to title case, handling camelCase and snake_case
+ * Converts a string to title case, handling camelCase, snake_case, and kebab-case
  * Useful for displaying formatted labels from code identifiers
  * @param str - The string to convert to title case
  * @returns Formatted string in title case with spaces between words
  */
 export function toTitleCase(str: string): string {
-  // Handle camelCase and snake_case by splitting on capitals and underscores
+  // Handle camelCase, snake_case, and kebab-case by splitting on capitals, underscores, and dashes
   return str
-    .split(/(?=[A-Z])|_/)
+    .split(/(?=[A-Z])|[_-]/)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ');
 }


### PR DESCRIPTION
## Summary

Extends the RBAC module (merged in #1269) to the first **project-scoped** surface: **AI Edge** (HTTP proxies) and all its detail routes. This is the first consumer of `scope: 'project'` and the `networking.datumapis.com` API group — the per-check engine handled both with zero module changes; only the call-site `group`/`scope` differ.

All checks: group `networking.datumapis.com`, namespace `default`, **`scope: 'project'`** (resolves to the project control-plane via the `RbacProvider` already mounted on the project layout). WAF is gated on the separate `trafficprotectionpolicies` resource.

## Coverage

| Surface | Check | Treatment |
|---|---|---|
| AI Edge list (`edge/index.tsx`) | `httpproxies·list` | bulk `usePermissionCheck`; `useHttpProxies` + watch gated `enabled: canList`; `RestrictedState` when denied; permission-aware empty copy |
| New button (header + empty action) | `httpproxies·create` | `PermissionButton` (disable + tooltip); empty action hidden when denied |
| List row Delete | `httpproxies·delete` | hidden when denied (View ungated) |
| Detail access (`edge/detail/layout.tsx`) | `httpproxies·get` | loader `gateRouteAccess` → discriminated-union + `RestrictedState`; proxy fetch skipped when denied; records denial metric |
| Header Delete (`ProxyHeaderActions`) | `httpproxies·delete` | `PermissionButton` disable + tooltip |
| Overview edits — name / host header / basic auth / hostnames / origins | `httpproxies·patch` | edit triggers disable + tooltip |
| AI Edge **WAF view** (list column + detail card) | `trafficprotectionpolicies·list` / `·get` | decoupled, permission-gated query (no request when denied); spinner while resolving; "—" + tooltip when denied; "Disabled" only after data loads |
| Overview **WAF** edit | `trafficprotectionpolicies·patch` | gated separately (disable + tooltip) |
| Overview Delete card | `httpproxies·delete` | `DangerCard actionHidden` + `RestrictedOverlay` / `LoaderOverlay` |
| Activity tab | — | covered by the shared activity error-formatter (403 → restricted message) |

## WAF decouple (follow-up)

Previously WAF (`TrafficProtectionPolicy`) was fetched **bundled** inside the proxy list/detail request, so a viewer with `httpproxies` but not `trafficprotectionpolicies` access hit a **403 that broke the whole list**. WAF is now a **separate, permission-gated query**:

- `http-proxy.service`: WAF removed from `fetchList`/`fetchOne`; added `listTrafficProtectionPolicies` / `getTrafficProtectionPolicy` (errors **surfaced**, not swallowed; 404 = "no policy"). Added WAF query keys.
- `http-proxy.queries`: `useTrafficProtectionPolicies` / `useTrafficProtectionPolicy`; WAF cache invalidation + optimistic updates wired into proxy mutations. `http-proxy.watch`: dropped dead WAF-preservation branches.
- No request is fired when the user can't view WAF; the column/card shows a permission tooltip instead of a misleading "Disabled".

## Permission freshness

The global `QueryClient` caches with `staleTime: 5min`, so a reload within that window could render a WAF verdict from a **stale cached permission**. The WAF gates now use a dedicated check with `staleTime: 0` + `refetchOnMount: 'always'` and a spinner/skeleton during re-validation, so the gate never shows a stale result. `usePermission` / `useCheckQuery` gained optional `staleTime` / `refetchOnMount` passthrough + an `isFetching` field (additive; other gates unchanged).

## Metrics 403 handling

Telemetry (Prometheus) metric widgets aren't K8s resources, so they can't be SSAR-gated. Instead they **degrade gracefully**: `usePrometheusAPIQuery` no longer retries on 403/401 (kills the retry spam), and `BaseMetric` + the proxy sparkline render a muted "no permission to view metrics" state instead of a destructive error.

## Notes / decisions

- **WAF is a distinct resource** (`trafficprotectionpolicies`) — view and edit are gated independently of `httpproxies`, so a role with one but not the other is handled accurately.
- **Detail loader** uses the standardized `gateRouteAccess` + discriminated-union + wrapper/inner-component pattern (hooks stay unconditional).
- For project-scope checks, `RbacService.resolveBaseURL` uses `projectId` to build the base, so the loader passes `projectId` as the org-id arg — verified harmless for project scope.
- TanStack Query dedupes the repeated `httpproxies/patch` checks across the overview cards into a single request (no N+1).
- **Backend follow-up (out of scope):** the deployed `gateway-viewer` role can lag the `trafficprotectionpolicies` grant, and the telemetry-viewer role can lack Prometheus access — tracked in datum-cloud/datum#235. This PR makes the frontend resilient regardless.

## Also included

- `feat(team)`: a Roles column in the org members table (`ChipsOverflow`) + `toTitleCase` kebab-case support — small, unrelated tagalong.