### PR TITLE
fix(rbac): keep PermissionButton tree stable to unblock regression suite

### DIFF
--- a/app/modules/rbac/components/PermissionButton.tsx
+++ b/app/modules/rbac/components/PermissionButton.tsx
@@ -37,17 +37,21 @@ export function PermissionButton({
   });
   const blocked = !hasPermission;
 
-  const button = (
-    <Button {...buttonProps} disabled={disabled || blocked}>
-      {children}
-    </Button>
-  );
-
-  if (!blocked) return button;
-
   const reason = isLoading
     ? 'Verifying permissions…'
     : (deniedReason ?? `You don't have permission to ${verb} ${resource}`);
 
-  return <Tooltip message={reason}>{button}</Tooltip>;
+  // Always wrap in Tooltip so the React tree stays stable across the
+  // permission-loading → permission-resolved transition. Returning a bare
+  // <Button> on the allowed branch and <Tooltip><Button/></Tooltip> on the
+  // blocked branch remounts the Button DOM node when the query resolves,
+  // which detaches it from any external reference (Cypress clicks, focus
+  // restoration, refs in parent components).
+  return (
+    <Tooltip message={reason} hidden={!blocked}>
+      <Button {...buttonProps} disabled={disabled || blocked}>
+        {children}
+      </Button>
+    </Tooltip>
+  );
 }

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -47,6 +47,40 @@ function stubAmbientApis(): void {
 
   // Marker.io feedback widget — third-party, not under test.
   cy.intercept(/api\.marker\.io/, { statusCode: 204, body: '' });
+
+  // RBAC access-review BFF (#1269). Every authenticated page fires one or
+  // both of these on mount; when they resolve, components re-render to
+  // reflect computed permission state. In the regression suite that lands
+  // mid-`cy.click()` on action buttons in `before all` hooks (most often
+  // `create-organization-button` and `create-project-button`), detaching
+  // the element and producing the "page updated while this command was
+  // executing" error.
+  //
+  // We default-allow for the regression user. Specs that legitimately test
+  // permission denial can override these intercepts locally — later
+  // `cy.intercept` calls for the same route win.
+  cy.intercept('POST', '/api/permissions/check', {
+    statusCode: 200,
+    body: { success: true, data: { allowed: true, denied: false } },
+  });
+  cy.intercept('POST', '/api/permissions/bulk-check', (req) => {
+    const checks = (req.body && Array.isArray(req.body.checks) ? req.body.checks : []) as Array<
+      Record<string, unknown>
+    >;
+    req.reply({
+      statusCode: 200,
+      body: {
+        success: true,
+        data: {
+          results: checks.map((c) => ({
+            allowed: true,
+            denied: false,
+            request: c,
+          })),
+        },
+      },
+    });
+  });
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

Fix the long-running regression-suite breakage that has gated cloud-portal's OCI bundle publish for ~6 days: every commit on main since [`cdc3fa70`](https://github.com/datum-cloud/cloud-portal/commit/cdc3fa70) has failed CI on the same `page updated while this command was executing` Cypress error in `before all` hooks, which in turn skipped `Publish Kustomize Bundles`. The bundle staging is currently pulling is from 2026-05-22.

## Root cause

`PermissionButton` structurally remounts the Button DOM node when its async `usePermission` query resolves:

```tsx
// before
const button = <Button {...buttonProps} disabled={disabled || blocked}>{children}</Button>;
if (!blocked) return button;                                    // ← bare button
return <Tooltip message={reason}>{button}</Tooltip>;            // ← Tooltip-wrapped
```

The two branches have different React roots, so when `hasPermission` flips `false → true` (loading → resolved), React unmounts the previous `<Button>` and mounts a fresh one in its place. Every external reference to the original DOM node detaches — including Cypress's click target between `.should('be.visible')` and `.click()`. The Cypress error message is the textbook symptom; it would also break parent refs, focus restoration, and any imperative DOM work on the button.

## Fix

Always wrap in `<Tooltip>` and drive popup visibility through Tooltip's existing `hidden` prop. The Button DOM node now stays in the same parent across permission state transitions.

```tsx
// after
return (
  <Tooltip message={reason} hidden={!blocked}>
    <Button {...buttonProps} disabled={disabled || blocked}>
      {children}
    </Button>
  </Tooltip>
);
```

## Defensive Cypress stubs

Also adds `/api/permissions/{check,bulk-check}` intercepts to `stubAmbientApis()` so other future `PermissionCheck` / `PermissionGate` consumers don't reintroduce a similar race in regression runs. Follows the existing pattern used for `/api/watch/stream`, `users/me/...userinvitations`, etc. Specs that genuinely test permission denial can override locally — later `cy.intercept` calls win.

## Local verification

Running with a fresh `datumctl auth get-token` against staging on my own account:

| Spec | Before fix | After fix |
| --- | --- | --- |
| `ai-edge-sticky.cy.ts` | ❌ `before each` button detach | ✅ pass |
| `domains.cy.ts` | ❌ `before all` button detach at 4s | gets past the click; downstream timeout at 90s waiting for project reconciliation (env-specific) |
| `projects.cy.ts` | ❌ `before all` button detach at 4s | gets past the click; same downstream env-specific timeout |

The remaining local failures only appear when running against staging as a non-bot account where K8s project reconciliation is slow and the 90s wait is insufficient. CI runs against the dedicated e2e bot account and should pass.

## Why this also matters outside Cypress

Anything holding a reference to the rendered button across the loading-resolved boundary breaks: refs (`<PermissionButton ref={…}>`), focus restoration after dialog close, third-party tooltips/popovers anchored to the button DOM, screen-reader focus tracking. The fix is a correctness fix that happens to also unblock CI.

## Test plan

- [x] `bun x tsc --noEmit` clean
- [x] `bun x eslint` clean
- [x] `bun x prettier --check` clean
- [x] `ai-edge-sticky.cy.ts` passes locally (was failing on main)
- [ ] CI `E2E Regression (1)` and `(3)` shards pass
- [ ] `Publish Kustomize Bundles` and `Publish Container Image` jobs run (no longer skipped by Final Status Check)
- [ ] OCIRepository in staging picks up the new `*-main-*` tag → `cloud-portal-milo-services` reconciles the new bundle (which contains the assistant ServiceConfiguration from #1272) → services-operator fans out the meters
