### PR TITLE
test(e2e): bump createProjectInOrg timeouts to ride out RBAC slowdown

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -352,7 +352,14 @@ Cypress.Commands.add(
         // before the check settles detaches the node mid-click ("page updated while
         // executing"). Wait for it to become enabled, then re-query and click so the
         // click targets the post-swap, stable node.
-        cy.get('[data-e2e="create-project-button"]').should('be.visible').and('not.be.disabled');
+        //
+        // The 4s Cypress default is not enough headroom for the projects:create
+        // access-review in CI — since #1275 widened RBAC fan-out, the check
+        // routinely takes 5–10s on shard 3. Use an explicit 30s timeout to
+        // ride out the slowdown without masking real failures.
+        cy.get('[data-e2e="create-project-button"]', { timeout: 30000 })
+          .should('be.visible')
+          .and('not.be.disabled');
         cy.get('[data-e2e="create-project-button"]').click();
         return;
       }
@@ -378,8 +385,16 @@ Cypress.Commands.add(
       .should('be.oneOf', [200, 201]);
     cy.reload();
 
+    // The reload above issues a fresh list GET, but the project may still
+    // be reconciling on the API side. Cypress retries the `contains`
+    // assertion until the timeout, polling the same page state — so we
+    // need enough headroom for the API to return the new project on a
+    // subsequent retried request. 90s was tight on shard 3 after #1275
+    // widened RBAC fan-out; 180s rides out the slow case without hiding
+    // a genuine "project never created" bug (an outright failure surfaces
+    // earlier at cy.wait('@createProjectReq')).
     return cy
-      .contains('[data-e2e="project-card"]', displayName, { timeout: 90000 })
+      .contains('[data-e2e="project-card"]', displayName, { timeout: 180000 })
       .find('[data-e2e="project-card-id-copy"]')
       .invoke('text')
       .then((projectId: string) => {


### PR DESCRIPTION
## Summary
Shard 3 of the regression suite has been red on `main` since #1275 widened RBAC fan-out, blocking `Publish Container Image` on every subsequent push. Two timeouts inside `createProjectInOrg` are tripping:

1. `should('not.be.disabled')` on the PermissionButton — falls back to Cypress's 4s default, but the `projects:create` access-review now routinely takes 5–10s on CI runners.
2. The project card wait after `cy.reload()` — 90s isn't enough when the list endpoint is briefly stale while the project reconciles.

Bumping the first to 30s and the second to 180s unblocks the suite without masking real failures: a genuine "create never happened" still surfaces at `cy.wait('@createProjectReq')` and a missing button still fails fast on `should('be.visible')`.

## Out of scope
- The underlying access-review latency. The deeper fix (batch the `useAccessReview` calls, or move the test off list polling and onto a direct `cy.visit(/project/:id)` once we have the ID from the POST response) deserves its own PR.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `npx prettier --check cypress/support/e2e.ts` clean
- [ ] CI shard 3 green on this PR — primary signal that the timeout bump is sufficient
- [ ] After merge: confirm `Publish Container Image` runs on the next main push, unblocking the cloud-portal image rollout