### PR TITLE
fix(tests): gate bun test in CI, fix mock.module pollution, add coverage baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,19 @@ jobs:
             ${{ env.BUN_CACHE }}
             **/node_modules
           key: ${{ runner.os }}-deps-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package.json') }}
-      - run: bun test
+      # Coverage is reported (text in the log + lcov artifact) but not gated yet.
+      # Bun only instruments files imported by tests, so the % reflects the
+      # unit-tested surface, not the whole repo.
+      - run: bun run test:coverage
         env:
           NODE_ENV: test
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: bun-coverage-${{ github.run_id }}
+          path: coverage/lcov.info
+          retention-days: 7
+          if-no-files-found: warn
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,24 @@ jobs:
           key: build-${{ github.sha }}
 
   # ─── Tests ──────────────────────────────────────────────────
+  bun-tests:
+    name: Bun Unit Tests
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with: { bun-version: 1.3.14 } # renovate: datasource=docker depName=oven/bun
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ${{ env.BUN_CACHE }}
+            **/node_modules
+          key: ${{ runner.os }}-deps-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package.json') }}
+      - run: bun test
+        env:
+          NODE_ENV: test
+
   unit-tests:
     name: Unit Tests
     needs: build
@@ -255,7 +273,7 @@ jobs:
   # ─── Status Gate ────────────────────────────────────────────
   status-check:
     name: Final Status Check
-    needs: [install, lint, typecheck, build, unit-tests, e2e-smoke, e2e-regression]
+    needs: [install, lint, typecheck, build, bun-tests, unit-tests, e2e-smoke, e2e-regression]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -310,7 +328,7 @@ jobs:
   # ─── PR Comment ─────────────────────────────────────────────
   pr-comment:
     name: PR Test Summary
