### PR TITLE
feat(rbac): gate connectors + DNS zones/records behind project-scoped permissions

### DIFF
--- a/app/features/edge/dns-zone/overview/description-form-card.tsx
+++ b/app/features/edge/dns-zone/overview/description-form-card.tsx
@@ -10,13 +10,16 @@ import {
 } from '@datum-cloud/datum-ui/card';
 import { Form } from '@datum-cloud/datum-ui/form';
 import { toast } from '@datum-cloud/datum-ui/toast';
+import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
 
 export const DescriptionFormCard = ({
   projectId,
   defaultValue,
+  canEdit = true,
 }: {
   projectId: string;
   defaultValue: DnsZone;
+  canEdit?: boolean;
 }) => {
   const updateDnsZoneMutation = useUpdateDnsZone(projectId, defaultValue?.name ?? '', {
     onSuccess: () => {
@@ -62,7 +65,12 @@ export const DescriptionFormCard = ({
               </Form.Field>
 
               <Form.Field name="description">
-                <Form.Input type="text" placeholder="e.g. Our main marketing site" autoFocus />
+                <Form.Input
+                  type="text"
+                  placeholder="e.g. Our main marketing site"
+                  autoFocus
+                  disabled={!canEdit}
+                />
               </Form.Field>
             </CardContent>
             <CardFooter className="flex flex-col-reverse gap-2 border-t pt-4 sm:flex-row sm:justify-end">
@@ -70,7 +78,7 @@ export const DescriptionFormCard = ({
                 htmlType="button"
                 type="quaternary"
                 theme="outline"
-                disabled={isSubmitting}
+                disabled={isSubmitting || !canEdit}
                 size="xs"
                 className="w-full sm:w-auto"
                 onClick={() => {
@@ -78,9 +86,17 @@ export const DescriptionFormCard = ({
                 }}>
                 Cancel
               </Button>
-              <Form.Submit size="xs" className="w-full sm:w-auto" loadingText="Saving">
-                Save
-              </Form.Submit>
+              {canEdit ? (
+                <Form.Submit size="xs" className="w-full sm:w-auto" loadingText="Saving">
+                  Save
+                </Form.Submit>
+              ) : (
+                <Tooltip message="You don't have permission to edit this DNS zone" side="top">
+                  <Form.Submit size="xs" className="w-full sm:w-auto" loadingText="Saving" disabled>
+                    Save
+                  </Form.Submit>
+                </Tooltip>
+              )}
             </CardFooter>
           </>
         )}

--- a/app/routes/project/detail/connectors/index.tsx
+++ b/app/routes/project/detail/connectors/index.tsx
@@ -1,10 +1,12 @@
 import { BadgeCopy } from '@/components/badge/badge-copy';
 import { DateTime } from '@/components/date-time';
 import { getOsLabel, OsIcon } from '@/components/icon/os-icon';
+import { RestrictedState } from '@/components/restricted-state/restricted-state';
 import { StatusPulseDot } from '@/components/status-pulse-dot';
 import { Table } from '@/components/table';
 import { ConnectorDownloadCard } from '@/features/connectors/connector-download-card';
 import { ConnectorSparkline } from '@/features/edge/proxy/metrics/connector-sparkline';
+import { usePermissionCheck } from '@/modules/rbac';
 import { ControlPlaneStatus } from '@/resources/base';
 import { type Connector, useConnectors, useConnectorsWatch } from '@/resources/connectors';
 import { type HttpProxy, useHttpProxies, useHttpProxiesWatch } from '@/resources/http-proxies';
@@ -68,18 +70,44 @@ export default function ConnectorsPage() {
 
   const isDownloadVisible = !downloadDismissed && dismissFetcher.state === 'idle';
 
-  useConnectorsWatch(projectId);
+  const { permissions, isLoading: permLoading } = usePermissionCheck([
+    {
+      resource: 'connectors',
+      verb: 'list',
+      group: 'networking.datumapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+    {
+      resource: 'httpproxies',
+      verb: 'list',
+      group: 'networking.datumapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+  ]);
+  const { canList, canListProxies } = useMemo(
+    () => ({
+      canList: permissions['connectors:list']?.allowed ?? false,
+      canListProxies: permissions['httpproxies:list']?.allowed ?? false,
+    }),
+    [permissions]
+  );
 
-  useHttpProxiesWatch(projectId);
+  useConnectorsWatch(projectId, { enabled: canList });
+
+  useHttpProxiesWatch(projectId, { enabled: canListProxies });
 
   const { data: connectorsData } = useConnectors(projectId, {
     refetchOnMount: false,
     staleTime: QUERY_STALE_TIME,
+    enabled: canList,
   });
 
   const { data: proxies } = useHttpProxies(projectId, {
     refetchOnMount: false,
     staleTime: QUERY_STALE_TIME,
+    enabled: canListProxies,
   });
 
   const tableData = useMemo((): ConnectorWithProxies[] => {
@@ -282,6 +310,15 @@ export default function ConnectorsPage() {
     ],
     [projectId]
   );
+
+  if (!permLoading && !canList) {
+    return (
+      <RestrictedState
+        title="Access restricted"
+        message="You don't have permission to view connectors."
+      />
+    );
+  }
 
   return (
     <Table.Client

--- a/app/routes/project/detail/dns-zones/detail/dns-records.tsx
+++ b/app/routes/project/detail/dns-zones/detail/dns-records.tsx
@@ -1,4 +1,5 @@
 import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
+import { RestrictedState } from '@/components/restricted-state/restricted-state';
 import {
   DnsRecordAiEdgeCell,
   DnsRecordTable,
@@ -17,6 +18,7 @@ import {
 } from '@/features/edge/dns-records/utils';
 import { useBreakpoint } from '@/hooks/use-breakpoint';
 import { AnalyticsAction, useAnalytics } from '@/modules/fathom';
+import { usePermissionCheck, PermissionButton } from '@/modules/rbac';
 import {
   IFlattenedDnsRecord,
   dnsRecordKeys,
@@ -35,10 +37,10 @@ import {
 } from '@/resources/http-proxies';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
+import { BadRequestError } from '@/utils/errors';
 import { getRecordHostname } from '@/utils/helpers/dns';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { generateId, generateRandomString } from '@/utils/helpers/text.helper';
-import { Button } from '@datum-cloud/datum-ui/button';
 import {
   useDataTablePagination,
   useDataTableSearch,
@@ -78,7 +80,13 @@ function AddDnsRecordButton({ onClick }: { onClick: () => void }) {
   };
 
   return (
-    <Button
+    <PermissionButton
+      resource="dnsrecordsets"
+      verb="create"
+      group="dns.networking.miloapis.com"
+      namespace="default"
+      scope="project"
+      deniedReason="You don't have permission to add a DNS record"
       htmlType="button"
       type="primary"
       theme="solid"
@@ -87,34 +95,88 @@ function AddDnsRecordButton({ onClick }: { onClick: () => void }) {
       onClick={handleClick}>
       <Icon icon={PlusIcon} className="size-4" />
       Add record
-    </Button>
+    </PermissionButton>
   );
 }
 
 export default function DnsRecordsPage() {
-  const { dnsZone, dnsRecordSets: initialDnsRecordSets } = useRouteLoaderData(
-    'dns-zone-detail'
-  ) as {
+  const { dnsZone } = useRouteLoaderData('dns-zone-detail') as {
     dnsZone: DnsZone;
-    dnsRecordSets: IFlattenedDnsRecord[];
   };
   const { projectId, dnsZoneId } = useParams();
+  if (!projectId || !dnsZoneId) {
+    throw new BadRequestError('Project ID and DNS Zone ID are required');
+  }
+
+  // DNS records are a separate, permission-gated resource — a zone viewer may
+  // lack dnsrecordsets access. Gate the query/watch behind the SSAR so a
+  // missing permission never fires the request. The httpproxies·list check
+  // gates the AI Edge cell enrichment so a viewer without proxy access doesn't
+  // 403 on the optional `findProxyForRecord` lookup.
+  const { permissions, isLoading: permLoading } = usePermissionCheck([
+    {
+      resource: 'dnsrecordsets',
+      verb: 'list',
+      group: 'dns.networking.miloapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+    {
+      resource: 'dnsrecordsets',
+      verb: 'create',
+      group: 'dns.networking.miloapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+    {
+      resource: 'dnsrecordsets',
+      verb: 'patch',
+      group: 'dns.networking.miloapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+    {
+      resource: 'dnsrecordsets',
+      verb: 'delete',
+      group: 'dns.networking.miloapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+    {
+      resource: 'httpproxies',
+      verb: 'list',
+      group: 'networking.datumapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+  ]);
+  const { canListRecords, canCreateRecord, canPatchRecord, canDeleteRecord, canListProxies } =
+    useMemo(
+      () => ({
+        canListRecords: permissions['dnsrecordsets:list']?.allowed ?? false,
+        canCreateRecord: permissions['dnsrecordsets:create']?.allowed ?? false,
+        canPatchRecord: permissions['dnsrecordsets:patch']?.allowed ?? false,
+        canDeleteRecord: permissions['dnsrecordsets:delete']?.allowed ?? false,
+        canListProxies: permissions['httpproxies:list']?.allowed ?? false,
+      }),
+      [permissions]
+    );
 
   // Subscribe to watch for real-time updates
-  useDnsRecordsWatch(projectId ?? '', dnsZoneId ?? '');
+  useDnsRecordsWatch(projectId, dnsZoneId, { enabled: canListRecords });
 
-  // Read from React Query cache (seeded synchronously from SSR loader data)
-  const { data: queryData } = useDnsRecords(projectId ?? '', dnsZoneId, undefined, {
-    initialData: initialDnsRecordSets,
-    initialDataUpdatedAt: Date.now(),
-    refetchOnMount: false,
+  const { data: queryData = [] } = useDnsRecords(projectId, dnsZoneId, undefined, {
     staleTime: QUERY_STALE_TIME,
+    enabled: canListRecords,
   });
 
-  const { data: proxies = [] } = useHttpProxies(projectId ?? '');
+  // AI Edge enrichment is optional — only fetch when the user can list proxies
+  // (a denied viewer still sees the records table without the linked-proxy cell).
+  const { data: proxies = [] } = useHttpProxies(projectId, {
+    enabled: canListProxies,
+  });
 
-  // Use React Query data, fallback to SSR data
-  const dnsRecords = queryData ?? initialDnsRecordSets;
+  const dnsRecords = queryData;
 
   const zoneDomain = dnsZone?.domainName ?? '';
   const enrichedRecords = useMemo((): IFlattenedDnsRecord[] => {
@@ -156,11 +218,23 @@ export default function DnsRecordsPage() {
   };
 
   const handleOpenEdit = (record: IFlattenedDnsRecord) => {
+    if (!canPatchRecord) {
+      toast.error("You don't have permission to edit DNS records");
+      return;
+    }
     setInlinePosition('row');
     // Must match DnsRecordTable's `getRowId` so only the clicked row
     // (not every row sharing a recordSetName) anchors the inline panel.
     setInlineRowId(getDnsRecordRowId(record));
     setInlineOpen(true);
+  };
+
+  const handleOpenEditMobile = (record: IFlattenedDnsRecord) => {
+    if (!canPatchRecord) {
+      toast.error("You don't have permission to edit DNS records");
+      return;
+    }
+    dnsRecordModalFormRef.current?.show('edit', record);
   };
 
   const handleInlineClose = () => {
@@ -372,11 +446,20 @@ export default function DnsRecordsPage() {
       label: 'Delete',
       variant: 'destructive',
       onClick: (record) => handleDelete(record),
-      hidden: (record) => record.type === 'SOA',
+      hidden: (record) => !canDeleteRecord || record.type === 'SOA',
       disabled: (record) => isRowLocked(record),
       tooltip: (record) => record.lockReason ?? '',
     },
   ];
+
+  if (!permLoading && !canListRecords) {
+    return (
+      <RestrictedState
+        title="Access restricted"
+        message="You don't have permission to view DNS records."
+      />
+    );
+  }
 
   // Desktop layout is the SSR-safe fallback (inline panel mode)
   // Mobile layout (modal mode) resolves on the client after breakpoint check
@@ -413,15 +496,17 @@ export default function DnsRecordsPage() {
         tableTitle={{
           actions: (
             <div className="flex w-full items-center gap-2 sm:w-auto sm:gap-3">
-              <DnsRecordImportAction
-                origin={dnsZone?.domainName}
-                existingRecords={dnsRecords}
-                projectId={projectId!}
-                dnsZoneId={dnsZoneId!}
-                onSuccess={() => {
-                  // Watch will automatically update the list with real-time changes
-                }}
-              />
+              {canCreateRecord && (
+                <DnsRecordImportAction
+                  origin={dnsZone?.domainName}
+                  existingRecords={dnsRecords}
+                  projectId={projectId!}
+                  dnsZoneId={dnsZoneId!}
+                  onSuccess={() => {
+                    // Watch will automatically update the list with real-time changes
+                  }}
+                />
+              )}
               <AddDnsRecordButton onClick={handleOpenCreate} />
             </div>
           ),
@@ -472,16 +557,24 @@ export default function DnsRecordsPage() {
             tableTitle={{
               actions: (
                 <div className="flex w-full items-center gap-2 sm:w-auto sm:gap-3">
-                  <DnsRecordImportAction
-                    origin={dnsZone?.domainName}
-                    existingRecords={dnsRecords}
-                    projectId={projectId!}
-                    dnsZoneId={dnsZoneId!}
-                    onSuccess={() => {
-                      // Watch will automatically update the list with real-time changes
-                    }}
-                  />
-                  <Button
+                  {canCreateRecord && (
+                    <DnsRecordImportAction
+                      origin={dnsZone?.domainName}
+                      existingRecords={dnsRecords}
+                      projectId={projectId!}
+                      dnsZoneId={dnsZoneId!}
+                      onSuccess={() => {
+                        // Watch will automatically update the list with real-time changes
+                      }}
+                    />
+                  )}
+                  <PermissionButton
+                    resource="dnsrecordsets"
+                    verb="create"
+                    group="dns.networking.miloapis.com"
+                    namespace="default"
+                    scope="project"
+                    deniedReason="You don't have permission to add a DNS record"
                     htmlType="button"
                     type="primary"
                     theme="solid"
@@ -490,7 +583,7 @@ export default function DnsRecordsPage() {
                     onClick={() => dnsRecordModalFormRef.current?.show('create')}>
                     <Icon icon={PlusIcon} className="size-4" />
                     Add record
-                  </Button>
+                  </PermissionButton>
                 </div>
               ),
             }}
@@ -499,9 +592,7 @@ export default function DnsRecordsPage() {
             inlineRowId={inlineRowId}
             onInlineClose={handleInlineClose}
             onOpenCreate={handleOpenCreate}
-            onOpenEdit={(record) => {
-              dnsRecordModalFormRef.current?.show('edit', record);
-            }}
+            onOpenEdit={handleOpenEditMobile}
             extraRowActions={extraRowActions}
           />
         </>

--- a/app/routes/project/detail/dns-zones/detail/layout.tsx
+++ b/app/routes/project/detail/dns-zones/detail/layout.tsx
@@ -1,6 +1,8 @@
+import { RestrictedState } from '@/components/restricted-state/restricted-state';
 import { type SubNavigationTab } from '@/components/sub-navigation';
 import { SubLayout } from '@/layouts';
-import { createDnsRecordService } from '@/resources/dns-records';
+import { logger } from '@/modules/logger';
+import { gateRouteAccess } from '@/modules/rbac/server/check-permission';
 import { createDnsZoneService, type DnsZone, useDnsZone } from '@/resources/dns-zones';
 import { createDomainService, type Domain, useDomain } from '@/resources/domains';
 import { paths } from '@/utils/config/paths.config';
@@ -18,20 +20,41 @@ import {
   useParams,
 } from 'react-router';
 
+type LayoutLoaderData =
+  | { restricted: true }
+  | { restricted: false; dnsZone: DnsZone; domain: Domain | null };
+
 export const handle = {
-  breadcrumb: (data: { dnsZone: DnsZone }) => <span>{data?.dnsZone?.domainName}</span>,
+  breadcrumb: (loaderData: LayoutLoaderData | undefined) => {
+    const name = loaderData && !loaderData.restricted ? loaderData.dnsZone?.domainName : undefined;
+    return <span>{name ?? 'DNS'}</span>;
+  },
 };
 
 export const meta: MetaFunction<typeof loader> = mergeMeta(({ loaderData }) => {
-  const { dnsZone } = loaderData as { dnsZone: DnsZone };
-  return metaObject(dnsZone?.domainName || 'DNS');
+  const name = loaderData && !loaderData.restricted ? loaderData.dnsZone?.domainName : undefined;
+  return metaObject(name || 'DNS');
 });
 
-export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
+const _loader = async ({ params }: LoaderFunctionArgs) => {
   const { projectId, dnsZoneId } = params;
 
   if (!projectId || !dnsZoneId) {
     throw new BadRequestError('Project ID and DNS ID are required');
+  }
+
+  // Access gate first — skip the zone fetch if the user can't view it.
+  const canView = await gateRouteAccess(projectId, {
+    resource: 'dnszones',
+    verb: 'get',
+    group: 'dns.networking.miloapis.com',
+    namespace: 'default',
+    scope: 'project',
+    projectId,
+  });
+
+  if (!canView) {
+    return data({ restricted: true as const });
   }
 
   // Services now use global axios client with AsyncLocalStorage
@@ -57,21 +80,53 @@ export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) =>
     );
   }
 
+  // Domain is a separate resource (`networking.datumapis.com/domains`); a viewer
+  // may have dnszones access without domains access. Tolerate failure so the
+  // zone detail still renders (nameservers/overview degrade gracefully).
   let domain: Domain | null = null;
   if (dnsZone.status?.domainRef?.name) {
     const domainService = createDomainService();
-    domain = await domainService.get(projectId, dnsZone.status?.domainRef?.name ?? '');
+    try {
+      domain = await domainService.get(projectId, dnsZone.status?.domainRef?.name ?? '');
+    } catch (error) {
+      logger.warn('DnsZoneDetailLayout: domain fetch failed (degrading gracefully)', {
+        error: error instanceof Error ? error.message : String(error),
+        projectId,
+        domainRef: dnsZone.status?.domainRef?.name,
+      });
+      domain = null;
+    }
   }
 
-  // Use new DNS Records service
-  const dnsRecordService = createDnsRecordService();
-  const dnsRecordSets = await dnsRecordService.list(projectId, dnsZoneId);
+  // DNS records are fetched in the dns-records child route via a gated client
+  // query so a missing dnsrecordsets permission doesn't break this layout.
+  return data({ restricted: false as const, dnsZone, domain });
+};
 
-  return data({ dnsZone, domain, dnsRecordSets });
-});
+export const loader = withLoaderErrors(_loader);
 
 export default function DnsZoneDetailLayout() {
-  const { dnsZone, domain } = useLoaderData<typeof loader>();
+  const loaderData = useLoaderData<typeof loader>();
+
+  if (loaderData.restricted) {
+    return (
+      <RestrictedState
+        title="Access restricted"
+        message="You don't have permission to view this DNS zone."
+      />
+    );
+  }
+
+  return <DnsZoneDetailLayoutInner dnsZone={loaderData.dnsZone} domain={loaderData.domain} />;
+}
+
+function DnsZoneDetailLayoutInner({
+  dnsZone,
+  domain,
+}: {
+  dnsZone: DnsZone;
+  domain: Domain | null;
+}) {
   const { projectId, dnsZoneId } = useParams();
 
   // Seed cache synchronously with SSR data so child routes read it without skeleton flash

--- a/app/routes/project/detail/dns-zones/detail/settings.tsx
+++ b/app/routes/project/detail/dns-zones/detail/settings.tsx
@@ -1,11 +1,14 @@
 import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
 import { DangerCard } from '@/components/danger-card/danger-card';
+import { RestrictedOverlay } from '@/components/restricted-overlay/restricted-overlay';
 import { ComingSoonCard } from '@/features/edge/dns-zone/overview/coming-soon-card';
 import { DescriptionFormCard } from '@/features/edge/dns-zone/overview/description-form-card';
+import { usePermission } from '@/modules/rbac';
 import { useDeleteDnsZone } from '@/resources/dns-zones';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
+import { LoaderOverlay } from '@datum-cloud/datum-ui/loader-overlay';
 import { useNavigate, useParams, useRouteLoaderData } from 'react-router';
 
 export const handle = {
@@ -16,6 +19,17 @@ export default function DnsZoneSettingsPage() {
   const { projectId } = useParams();
   const { dnsZone } = useRouteLoaderData('dns-zone-detail');
   const navigate = useNavigate();
+
+  const { hasPermission: canEdit } = usePermission('dnszones', 'patch', {
+    group: 'dns.networking.miloapis.com',
+    namespace: 'default',
+    scope: 'project',
+  });
+  const { hasPermission: canDelete, isLoading: deleteLoading } = usePermission(
+    'dnszones',
+    'delete',
+    { group: 'dns.networking.miloapis.com', namespace: 'default', scope: 'project' }
+  );
 
   const deleteMutation = useDeleteDnsZone(projectId ?? '', {
     onSuccess: () => {
@@ -55,7 +69,11 @@ export default function DnsZoneSettingsPage() {
       <Row gutter={[0, 24]}>
         <Col span={24}>
           <h3 className="mb-4 text-base font-medium">Zone Description</h3>
-          <DescriptionFormCard projectId={projectId ?? ''} defaultValue={dnsZone} />
+          <DescriptionFormCard
+            projectId={projectId ?? ''}
+            defaultValue={dnsZone}
+            canEdit={canEdit}
+          />
         </Col>
 
         <Col span={24}>
@@ -72,7 +90,15 @@ export default function DnsZoneSettingsPage() {
             loading={deleteMutation.isPending}
             onDelete={deleteDnsZone}
             data-e2e="delete-dns-zone-button"
-          />
+            actionHidden={deleteLoading || !canDelete}>
+            {deleteLoading ? (
+              <LoaderOverlay />
+            ) : (
+              !canDelete && (
+                <RestrictedOverlay message="You don't have permission to delete this DNS zone" />
+              )
+            )}
+          </DangerCard>
         </Col>
       </Row>
     </div>

--- a/app/routes/project/detail/dns-zones/index.tsx
+++ b/app/routes/project/detail/dns-zones/index.tsx
@@ -2,11 +2,14 @@ import { BadgeProgrammingError } from '@/components/badge/badge-programming-erro
 import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
 import { DateTime } from '@/components/date-time';
 import { NameserverChips } from '@/components/nameserver-chips';
+import { RestrictedState } from '@/components/restricted-state/restricted-state';
 import { createActionsColumn, Table } from '@/components/table';
 import {
   DnsZoneFormDialog,
   type DnsZoneFormDialogRef,
 } from '@/features/edge/dns-zone/dns-zone-form-dialog';
+import { usePermissionCheck, PermissionButton } from '@/modules/rbac';
+import { gateRouteAccess } from '@/modules/rbac/server/check-permission';
 import { IExtendedControlPlaneStatus } from '@/resources/base';
 import {
   createDnsZoneService,
@@ -22,7 +25,6 @@ import { BadRequestError, withLoaderErrors } from '@/utils/errors';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
-import { Button } from '@datum-cloud/datum-ui/button';
 import { Icon } from '@datum-cloud/datum-ui/icons';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
@@ -43,6 +45,8 @@ export const meta: MetaFunction = mergeMeta(() => {
   return metaObject('DNS');
 });
 
+type DnsZonesLoaderData = { restricted: true } | { restricted: false; zones: DnsZone[] };
+
 export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) => {
   const { projectId } = params;
 
@@ -50,11 +54,25 @@ export const loader = withLoaderErrors(async ({ params }: LoaderFunctionArgs) =>
     throw new BadRequestError('Project ID is required');
   }
 
+  // Access gate first — skip the list call if the user can't view DNS zones.
+  const canList = await gateRouteAccess(projectId, {
+    resource: 'dnszones',
+    verb: 'list',
+    group: 'dns.networking.miloapis.com',
+    namespace: 'default',
+    scope: 'project',
+    projectId,
+  });
+
+  if (!canList) {
+    return data({ restricted: true as const } satisfies DnsZonesLoaderData);
+  }
+
   // Services now use global axios client with AsyncLocalStorage
   const dnsZoneService = createDnsZoneService();
   const zones = await dnsZoneService.list(projectId);
 
-  return data({ zones });
+  return data({ restricted: false as const, zones } satisfies DnsZonesLoaderData);
 });
 
 interface DnsZoneWithComputed extends DnsZone {
@@ -67,8 +85,51 @@ interface DnsZoneWithComputed extends DnsZone {
 }
 
 export default function DnsZonesPage() {
-  const { zones: initialZones } = useLoaderData<typeof loader>();
+  const loaderData = useLoaderData<typeof loader>();
+
+  if (loaderData.restricted) {
+    return (
+      <RestrictedState title="Access restricted" message="You don't have permission to view DNS." />
+    );
+  }
+
+  return <DnsZonesPageInner initialZones={loaderData.zones} />;
+}
+
+function DnsZonesPageInner({ initialZones }: { initialZones: DnsZone[] }) {
   const { projectId } = useParams();
+
+  const { permissions } = usePermissionCheck([
+    {
+      resource: 'dnszones',
+      verb: 'create',
+      group: 'dns.networking.miloapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+    {
+      resource: 'dnszones',
+      verb: 'delete',
+      group: 'dns.networking.miloapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+    {
+      resource: 'domains',
+      verb: 'patch',
+      group: 'networking.datumapis.com',
+      namespace: 'default',
+      scope: 'project',
+    },
+  ]);
+  const { canCreate, canDelete, canPatchDomain } = useMemo(
+    () => ({
+      canCreate: permissions['dnszones:create']?.allowed ?? false,
+      canDelete: permissions['dnszones:delete']?.allowed ?? false,
+      canPatchDomain: permissions['domains:patch']?.allowed ?? false,
+    }),
+    [permissions]
+  );
 
   // Subscribe to watch for real-time updates
   useDnsZonesWatch(projectId ?? '');
@@ -303,17 +364,18 @@ export default function DnsZonesPage() {
         },
         {
           label: 'Refresh nameservers',
-          hidden: (row) => !row.status?.domainRef?.name,
+          hidden: (row) => !canPatchDomain || !row.status?.domainRef?.name,
           onClick: (row) => refreshDomain(row),
         },
         {
           label: 'Delete',
           variant: 'destructive',
+          hidden: () => !canDelete,
           onClick: (row) => deleteDnsZone(row),
         },
       ]),
     ],
-    [projectId, navigate, refreshDomain, deleteDnsZone]
+    [projectId, navigate, refreshDomain, deleteDnsZone, canPatchDomain, canDelete]
   );
 
   return (
@@ -334,19 +396,27 @@ export default function DnsZonesPage() {
           )
         }
         empty={{
-          title: "let's add a DNS to get you started",
-          actions: [
-            {
-              type: 'button',
-              label: 'Add zone',
-              onClick: () => dialogRef.current?.show(),
-              icon: <Icon icon={PlusIcon} className="size-3" />,
-            },
-          ],
+          title: canCreate ? "let's add a DNS to get you started" : 'No DNS yet',
+          actions: canCreate
+            ? [
+                {
+                  type: 'button',
+                  label: 'Add zone',
+                  onClick: () => dialogRef.current?.show(),
+                  icon: <Icon icon={PlusIcon} className="size-3" />,
+                },
+              ]
+            : [],
         }}
         actions={[
-          <Button
+          <PermissionButton
             key="add-zone"
+            resource="dnszones"
+            verb="create"
+            group="dns.networking.miloapis.com"
+            namespace="default"
+            scope="project"
+            deniedReason="You don't have permission to add a DNS zone"
             type="primary"
             theme="solid"
             size="small"
@@ -355,7 +425,7 @@ export default function DnsZonesPage() {
             onClick={() => dialogRef.current?.show()}>
             <Icon icon={PlusIcon} className="size-4" />
             Add zone
-          </Button>,
+          </PermissionButton>,
         ]}
       />
     </>

--- a/app/utils/config/query.config.ts
+++ b/app/utils/config/query.config.ts
@@ -2,4 +2,4 @@
 export const QUERY_STALE_TIME = 5 * 60 * 1000;
 
 /** Download base URL for Datum Desktop connector app. */
-export const DATUM_DESKTOP_DOWNLOAD_URL = 'https://datum.net/downloads';
+export const DATUM_DESKTOP_DOWNLOAD_URL = 'https://datum.net/download';


### PR DESCRIPTION
## Summary

Extends the project-scoped RBAC pattern (AI Edge / #1273) to two more surfaces:

- **Connectors** (`networking.datumapis.com/connectors`) — list-only gating; lifecycle is owned by Datum Desktop.
- **DNS Zones** (`dns.networking.miloapis.com/dnszones`) — list, detail, settings.
- **DNS Records** (`dns.networking.miloapis.com/dnsrecordsets`) — sub-resource, decoupled from the zone-detail loader and gated by its own permission (same pattern as AI Edge WAF).
- Auxiliary: `domains·get` tolerated on the zone-detail layout; `domains·patch` gates "Refresh nameservers"; `httpproxies·list` gates the optional AI Edge enrichment in DNS records.

Patterns mirror the AI Edge work: bulk `usePermissionCheck`, `gateRouteAccess` + discriminated-union loader, `PermissionButton`, `RestrictedState` / `RestrictedOverlay`.

## Coverage

| Surface | Check | Treatment |
|---|---|---|
| Connectors list | `connectors·list` (+ `httpproxies·list`) | `RestrictedState` if denied; watch + query gated; AI Edge column degrades gracefully when proxy list is denied |
| DNS Zones list | `dnszones·list` | loader `gateRouteAccess` → discriminated-union + `RestrictedState` |
| → Add zone | `dnszones·create` | `PermissionButton` (header + empty action) |
| → Row Delete | `dnszones·delete` | hidden when denied |
| → Row Refresh nameservers | `domains·patch` | hidden when denied |
| DNS Zones detail layout | `dnszones·get` | loader `gateRouteAccess` + discriminated-union + `RestrictedState`. **dnsRecordSets** decoupled to a child-route query; **domain** wrapped in try/catch + `logger.warn` so it degrades without breaking the layout |
| Settings — Description | `dnszones·patch` | `canEdit` on `DescriptionFormCard` disables inputs + Save + tooltip |
| Settings — Delete | `dnszones·delete` | `DangerCard actionHidden` + `RestrictedOverlay` |
| DNS Records list | `dnsrecordsets·list` | gated client query (no request when denied); `RestrictedState` |
| → Add record | `dnsrecordsets·create` | `PermissionButton` (desktop + mobile) |
| → Import | `dnsrecordsets·create` | hidden when denied |
| → Edit | `dnsrecordsets·patch` | toasts a permission message when denied |
| → Row Delete | `dnsrecordsets·delete` | hidden when denied (SOA hide preserved) |
| AI Edge cell enrichment | `httpproxies·list` | optional fetch gated on flag; missing proxy access doesn't 403 the records tab |

## Notes

- **Sub-resource decoupling** for `dnsrecordsets` mirrors the WAF approach: a viewer without records access never triggers the request, and the zone-detail layout stays functional regardless.
- **Domain tolerance** in the zone-detail loader: `networking.datumapis.com/domains·get` failures are caught and logged; `domain = null`, nameservers/overview degrade gracefully.
- **DescriptionFormCard** gained an optional `canEdit` prop (defaults `true`) — backward-compatible.
- `refreshRegistration` calls `domains·patch` (verified in `domainService`).
- Tagalong: small URL fix in `query.config.ts` (`downloads` → `download`).