### PR TITLE
feat(dns-zones): surface zone errors on detail view (#1031)

### DIFF
--- a/app/features/edge/dns-zone/components/dns-zone-error-banner.tsx
+++ b/app/features/edge/dns-zone/components/dns-zone-error-banner.tsx
@@ -1,0 +1,41 @@
+import type { DnsZone } from '@/resources/dns-zones';
+import { getDnsZoneErrorState, getDnsZoneErrorGuidance } from '@/utils/helpers/dns';
+import { Alert, AlertDescription, AlertTitle } from '@datum-cloud/datum-ui/alert';
+import { Icon } from '@datum-cloud/datum-ui/icons';
+import { TriangleAlertIcon } from 'lucide-react';
+import { useMemo } from 'react';
+
+interface DnsZoneErrorBannerProps {
+  zone?: DnsZone | null;
+  className?: string;
+}
+
+/**
+ * Detail-page banner that surfaces a DNS zone's errored state with actionable
+ * guidance.
+ *
+ * Renders nothing when the zone is healthy. The error detection mirrors the DNS
+ * zone list page (Programmed condition = False), and the message is mapped to
+ * human-facing remediation guidance via {@link getDnsZoneErrorGuidance}.
+ *
+ * Addresses issue #1031 — an errored zone now explains itself on the detail view
+ * instead of silently sitting on the "Discovering DNS Records" screen.
+ */
+export function DnsZoneErrorBanner({ zone, className }: DnsZoneErrorBannerProps) {
+  const guidance = useMemo(() => {
+    const { hasError, reason, message } = getDnsZoneErrorState(zone);
+    return hasError ? getDnsZoneErrorGuidance(reason, message) : null;
+  }, [zone]);
+
+  if (!guidance) {
+    return null;
+  }
+
+  return (
+    <Alert variant="destructive" className={className} data-e2e="dns-zone-error-banner">
+      <Icon icon={TriangleAlertIcon} className="size-4" />
+      <AlertTitle className="text-destructive text-sm">{guidance.title}</AlertTitle>
+      <AlertDescription>{guidance.description}</AlertDescription>
+    </Alert>
+  );
+}

--- a/app/routes/project/detail/dns-zones/detail/layout.tsx
+++ b/app/routes/project/detail/dns-zones/detail/layout.tsx
@@ -1,4 +1,5 @@
 import { type SubNavigationTab } from '@/components/sub-navigation';
+import { DnsZoneErrorBanner } from '@/features/edge/dns-zone/components/dns-zone-error-banner';
 import { SubLayout } from '@/layouts';
 import { defineResourceRoute } from '@/modules/rbac/define-resource-route';
 import { runDetailLoader } from '@/modules/rbac/run-resource-loader';
@@ -105,6 +106,7 @@ export default route.Page(({ data: dnsZone }) => {
 
   return (
     <SubLayout title={dnsZone?.domainName} navItems={navItems}>
+      <DnsZoneErrorBanner zone={dnsZone} className="mb-6" />
       <Outlet />
     </SubLayout>
   );

--- a/app/routes/project/detail/dns-zones/index.tsx
+++ b/app/routes/project/detail/dns-zones/index.tsx
@@ -23,6 +23,7 @@ import { useRefreshDomainRegistration } from '@/resources/domains';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
+import { getDnsZoneErrorGuidance, isDnsZoneErrored } from '@/utils/helpers/dns';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Icon } from '@datum-cloud/datum-ui/icons';
 import { toast } from '@datum-cloud/datum-ui/toast';
@@ -54,6 +55,8 @@ interface DnsZoneWithComputed extends DnsZone {
   _computed: {
     status: IExtendedControlPlaneStatus;
     hasError: boolean;
+    /** Friendly guidance description (shared with the detail banner) shown in the error tooltip. */
+    errorDescription?: string;
     hasNameservers: boolean;
     isLoading: boolean;
   };
@@ -122,7 +125,7 @@ function DnsZonesInner({ initialZones }: { initialZones: DnsZone[] }) {
       const status = transformControlPlaneStatus(zone.status, {
         includeConditionDetails: true,
       });
-      const hasError = status.isProgrammed === false && !!status.programmedReason;
+      const hasError = isDnsZoneErrored(status);
       const hasNameservers = !!zone.status?.domainRef?.status?.nameservers;
 
       return {
@@ -130,6 +133,9 @@ function DnsZonesInner({ initialZones }: { initialZones: DnsZone[] }) {
         _computed: {
           status,
           hasError,
+          errorDescription: hasError
+            ? getDnsZoneErrorGuidance(status.programmedReason, status.message).description
+            : undefined,
           hasNameservers,
           isLoading: !hasNameservers && !hasError,
         },
@@ -197,7 +203,7 @@ function DnsZonesInner({ initialZones }: { initialZones: DnsZone[] }) {
         header: 'Zone Name',
         accessorKey: 'domainName',
         cell: ({ row }) => {
-          const { status } = row.original._computed;
+          const { status, errorDescription } = row.original._computed;
 
           return (
             <div className="flex items-center gap-2" data-e2e="dns-zone-card">
@@ -208,7 +214,7 @@ function DnsZonesInner({ initialZones }: { initialZones: DnsZone[] }) {
                 className="rounded-lg px-2 py-0.5"
                 isProgrammed={status.isProgrammed}
                 programmedReason={status.programmedReason}
-                statusMessage={status.message}
+                statusMessage={errorDescription ?? status.message}
                 errorReasons={null}
               />
             </div>

--- a/app/utils/helpers/dns/dns-zone-error.helper.ts
+++ b/app/utils/helpers/dns/dns-zone-error.helper.ts
@@ -1,0 +1,166 @@
+import type { IExtendedControlPlaneStatus } from '@/resources/base';
+import type { DnsZone } from '@/resources/dns-zones';
+import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
+
+// =============================================================================
+// DNS Zone Error Helpers
+// =============================================================================
+
+/**
+ * Resolved error state for a DNS zone.
+ *
+ * Mirrors the computation used by the DNS zone list page so the list badge and
+ * the detail banner can never disagree about whether a zone is errored.
+ */
+export interface IDnsZoneErrorState {
+  hasError: boolean;
+  /** Raw K8s `Programmed` condition reason (free-form string). */
+  reason?: string;
+  /** Raw K8s condition message surfaced by `transformControlPlaneStatus`. */
+  message?: string;
+}
+
+/**
+ * Human-facing remediation guidance shown in the detail banner.
+ */
+export interface IDnsZoneErrorGuidance {
+  title: string;
+  description: string;
+}
+
+/**
+ * A single reason→guidance mapping rule.
+ *
+ * A rule matches when EITHER the K8s `reason` matches `reason` (case-insensitive)
+ * OR the condition `message` matches `messagePattern`. Message matching is the
+ * primary key because the control-plane types do not expose reason enums.
+ */
+interface DnsZoneErrorRule {
+  reason?: string;
+  messagePattern?: RegExp;
+  guidance: IDnsZoneErrorGuidance;
+}
+
+/**
+ * Known DNS zone error reasons → actionable guidance.
+ *
+ * NOTE: To add a new known failure mode, append a rule here. Rules are evaluated
+ * top-to-bottom; the first match wins. Unknown errors fall back to the raw
+ * condition message (see {@link getDnsZoneErrorGuidance}).
+ */
+const DNS_ZONE_ERROR_RULES: DnsZoneErrorRule[] = [
+  {
+    // e.g. "DNSZone claimed by another resource"
+    messagePattern: /claimed by another/i,
+    guidance: {
+      title: 'This domain is already in use',
+      description:
+        'Already claimed by another DNS zone. Delete the conflicting zone (it may be in this or another project), or use a different domain name.',
+    },
+  },
+  {
+    // e.g. "invalid domain name", "not a registrable domain", public-suffix rejections
+    messagePattern: /invalid domain|not a valid|not registrable|public suffix/i,
+    guidance: {
+      title: 'Invalid domain name',
+      description:
+        'Not usable as a DNS zone. Check for typos and confirm it’s a registrable domain you control.',
+    },
+  },
+  {
+    // e.g. "quota exceeded", "DNS zone limit reached", "too many zones"
+    messagePattern: /quota|limit (exceeded|reached)|too many/i,
+    guidance: {
+      title: 'DNS zone limit reached',
+      description:
+        'DNS zone limit reached for this project. Delete an unused zone or ask an administrator to raise it.',
+    },
+  },
+  {
+    // e.g. "zone not delegated", "nameservers not configured", "missing NS record".
+    // Patterns require an error-bearing context so a benign mention of
+    // "nameserver" in some other message does not match here.
+    messagePattern:
+      /delegat|nameservers?\s+(not|missing|incorrect|misconfigured|need)|missing\s+ns\s+record/i,
+    guidance: {
+      title: 'Nameserver delegation incomplete',
+      description:
+        'Nameserver delegation is incomplete, so traffic isn’t flowing yet. Update the domain’s nameservers at your registrar to the values on the Nameservers tab.',
+    },
+  },
+  {
+    // Generic backend/reconciliation failure — keep LAST so specific rules win first.
+    messagePattern:
+      /programming failed|reconcil|internal error|provider error|failed to provision/i,
+    guidance: {
+      title: 'DNS zone provisioning failed',
+      description:
+        'Provisioning failed. Often temporary — try again shortly, or contact support if it persists.',
+    },
+  },
+];
+
+const GENERIC_GUIDANCE_TITLE = 'DNS Zone configuration error';
+const GENERIC_GUIDANCE_FALLBACK =
+  'Something is preventing this DNS zone from being provisioned. Review the configuration or contact support if the problem persists.';
+
+/**
+ * Single source of truth for "is this DNS zone errored?".
+ *
+ * A zone is errored when its `Programmed` condition is `False` and a reason is
+ * present. Operates on an already-transformed status so callers that have one
+ * (e.g. the list page) can reuse it without re-running
+ * {@link transformControlPlaneStatus}.
+ */
+export function isDnsZoneErrored(status: IExtendedControlPlaneStatus): boolean {
+  return status.isProgrammed === false && !!status.programmedReason;
+}
+
+/**
+ * Compute whether a DNS zone is in an errored state.
+ *
+ * Convenience wrapper around {@link isDnsZoneErrored} for callers that hold the
+ * raw zone rather than a transformed status (e.g. the detail banner).
+ */
+export function getDnsZoneErrorState(zone?: DnsZone | null): IDnsZoneErrorState {
+  if (!zone) {
+    return { hasError: false };
+  }
+
+  const status = transformControlPlaneStatus(zone.status, {
+    includeConditionDetails: true,
+  });
+
+  if (!isDnsZoneErrored(status)) {
+    return { hasError: false };
+  }
+
+  return {
+    hasError: true,
+    reason: status.programmedReason,
+    message: status.message,
+  };
+}
+
+/**
+ * Map a raw error reason/message to human-facing remediation guidance.
+ *
+ * Falls back to the raw condition message (or a generic line) when the reason
+ * is not in {@link DNS_ZONE_ERROR_RULES}.
+ */
+export function getDnsZoneErrorGuidance(reason?: string, message?: string): IDnsZoneErrorGuidance {
+  const matched = DNS_ZONE_ERROR_RULES.find((rule) => {
+    const reasonMatch = rule.reason && reason && rule.reason.toLowerCase() === reason.toLowerCase();
+    const messageMatch = rule.messagePattern && message && rule.messagePattern.test(message);
+    return Boolean(reasonMatch || messageMatch);
+  });
+
+  if (matched) {
+    return matched.guidance;
+  }
+
+  return {
+    title: GENERIC_GUIDANCE_TITLE,
+    description: message?.trim() || GENERIC_GUIDANCE_FALLBACK,
+  };
+}

--- a/app/utils/helpers/dns/index.ts
+++ b/app/utils/helpers/dns/index.ts
@@ -80,6 +80,15 @@ export {
 // Error formatting helpers
 export { formatDnsConflictError, formatDnsError } from './error-formatting.helper';
 
+// DNS zone error state + remediation guidance
+export {
+  isDnsZoneErrored,
+  getDnsZoneErrorState,
+  getDnsZoneErrorGuidance,
+  type IDnsZoneErrorState,
+  type IDnsZoneErrorGuidance,
+} from './dns-zone-error.helper';
+
 // Record type configuration
 export {
   DNS_RECORD_TYPE_CONFIG,

--- a/cypress/component/dns-zone-error.cy.ts
+++ b/cypress/component/dns-zone-error.cy.ts
@@ -1,0 +1,130 @@
+import type { IExtendedControlPlaneStatus } from '@/resources/base';
+import type { DnsZone } from '@/resources/dns-zones';
+import {
+  getDnsZoneErrorGuidance,
+  getDnsZoneErrorState,
+  isDnsZoneErrored,
+} from '@/utils/helpers/dns';
+
+/** Loose factory so tests only specify the condition fields under test. */
+const status = (partial: Partial<IExtendedControlPlaneStatus>): IExtendedControlPlaneStatus =>
+  ({ status: 'pending', message: '', ...partial }) as IExtendedControlPlaneStatus;
+
+type Condition = {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason?: string;
+  message?: string;
+};
+
+const makeZone = (conditions: Condition[]): DnsZone =>
+  ({
+    uid: 'example-zone-uid',
+    name: 'example-zone',
+    displayName: 'Example Zone',
+    namespace: 'default',
+    resourceVersion: '1',
+    createdAt: new Date(),
+    domainName: 'example.com',
+    dnsZoneClassName: 'default',
+    status: { conditions },
+  }) as DnsZone;
+
+const programmed = (status: 'True' | 'False', reason?: string, message?: string): Condition => ({
+  type: 'Programmed',
+  status,
+  reason,
+  message,
+});
+
+describe('getDnsZoneErrorState', () => {
+  it('returns no error when the zone is missing', () => {
+    expect(getDnsZoneErrorState(undefined).hasError).to.equal(false);
+    expect(getDnsZoneErrorState(null).hasError).to.equal(false);
+  });
+
+  it('returns no error when Programmed is True', () => {
+    const zone = makeZone([programmed('True')]);
+    expect(getDnsZoneErrorState(zone).hasError).to.equal(false);
+  });
+
+  it('returns the reason and message when Programmed is False', () => {
+    const zone = makeZone([programmed('False', 'Claimed', 'DNSZone claimed by another resource')]);
+
+    const result = getDnsZoneErrorState(zone);
+
+    expect(result.hasError).to.equal(true);
+    expect(result.reason).to.equal('Claimed');
+    expect(result.message).to.equal('DNSZone claimed by another resource');
+  });
+});
+
+describe('isDnsZoneErrored', () => {
+  it('is true only when Programmed is explicitly False with a reason', () => {
+    expect(isDnsZoneErrored(status({}))).to.equal(false); // no Programmed condition
+    expect(isDnsZoneErrored(status({ isProgrammed: true }))).to.equal(false);
+    expect(isDnsZoneErrored(status({ isProgrammed: false }))).to.equal(false); // no reason
+    expect(isDnsZoneErrored(status({ isProgrammed: false, programmedReason: 'Claimed' }))).to.equal(
+      true
+    );
+  });
+});
+
+describe('getDnsZoneErrorGuidance', () => {
+  it('maps a "claimed" message to the in-use guidance', () => {
+    const guidance = getDnsZoneErrorGuidance('Claimed', 'DNSZone claimed by another resource');
+    expect(guidance.title).to.equal('This domain is already in use');
+  });
+
+  it('maps an invalid-domain message', () => {
+    expect(getDnsZoneErrorGuidance(undefined, 'invalid domain name').title).to.equal(
+      'Invalid domain name'
+    );
+  });
+
+  it('maps a quota message', () => {
+    expect(getDnsZoneErrorGuidance(undefined, 'project quota exceeded').title).to.equal(
+      'DNS zone limit reached'
+    );
+  });
+
+  it('maps a delegation message but not a benign nameserver mention', () => {
+    expect(
+      getDnsZoneErrorGuidance(undefined, 'nameservers not configured at registrar').title
+    ).to.equal('Nameserver delegation incomplete');
+
+    // A message that merely mentions "nameserver" without an error context should
+    // NOT be categorized as a delegation failure — it falls through to generic.
+    expect(getDnsZoneErrorGuidance(undefined, 'fetching nameserver records').title).to.equal(
+      'DNS Zone configuration error'
+    );
+  });
+
+  it('maps a generic backend failure', () => {
+    expect(getDnsZoneErrorGuidance(undefined, 'programming failed: internal error').title).to.equal(
+      'DNS zone provisioning failed'
+    );
+  });
+
+  it('prefers the more specific rule over the generic one (ordering)', () => {
+    // Message matches both the "claimed" rule and the generic "reconcile" rule;
+    // the specific rule is listed first, so it must win.
+    const guidance = getDnsZoneErrorGuidance(
+      undefined,
+      'claimed by another resource during reconcile'
+    );
+    expect(guidance.title).to.equal('This domain is already in use');
+  });
+
+  it('falls back to the raw message for an unknown reason', () => {
+    const guidance = getDnsZoneErrorGuidance(undefined, 'something very unusual happened');
+    expect(guidance.title).to.equal('DNS Zone configuration error');
+    expect(guidance.description).to.equal('something very unusual happened');
+  });
+
+  it('falls back to a generic description when there is no message', () => {
+    const guidance = getDnsZoneErrorGuidance(undefined, '');
+    expect(guidance.title).to.equal('DNS Zone configuration error');
+    expect(guidance.description).to.contain('Something is preventing this DNS zone');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1031.

When a DNS zone is in an errored state (e.g. _"DNSZone claimed by another resource"_), the error was only visible as a badge on the list page — the detail view showed nothing and sat on the "Discovering DNS Records" screen with no explanation.

This PR surfaces the error where users look for it:

- **Detail view** — shows a destructive banner with actionable guidance, persisting across all zone tabs.
- **List tooltip** — reuses the same guidance text on the existing error badge for consistency.

## How it works

- A small reason→guidance map translates raw K8s condition messages into human-friendly remediation text, falling back to the raw message for unrecognized errors (nothing is ever silent).
- A shared `isDnsZoneErrored` predicate is the single source of truth for error detection (list + detail), avoiding any drift.

## Test plan

- [x] New unit spec `cypress/component/dns-zone-error.cy.ts` — 12 cases (detection, every guidance rule, rule ordering, fallbacks). All passing.
- [x] `typecheck` and `lint` clean.

## Preview
<img width="1331" height="1271" alt="Screenshot 2026-06-02 at 22 19 08" src="https://github.com/user-attachments/assets/3a4b4526-7527-45a4-be66-6b4c3b1b007f" />
