### PR TITLE
fix(rbac): derive SSAR namespace from scope to stop false denials

### DIFF
--- a/app/modules/rbac/server/rbac.service.test.ts
+++ b/app/modules/rbac/server/rbac.service.test.ts
@@ -73,6 +73,51 @@ describe('RbacService.checkPermission', () => {
   });
 });
 
+describe('RbacService namespace resolution', () => {
+  /** Pull the namespace from the SSAR payload (2nd positional arg to create). */
+  function sentNamespace(create: { mock: { calls: unknown[][] } }): string {
+    return (create.mock.calls[0] as [string, { namespace: string }, unknown])[1].namespace;
+  }
+
+  test('org-scoped check (default scope) targets the organization namespace', async () => {
+    const fakeAccessReview = { create: mock(async () => ({ allowed: true, denied: false })) };
+    const svc = new RbacService(() => fakeAccessReview as never);
+    await svc.checkPermission('acme', { resource: 'members', verb: 'list', scope: 'org' });
+    expect(sentNamespace(fakeAccessReview.create)).toBe('organization-acme');
+  });
+
+  test('project-scoped check targets the default namespace', async () => {
+    const fakeAccessReview = { create: mock(async () => ({ allowed: true, denied: false })) };
+    const svc = new RbacService(() => fakeAccessReview as never);
+    await svc.checkPermission('acme', {
+      resource: 'dnszones',
+      verb: 'list',
+      scope: 'project',
+      projectId: 'proj-1',
+    });
+    expect(sentNamespace(fakeAccessReview.create)).toBe('default');
+  });
+
+  test('user-scoped check targets the empty (cluster-scoped) namespace', async () => {
+    const fakeAccessReview = { create: mock(async () => ({ allowed: true, denied: false })) };
+    const svc = new RbacService(() => fakeAccessReview as never);
+    await svc.checkPermission('acme', { resource: 'organizations', verb: 'list', scope: 'user' });
+    expect(sentNamespace(fakeAccessReview.create)).toBe('');
+  });
+
+  test('explicit namespace overrides scope derivation', async () => {
+    const fakeAccessReview = { create: mock(async () => ({ allowed: true, denied: false })) };
+    const svc = new RbacService(() => fakeAccessReview as never);
+    await svc.checkPermission('acme', {
+      resource: 'members',
+      verb: 'list',
+      scope: 'org',
+      namespace: 'custom-ns',
+    });
+    expect(sentNamespace(fakeAccessReview.create)).toBe('custom-ns');
+  });
+});
+
 describe('RbacService.checkPermissions (bulk)', () => {
   test('returns per-check results with originating request', async () => {
     const fakeAccessReview = { create: mock(async () => ({ allowed: true, denied: false })) };
@@ -90,7 +135,8 @@ describe('RbacService.checkPermissions (bulk)', () => {
         resource: 'secrets',
         verb: 'get',
         group: '',
-        namespace: undefined,
+        // No scope → defaults to 'org' → resolved org namespace.
+        namespace: 'organization-acme',
         name: undefined,
       },
     });
@@ -119,7 +165,8 @@ describe('RbacService.checkPermissions (bulk)', () => {
         resource: 'secrets',
         verb: 'delete',
         group: '',
-        namespace: undefined,
+        // No scope → defaults to 'org' → resolved org namespace.
+        namespace: 'organization-acme',
         name: undefined,
       },
     });

--- a/app/modules/rbac/server/rbac.service.ts
+++ b/app/modules/rbac/server/rbac.service.ts
@@ -1,6 +1,7 @@
 import { logger } from '@/modules/logger';
 import { createAccessReviewService, type SupportedVerb } from '@/resources/access-review';
 import { getOrgScopedBase, getProjectScopedBase, getUserScopedBase } from '@/resources/base/utils';
+import { buildOrganizationNamespace, buildProjectNamespace } from '@/utils/common';
 
 /**
  * Scope determines which control-plane base the SelfSubjectAccessReview is
@@ -64,6 +65,37 @@ export class RbacService {
     }
   }
 
+  /**
+   * Resolve the namespace a SelfSubjectAccessReview should target, derived from
+   * the check's scope (the "area" being requested). Omitting the namespace makes
+   * the authorizer evaluate against the empty namespace, which fails closed for
+   * any namespaced resource whose RoleBinding lives elsewhere — the always-false
+   * bug this method exists to prevent.
+   *
+   * An explicit `check.namespace` always wins so callers can target a specific
+   * namespace (cross-namespace checks). `''` is a deliberate value (cluster-scoped
+   * resources), so we branch on `undefined`, not falsiness.
+   *
+   * Scope → namespace:
+   * - project → 'default'                          (project control-plane resources)
+   * - org     → `organization-{organizationId}`    (org RoleBindings live here)
+   * - user    → '' (cluster-scoped root resources, e.g. `organizations`)
+   */
+  private resolveNamespace(organizationId: string, check: PermissionCheckInput): string {
+    if (check.namespace !== undefined) {
+      return check.namespace;
+    }
+    switch (check.scope ?? 'org') {
+      case 'project':
+        return buildProjectNamespace();
+      case 'user':
+        return '';
+      case 'org':
+      default:
+        return buildOrganizationNamespace(organizationId);
+    }
+  }
+
   async checkPermission(
     organizationId: string,
     check: PermissionCheckInput
@@ -73,7 +105,7 @@ export class RbacService {
       const result = await accessReview.create(
         organizationId,
         {
-          namespace: check.namespace || '',
+          namespace: this.resolveNamespace(organizationId, check),
           verb: check.verb,
           group: check.group || '',
           resource: check.resource,
@@ -112,7 +144,7 @@ export class RbacService {
         const result = await accessReview.create(
           organizationId,
           {
-            namespace: check.namespace || '',
+            namespace: this.resolveNamespace(organizationId, check),
             verb: check.verb,
             group: check.group || '',
             resource: check.resource,
@@ -134,7 +166,9 @@ export class RbacService {
         resource: check.resource,
         verb: check.verb,
         group: check.group || '',
-        namespace: check.namespace,
+        // Echo the namespace actually sent to the authorizer (resolved from scope),
+        // not the caller's raw (often undefined) value, so diagnostics are truthful.
+        namespace: this.resolveNamespace(organizationId, check),
         name: check.name,
       };
       if (outcome.status === 'fulfilled') {

--- a/app/utils/common.ts
+++ b/app/utils/common.ts
@@ -91,6 +91,19 @@ export function buildOrganizationNamespace(organizationId: string): string {
 }
 
 /**
+ * Namespace for project-scoped control-plane resources.
+ *
+ * Today every project resource lives in the shared `default` namespace, so this
+ * takes no argument. It's a function (not a bare constant) to mirror
+ * {@link buildOrganizationNamespace} and to leave a seam: if projects ever move
+ * to a per-project namespace (e.g. `project-${projectId}`), only this body
+ * changes — call sites already route through it.
+ */
+export function buildProjectNamespace(): string {
+  return 'default';
+}
+
+/**
  * Trigger a file download in the browser
  * @param content - File content as string
  * @param filename - Name of the file to download


### PR DESCRIPTION
## Issue

Permission checks (both the SSR loader gate and the client BFF `/check` & `/bulk-check`) sent an **empty namespace** to the `SelfSubjectAccessReview` whenever the caller didn't pass one. For namespaced resources the authorizer then evaluated against the wrong namespace and returned **denied**, so org-area actions were gated off even for users who actually have permission.

## Fix

Derive the namespace from the check's **scope** in `RbacService` — the single chokepoint both the SSR and client paths share:

- `project` → `default`
- `org` → `organization-{organizationId}`
- `user` → `''` (cluster-scoped root resources)

An explicit `namespace` still wins for cross-namespace checks. Also adds `buildProjectNamespace()` next to `buildOrganizationNamespace()` as the shared source of truth.

## Tests

`bun test app/modules/rbac` — 12/12 pass (added scope→namespace + explicit-override cases). Typecheck clean.

## Preview
### Before
<img width="2550" height="813" alt="Screenshot 2026-06-03 at 08 10 59" src="https://github.com/user-attachments/assets/f0c37795-36fd-4495-aba9-605792e3f746" />

### After
<img width="2557" height="878" alt="Screenshot 2026-06-03 at 08 09 27" src="https://github.com/user-attachments/assets/32e83b9d-c2d2-41ea-a0ab-1017df7853ef" />