-    needs: [unit-tests, e2e-smoke]
+    needs: [bun-tests, unit-tests, e2e-smoke]
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:
@@ -334,7 +352,7 @@ jobs:
             });
 
             const testJobs = jobs.jobs.filter(j =>
-              j.name === 'Unit Tests' || j.name.startsWith('E2E')
+              j.name === 'Bun Unit Tests' || j.name === 'Unit Tests' || j.name.startsWith('E2E')
             );
 
             const statusEmoji = (conclusion) => {
@@ -374,5 +392,4 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: pr-summary.md
-          comment-tag: ci-summary
           edit-mode: replace

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ temp-openapi-spec.json
 # GraphQL generation temp files
 temp-filtered-schema.graphql
 
+# Coverage reports
+/coverage
+
 # Cypress files
 cypress/screenshots
 cypress/videos

--- a/app/resources/search/search.service.test.ts
+++ b/app/resources/search/search.service.test.ts
@@ -9,8 +9,13 @@ mock.module('@/modules/control-plane/search', () => ({
   createSearchMiloapisComV1Alpha1ResourceSearchQuery: (...args: unknown[]) => createSpy(...args),
 }));
 
+// NOTE: `mock.module` in Bun is process-global and persists for the rest of
+// the run, so it can leak into other test files. Keep these mocks faithful to
+// the real modules' shape/output (e.g. the real scoped-base URL format and the
+// full logger surface) so execution order can never matter.
 mock.module('@/resources/base/utils', () => ({
-  getProjectScopedBase: (id: string) => `/api/proxy/projects/${id}/control-plane`,
+  getProjectScopedBase: (id: string) =>
+    `/apis/resourcemanager.miloapis.com/v1alpha1/projects/${id}/control-plane`,
 }));
 
 mock.module('@/utils/errors/error-mapper', () => ({
@@ -18,7 +23,15 @@ mock.module('@/utils/errors/error-mapper', () => ({
 }));
 
 mock.module('@/modules/logger', () => ({
-  logger: { service: mock(() => {}), error: mock(() => {}) },
+  logger: {
+    debug: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    request: mock(() => {}),
+    api: mock(() => {}),
+    service: mock(() => {}),
+  },
 }));
 
 beforeEach(() => {
@@ -48,7 +61,9 @@ describe('searchService', () => {
     const svc = createSearchService();
     await svc.searchInProject('alpha', { query: 'acme', targetResources: PROJECT_KINDS });
     const call = createSpy.mock.calls[0][0];
-    expect(call.baseURL).toBe('/api/proxy/projects/alpha/control-plane');
+    expect(call.baseURL).toBe(
+      '/apis/resourcemanager.miloapis.com/v1alpha1/projects/alpha/control-plane'
+    );
   });
 
   it('passes apiVersion, kind, metadata in body', async () => {

--- a/app/resources/search/search.telemetry.test.ts
+++ b/app/resources/search/search.telemetry.test.ts
@@ -8,10 +8,21 @@ mock.module('@/modules/sentry', () => ({
   addBreadcrumb,
 }));
 
-// Mock @/modules/logger
+// Mock @/modules/logger. `mock.module` is process-global in Bun and persists
+// for the rest of the run, so keep the mocked logger faithful to the real
+// surface (don't ship a partial `{ info }` that breaks other files' `error`
+// calls when this mock leaks into them).
 const loggerInfo = mock(() => {});
 mock.module('@/modules/logger', () => ({
-  logger: { info: loggerInfo },
+  logger: {
+    debug: mock(() => {}),
+    info: loggerInfo,
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    request: mock(() => {}),
+    api: mock(() => {}),
+    service: mock(() => {}),
+  },
 }));
 
 describe('emitSearchEvent', () => {

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,11 @@
+[test]
+# Coverage is opt-in via `--coverage` (see `bun run test:coverage`); these
+# settings only take effect when that flag is passed, so plain `bun test`
+# stays fast for local/CI runs.
+#
+# NOTE: Bun only instruments files that tests import, so the reported
+# percentage reflects covered files, not the whole repo. Treat it as a
+# ratchet for the unit-tested surface, not as repo-wide coverage.
+coverageReporter = ["text", "lcov"]
+coverageDir = "coverage"
+coverageSkipTestFiles = true

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:unit:prod": "cypress run --component --config-file cypress.config.ts --quiet",
     "test:unit:debug": "cypress open --component",
     "test:lib": "bun test app/lib",
-    "test:rbac": "bun test app/modules/rbac"
+    "test:rbac": "bun test app/modules/rbac",
+    "test:coverage": "bun test --coverage"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.71",


### PR DESCRIPTION
## Summary

The `bun test` unit suites (`app/lib`, `app/modules/rbac`, `app/features/search`, `app/resources/search`) ran **nowhere in CI** — only the Cypress component suite (`test:unit:prod`) was gated. As a result the bun tests silently rotted: 3 of them were failing on `main`.

This PR fixes the failures, wires `bun test` into CI so it can't rot again, and adds a coverage baseline to track improvement from.

## Commits
1. **Fix the 3 failing tests** — eliminate `mock.module` pollution across bun test files.
2. **Gate `bun test` in CI** — new `Bun Unit Tests` job + status-check gate; also fixes an invalid workflow input.
3. **Add coverage measurement** — report-only baseline, no gate yet.

## Root cause of the 3 failures

Not a product bug — **test pollution**. Bun's `mock.module` is process-global and persists for the rest of the run, so the search test files leaked partial/divergent module mocks into `rbac.service.test.ts`:

- `@/resources/base/utils` was mocked to return `/api/proxy/...`, which leaked into the rbac project-scope base-URL assertion.
- `@/modules/logger` was mocked as a partial `{ info }` stub, so `logger.error` was `undefined` when the mock leaked into `RbacService.checkPermissions`.

The failures only appeared in the full-suite run (order-dependent); each file passed in isolation.

### Fix
Make both leaking mocks faithful to the real modules so execution order can never matter:
- Align `getProjectScopedBase` to the real scoped-base URL format (and update search's own assertion in lockstep).
- Expose the full logger surface (`debug/info/warn/error/request/api/service`) in both mocks.

Added inline comments in both files explaining why the mocks must stay faithful.

## CI changes
- New **`Bun Unit Tests`** job running `bun test`, gated on `install` (no Cypress, no build → runs early in parallel with lint/typecheck/build).
- Added to the `status-check` gate so a `bun test` failure blocks merge.
- Surfaced in the PR Test Summary (`needs` + job filter).
- Removed the invalid `comment-tag` input from `create-or-update-comment@v5` — not a supported input (silently ignored at runtime), so removal is behavior-neutral and clears the workflow lint error.

## Coverage measurement (report-only)
- `bunfig.toml`: `text` + `lcov` reporters, opt-in via `--coverage` so plain `bun test` stays fast.
- New `test:coverage` script (`bun test --coverage`).
- The `bun-tests` job runs coverage, prints the text summary in the log, and uploads `coverage/lcov.info` as an artifact. **No threshold gate yet** — measuring first.
- `/coverage` gitignored.

**Baseline today:** `49.65%` lines / `~45%` funcs across the **78 files the tests import**. Note: Bun only instruments imported files, so this reflects the unit-tested surface, not the whole repo (~960 source files are untested and don't appear in the denominator). Treat it as a ratchet for the unit suite.

## Verification
- `bun test` (whole suite, one process): **115 pass / 0 fail**
- Previously-failing order combos (`search.* → rbac`): all pass
- `ci.yml`: YAML valid, IDE diagnostics clear

## Notes / follow-ups
- The PR "sticky" summary comment was never actually working (`comment-tag` was ignored), so it posts a fresh comment each run. Left as-is here; a proper fix would add a `peter-evans/find-comment` step feeding `comment-id`.
- Next step (separate PR): adapter test sweep + a factory layer, then ratchet a coverage threshold once we have a target.