### PR TITLE
fix(usage): emit assistant usage via in-cluster Vector collector

### DIFF
--- a/app/modules/usage/emitter.ts
+++ b/app/modules/usage/emitter.ts
@@ -1,17 +1,25 @@
 // app/modules/usage/emitter.ts
 //
-// Thin HTTP client that POSTs CloudEvent batches to the durable Ingestion
-// Gateway. Until the gateway is reachable in the deployment env (i.e.
+// Thin HTTP client that POSTs CloudEvent batches to the in-cluster usage
+// collector (Vector). This is the blessed ingestion path: producer ->
+// Vector -> gateway -> NATS. Vector provides Tier-1 disk durability and
+// injects the gateway api-key when forwarding, so producers post plaintext
+// with no auth. Calling the ingestion gateway directly is explicitly
+// discouraged (see billing/docs/emitting-usage.md) because it loses that
+// durability guarantee.
+//
+// Until the collector is reachable in the deployment env (i.e.
 // USAGE_GATEWAY_URL is unset), `emitUsageEvents` is a no-op; this lets
 // the rest of the codebase wire emission unconditionally without
 // breaking dev/staging.
 //
-// Wire contract (billing/internal/gateway/handler/batch.go):
-//   POST <gateway>/v1/usage/events:batchIngest
-//   Body: JSON array of CloudEvents (max 100 per batch)
-//   Headers: x-api-key when USAGE_GATEWAY_API_KEY is set
-//   Response: 200 with {"accepted": N}, 207 with per-event rejections,
-//            400 on malformed body, 401 when api key is missing/invalid
+// Wire contract (Vector http_server source, path /cloudevents, json codec):
+//   POST <collector>/cloudevents
+//   Body: JSON array of CloudEvents (Vector splits the array into events;
+//         we cap at 100 per batch defensively)
+//   Headers: content-type: application/json. x-api-key is still sent when
+//            USAGE_GATEWAY_API_KEY is set, but the collector endpoint is
+//            unauthenticated in-cluster so it is normally unset.
 //
 // On any error we log and resolve — never throw — so usage emission can
 // never fail a user's chat request. Drops are surfaced via structured
@@ -23,9 +31,11 @@ import { logger } from '@/modules/logger';
 import { env } from '@/utils/env/env.server';
 
 const EMIT_TIMEOUT_MS = 5_000;
-const BATCH_PATH = '/v1/usage/events:batchIngest';
+// Vector's http_server source listens on this path; the downstream gateway
+// (which Vector forwards to) enforces the 100-event batch cap.
+const BATCH_PATH = '/cloudevents';
 
-// Gateway enforces 100 events per batch. We slice on the client so a
+// The gateway enforces 100 events per batch. We slice on the client so a
 // single oversize Record() call never trips the cap. A typical assistant
 // turn emits ≤5 events, so this is purely defensive.
 const MAX_BATCH_SIZE = 100;

--- a/app/modules/usage/types.ts
+++ b/app/modules/usage/types.ts
@@ -6,9 +6,10 @@
 //      ergonomic for `buildAssistantUsageEvents` to populate and stays
 //      easy to unit-test without committing to CloudEvents trivia.
 //
-//   2. `CloudEvent` — the *external* wire shape the billing Ingestion
-//      Gateway accepts at `POST /v1/usage/events:batchIngest`. Each
-//      entry must satisfy the structural rules in
+//   2. `CloudEvent` — the *external* wire shape posted to the in-cluster
+//      usage collector (Vector, `POST /cloudevents`), which forwards to
+//      the billing Ingestion Gateway. Each entry must satisfy the
+//      structural rules the gateway enforces in
 //      billing/internal/gateway/validate/validate.go (ULID id,
 //      specversion/type/source/subject present, subject =
 //      `projects/{name}`, datacontenttype = application/json,


### PR DESCRIPTION
## Problem

The assistant usage emitter POSTed CloudEvent batches **directly to the billing ingestion gateway** (`/v1/usage/events:batchIngest`). Per `billing/docs/emitting-usage.md`, that's the discouraged path — it bypasses the Vector collector (losing Tier-1 disk durability) and forces every producer to terminate the gateway's TLS and present the gateway api-key.

In staging this is exactly why assistant usage never reached Amberflo:
1. First it failed TLS verification (`unable to verify the first certificate`) against the gateway's self-signed proxy cert.
2. After that was addressed, it failed with `401 "Client authentication failed."` from the gateway's Envoy `apiKeyAuth` SecurityPolicy — the portal sends no api-key.

## Fix

Point the emitter at **Vector's `http_server` source path (`/cloudevents`)** instead of the gateway batch path. Vector is plaintext + unauthenticated in-cluster, injects the gateway `x-api-key` when forwarding, and buffers to disk.

- Body is **unchanged** — a JSON array of CloudEvents. Vector's `json` codec splits the array into individual events, and the gateway still validates each one downstream (`validate.go`), so the structural contract in `types.ts` still holds.
- `x-api-key` is still sent if `USAGE_GATEWAY_API_KEY` is set, but the collector endpoint doesn't require it, so it's normally unset.
- Only `emitter.ts` (path constant + wire-contract comment) and a `types.ts` comment change.

## Paired infra change

datum-cloud/infra PR repoints `USAGE_GATEWAY_URL` to the collector Service (`http://billing-usage-collector-vector.billing-system.svc.cluster.local:9880`) and adds the `billing.miloapis.com/emits-usage: "true"` pod label required by the `restrict-vector-ingress` NetworkPolicy.

## Verification

After both merge + deploy: send an assistant message in staging → expect `usage.emit.ok` in cloud-portal logs → event flows Vector → gateway → NATS → Amberflo meter.