### PR TITLE
refactor(rbac): keep PermissionButton bare on the allowed path

### DIFF
--- a/app/modules/rbac/components/PermissionButton.tsx
+++ b/app/modules/rbac/components/PermissionButton.tsx
@@ -35,23 +35,23 @@ export function PermissionButton({
     scope,
     projectId,
   });
-  const blocked = !hasPermission;
 
-  const reason = isLoading
-    ? 'Verifying permissions…'
-    : (deniedReason ?? `You don't have permission to ${verb} ${resource}`);
-
-  // Always wrap in Tooltip so the React tree stays stable across the
-  // permission-loading → permission-resolved transition. Returning a bare
-  // <Button> on the allowed branch and <Tooltip><Button/></Tooltip> on the
-  // blocked branch remounts the Button DOM node when the query resolves,
-  // which detaches it from any external reference (Cypress clicks, focus
-  // restoration, refs in parent components).
-  return (
-    <Tooltip message={reason} hidden={!blocked}>
-      <Button {...buttonProps} disabled={disabled || blocked}>
-        {children}
-      </Button>
-    </Tooltip>
+  const button = (
+    <Button {...buttonProps} disabled={disabled || !hasPermission}>
+      {children}
+    </Button>
   );
+
+  // Render the bare Button while the check is in flight AND once it resolves to
+  // allowed, toggling only `disabled`. The allowed transition therefore never
+  // remounts the node — that remount is what detached in-flight clicks (the e2e
+  // "page updated while executing" flake addressed in #1273) — and the permitted
+  // case keeps its natural layout (no Tooltip wrapper, so `w-full sm:w-auto`
+  // create buttons stay full-width on mobile and pages avoid Radix Tooltip
+  // overhead on every gated button). Only a definitively denied action gets
+  // wrapped in the explanatory Tooltip; it stays disabled, so nothing clicks it.
+  if (isLoading || hasPermission) return button;
+
+  const reason = deniedReason ?? `You don't have permission to ${verb} ${resource}`;
+  return <Tooltip message={reason}>{button}</Tooltip>;
 }

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -346,17 +346,37 @@ Cypress.Commands.add(
     cy.get('body', { timeout: 30000 }).then(($body) => {
       const hasToolbarCreate = $body.find('[data-e2e="create-project-button"]').length > 0;
       if (hasToolbarCreate) {
-        cy.get('[data-e2e="create-project-button"]').should('be.visible').click();
+        // create-project-button is a PermissionButton: while the projects:create
+        // permission check is in flight it renders disabled (wrapped in a Tooltip),
+        // then swaps to a bare, enabled button once the check resolves. Clicking
+        // before the check settles detaches the node mid-click ("page updated while
+        // executing"). Wait for it to become enabled, then re-query and click so the
+        // click targets the post-swap, stable node.
+        cy.get('[data-e2e="create-project-button"]').should('be.visible').and('not.be.disabled');
+        cy.get('[data-e2e="create-project-button"]').click();
         return;
       }
 
       // Fresh org empty state uses a generic "Create project" button without data-e2e.
       cy.contains('button', /^Create project$/i, { timeout: 30000 })
         .should('be.visible')
-        .click();
+        .and('not.be.disabled');
+      cy.contains('button', /^Create project$/i).click();
     });
     cy.get('[data-e2e="create-project-name-input"]').type(displayName);
+
+    // The projects list only auto-refreshes through the real-time watch
+    // (create → waitForProjectReady → invalidateQueries). That watch is inert
+    // under the e2e ambient-API stubs, so the new card never appears on its own.
+    // Wait for the create API to succeed, then reload to force a fresh list GET —
+    // which returns the project even while it is still reconciling — so we can
+    // read its resource ID.
+    cy.intercept('POST', '**/control-plane/**/v1alpha1/projects').as('createProjectReq');
     cy.contains('button', 'Confirm').click();
+    cy.wait('@createProjectReq', { timeout: 30000 })
+      .its('response.statusCode')
+      .should('be.oneOf', [200, 201]);
+    cy.reload();
 
     return cy
       .contains('[data-e2e="project-card"]', displayName, { timeout: 90000 })


### PR DESCRIPTION
## Summary

Follow-up to #1273 (which fixed the regression-suite flake by always wrapping `PermissionButton` in a Tooltip). That fix is correct but pays Radix Tooltip overhead on every gated button — including the common permitted case — and changes the rendered DOM enough to shrink `w-full sm:w-auto` create buttons to content-width on mobile (the wrapper `<span class="relative inline-flex">` becomes the flex child, and `w-full` resolves against it).

This PR reaches the same DOM-stability goal a different way:

- Render the bare `<Button>` while the permission check is in flight **and** once it resolves to allowed, toggling only `disabled`. The loading → allowed transition no longer remounts the node — which was the root cause of the e2e "page updated while executing" detach.
- Wrap in the explanatory Tooltip **only** when the check is definitively denied. Denied buttons stay disabled, so nothing clicks them.

Net effect:

- Common path (permitted user): zero Radix Tooltip render/mount cost per gated button. Especially noticeable on list/table pages with one gated button per row.
- Allowed buttons keep their natural layout — no mobile `w-full` regression.
- Denied buttons render exactly as they shipped today.
- The RBAC e2e stubs from #1273 are preserved (still default-allow regression).

## Also in this PR — `createProjectInOrg` cypress hardening

The shared `before` hook in regression specs (`cy.ensureSharedResources()` → `createProjectInOrg`) had a second failure mode independent of the PermissionButton flake:

- After the create POST returns 201, the new project card only renders via `create → waitForProjectReady (watch SSE) → invalidateQueries(projectKeys.list) → refetch`. When the watch stream is slow/inert (e.g. local dev, or any future change that stubs it), the list never refetches and the card never appears within 90 s.

Hardened the helper to:

1. Wait for the create button to be `not.be.disabled` and re-query before clicking (defense in depth even with the RBAC stubs in place).
2. After Confirm, `cy.wait` the create POST then `cy.reload()` to force a fresh list GET — the project is listable as soon as it exists (even while still reconciling), independent of the watch.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx cypress run --spec cypress/e2e/regression/http-proxies.cy.ts` — 3/3 passing, shared org cleanup OK
- [ ] Manual: spot-check that a denied `PermissionButton` (e.g. on a route the test account doesn't have permission for) still shows the explanatory Tooltip
- [ ] CI regression suite green

## Notes

- No public-API change to `PermissionButton`. Drop-in replacement.
- The conditional branch (`if (isLoading || hasPermission) return button;`) adds one tiny condition vs. #1273's single return path; the runtime/footprint win on every gated render is the trade.