### PR TITLE
feat(rbac): runRouteGate gate-only DSL primitive + new-page RBAC smoke tests

### DIFF
--- a/app/modules/rbac/define-resource-route.tsx
+++ b/app/modules/rbac/define-resource-route.tsx
@@ -1,5 +1,12 @@
 import { GuardedPage } from './components/GuardedPage';
-import type { DefineListPageInput, DefineDetailPageInput, DslLoaderData } from './types';
+import type {
+  DefineListPageInput,
+  DefineDetailPageInput,
+  DefineGatePageInput,
+  DslLoaderData,
+  GateLoaderData,
+} from './types';
+import { RestrictedState } from '@/components/restricted-state/restricted-state';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { useCallback } from 'react';
 import { useLoaderData, useParams, type MetaFunction } from 'react-router';
@@ -37,6 +44,13 @@ interface DefineDetailRouteOutput<TData, TCompanions extends Record<string, unkn
   ) => () => React.ReactElement;
 }
 
+interface DefineGateRouteOutput {
+  meta: MetaFunction;
+  // Gate routes fetch no resource, so the render prop takes no args. The
+  // wrapper emits <RestrictedState> when the loader verdict is restricted.
+  Page: (render: () => React.ReactNode) => () => React.ReactElement;
+}
+
 export function defineResourceRoute<TData>(
   input: DefineListPageInput
 ): DefineListRouteOutput<TData>;
@@ -46,13 +60,19 @@ export function defineResourceRoute<
   TCompanions extends Record<string, unknown> = Record<string, never>,
 >(input: DefineDetailPageInput<TData, TCompanions>): DefineDetailRouteOutput<TData, TCompanions>;
 
+export function defineResourceRoute(input: DefineGatePageInput): DefineGateRouteOutput;
+
 export function defineResourceRoute(input: unknown): unknown {
   const cfg = input as
     | DefineListPageInput
-    | DefineDetailPageInput<unknown, Record<string, unknown>>;
+    | DefineDetailPageInput<unknown, Record<string, unknown>>
+    | DefineGatePageInput;
 
   if (cfg.type === 'list') {
     return defineListRoute(cfg);
+  }
+  if (cfg.type === 'gate') {
+    return defineGateRoute(cfg);
   }
   return defineDetailRoute(cfg);
 }
@@ -83,6 +103,22 @@ function defineListRoute<TData>(cfg: DefineListPageInput): DefineListRouteOutput
           {(d, companions) => render({ data: d, companions })}
         </GuardedPage>
       );
+    };
+  };
+
+  return { meta, Page };
+}
+
+function defineGateRoute(cfg: DefineGatePageInput): DefineGateRouteOutput {
+  const meta: MetaFunction = mergeMeta(() => metaObject(cfg.metaTitle ?? cfg.restrictedTitle));
+
+  const Page: DefineGateRouteOutput['Page'] = (render) => {
+    return function GuardedGateOutlet() {
+      const loaderData = useLoaderData<GateLoaderData>();
+      if (loaderData.restricted) {
+        return <RestrictedState title={cfg.restrictedTitle} message={cfg.restrictedMessage} />;
+      }
+      return <>{render()}</>;
     };
   };
 

--- a/app/modules/rbac/run-resource-loader.ts
+++ b/app/modules/rbac/run-resource-loader.ts
@@ -3,7 +3,9 @@ import type {
   CompanionDeclaration,
   RunListLoaderInput,
   RunDetailLoaderInput,
+  RunRouteGateInput,
   DslLoaderData,
+  GateLoaderData,
 } from './types';
 import { logger } from '@/modules/logger';
 import { redirectWithToast } from '@/utils/cookies';
@@ -137,6 +139,41 @@ export async function runListLoader<TData>(
       data: result,
       companions: {},
     } satisfies DslLoaderData<TData, Record<string, never>>);
+  } catch (error) {
+    rethrowAsResponse(error);
+  }
+}
+
+/**
+ * Gate-only loader for routes that gate access but fetch no resource —
+ * create/"new" pages, action pages, and non-`get` settings sub-routes.
+ *
+ * Mirrors `runListLoader`'s gate, minus the fetch/seed: it reuses
+ * `resolveScopeContext` (so `projectId` is always set for project scope —
+ * the footgun that bit the inline `gateRouteAccess` callers) and the shared
+ * `rethrowAsResponse` AppError→Response mapping. Returns the `GateLoaderData`
+ * envelope; pair with `defineResourceRoute({ type: 'gate' })` on the page.
+ */
+export async function runRouteGate(args: LoaderFunctionArgs, cfg: RunRouteGateInput) {
+  try {
+    const ctx = resolveScopeContext(cfg.scope, args);
+
+    // gateRouteAccess's first positional arg is interpreted per cfg.scope —
+    // see resolveScopeContext + RbacService.resolveBaseURL (project no-op,
+    // org real id, user empty string).
+    const allowed = await gateRouteAccess(ctx.gateScopeId, {
+      resource: cfg.resource,
+      verb: cfg.verb,
+      group: cfg.group ?? '',
+      namespace: cfg.namespace,
+      scope: cfg.scope ?? 'project',
+      projectId: ctx.projectId,
+      // For scope='user' gates the URL :param is the resource name, not a
+      // scope identifier — pass it via check.name (mirrors runDetailLoader).
+      name: cfg.name,
+    });
+
+    return data({ restricted: !allowed } satisfies GateLoaderData);
   } catch (error) {
     rethrowAsResponse(error);
   }

--- a/app/modules/rbac/types.ts
+++ b/app/modules/rbac/types.ts
@@ -107,6 +107,13 @@ export type DslLoaderData<TData, TCompanions> =
   | { restricted: true }
   | { restricted: false; data: TData; companions: TCompanions };
 
+/**
+ * Envelope returned by `runRouteGate` — the gate-only DSL variant for routes
+ * that gate access but fetch no resource (create/"new" pages, action pages,
+ * non-`get` settings sub-routes). No `data`/`companions`, just the verdict.
+ */
+export type GateLoaderData = { restricted: boolean };
+
 /** Per-verb React Query options forwarded to the underlying SSAR call. */
 export interface ResourcePermissionVerbOptions {
   staleTime?: number;
@@ -247,6 +254,19 @@ export interface DefineDetailPageInput<TData, TCompanions extends Record<string,
 }
 
 /**
+ * Page-side input for the gate-only DSL variant (`type: 'gate'`). Client-safe
+ * metadata only — the gate verb/group/scope drive the server-only loader and
+ * live in `RunRouteGateInput`. Used for create/"new" and non-`get` settings
+ * routes that gate access but fetch no resource.
+ */
+export interface DefineGatePageInput {
+  type: 'gate';
+  restrictedTitle?: string;
+  restrictedMessage: string;
+  metaTitle?: string;
+}
+
+/**
  * Server-side input for `runListLoader` / `runDetailLoader`. Contains the
  * gate inputs (`group`/`scope`/`namespace`) and the `fetch` closure.
  * Lives in the same types file because it's small and shares the
@@ -259,6 +279,23 @@ export interface RunListLoaderInput<TData> {
   namespace?: string;
   scope?: 'project' | 'org' | 'user';
   fetch: (ctx: { projectId?: string; orgId?: string; args: LoaderFunctionArgs }) => Promise<TData>;
+}
+
+/**
+ * Server-side input for `runRouteGate` — the gate-only loader. No `fetch`;
+ * `verb` is explicit (unlike `runListLoader`/`runDetailLoader` which hardcode
+ * `list`/`get`) so create/patch/etc. routes can gate the verb they perform.
+ * Scope handling (incl. `projectId` resolution) is shared with the other
+ * loaders via `resolveScopeContext`, so callers can't forget `projectId`.
+ */
+export interface RunRouteGateInput {
+  resource: string;
+  verb: PermissionVerb;
+  group?: string;
+  namespace?: string;
+  scope?: 'project' | 'org' | 'user';
+  /** For scope='user' gates where a URL param is the resource name, not a scope id. */
+  name?: string;
 }
 
 export interface RunDetailLoaderInput<TData, TCompanions extends Record<string, unknown>> {

--- a/app/routes/project/detail/metrics/detail/settings.tsx
+++ b/app/routes/project/detail/metrics/detail/settings.tsx
@@ -1,17 +1,19 @@
-import { RestrictedState } from '@/components/restricted-state/restricted-state';
 import { ExportPolicyUpdateForm } from '@/features/metric/export-policies/form/update-form';
 import { useGuardedRouteData } from '@/modules/rbac';
-import { gateRouteAccess } from '@/modules/rbac/server/check-permission';
+import { defineResourceRoute } from '@/modules/rbac/define-resource-route';
+import { runRouteGate } from '@/modules/rbac/run-resource-loader';
 import { type ExportPolicy, type IExportPolicyControlResponse } from '@/resources/export-policies';
-import { BadRequestError, withLoaderErrors } from '@/utils/errors';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
-import {
-  data,
-  useLoaderData,
-  useParams,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from 'react-router';
+import { useParams, type LoaderFunctionArgs, type MetaFunction } from 'react-router';
+
+// Gate-only route: render-side restriction comes from `route.Page`. We keep a
+// custom `meta` (reads the parent export-policy-detail match) and `handle`
+// rather than the gate DSL's metaTitle, so only `route.Page` is used here.
+const route = defineResourceRoute({
+  type: 'gate',
+  restrictedTitle: 'Access restricted',
+  restrictedMessage: "You don't have permission to edit this export policy.",
+});
 
 export const handle = {
   breadcrumb: () => <span>Settings</span>,
@@ -24,40 +26,15 @@ export const meta: MetaFunction = mergeMeta(({ matches }) => {
   return metaObject((exportPolicy as ExportPolicy)?.name || 'Export Policy');
 });
 
-export const loader = withLoaderErrors(async (args: LoaderFunctionArgs) => {
-  const { projectId, exportPolicyId } = args.params;
-  if (!projectId || !exportPolicyId) {
-    throw new BadRequestError('Project ID and export policy ID are required');
-  }
-
-  const allowed = await gateRouteAccess(projectId, {
+export const loader = (args: LoaderFunctionArgs) =>
+  runRouteGate(args, {
     resource: 'exportpolicies',
     verb: 'patch',
     group: 'telemetry.miloapis.com',
     scope: 'project',
   });
 
-  if (!allowed) {
-    return data({ restricted: true as const });
-  }
-
-  return data({ restricted: false as const });
-});
-
-export default function ExportPolicySettingsPage() {
-  const loaderData = useLoaderData<typeof loader>();
-
-  if (loaderData.restricted) {
-    return (
-      <RestrictedState
-        title="Access restricted"
-        message="You don't have permission to edit this export policy."
-      />
-    );
-  }
-
-  return <SettingsForm />;
-}
+export default route.Page(() => <SettingsForm />);
 
 function SettingsForm() {
   const { data } = useGuardedRouteData<ExportPolicy, Record<string, never>>('export-policy-detail');

--- a/app/routes/project/detail/metrics/detail/settings.tsx
+++ b/app/routes/project/detail/metrics/detail/settings.tsx
@@ -35,6 +35,10 @@ export const loader = withLoaderErrors(async (args: LoaderFunctionArgs) => {
     verb: 'patch',
     group: 'telemetry.miloapis.com',
     scope: 'project',
+    // Required for project-scoped checks: RbacService.resolveBaseURL reads
+    // check.projectId (the first positional arg is ignored for scope:'project').
+    // Omitting it throws "projectId is required…" → the check fails closed.
+    projectId,
   });
 
   if (!allowed) {

--- a/app/routes/project/detail/metrics/new.tsx
+++ b/app/routes/project/detail/metrics/new.tsx
@@ -28,6 +28,10 @@ export const loader = withLoaderErrors(async (args: LoaderFunctionArgs) => {
     verb: 'create',
     group: 'telemetry.miloapis.com',
     scope: 'project',
+    // Required for project-scoped checks: RbacService.resolveBaseURL reads
+    // check.projectId (the first positional arg is ignored for scope:'project').
+    // Omitting it throws "projectId is required…" → the check fails closed.
+    projectId,
   });
 
   if (!allowed) return data({ restricted: true as const });

--- a/app/routes/project/detail/metrics/new.tsx
+++ b/app/routes/project/detail/metrics/new.tsx
@@ -1,53 +1,28 @@
-import { RestrictedState } from '@/components/restricted-state/restricted-state';
 import { ExportPolicyComingSoonCard } from '@/features/metric/export-policies/card/coming-soon-card';
 import { ExportPolicyGrafanaCard } from '@/features/metric/export-policies/card/grafana-card';
-import { gateRouteAccess } from '@/modules/rbac/server/check-permission';
-import { BadRequestError, withLoaderErrors } from '@/utils/errors';
-import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
+import { defineResourceRoute } from '@/modules/rbac/define-resource-route';
+import { runRouteGate } from '@/modules/rbac/run-resource-loader';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
 import { useEffect, useRef } from 'react';
-import {
-  data,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-  useLoaderData,
-  useParams,
-  useSearchParams,
-} from 'react-router';
+import { type LoaderFunctionArgs, useParams, useSearchParams } from 'react-router';
 
-export const meta: MetaFunction = mergeMeta(() => {
-  return metaObject('Create an Export Policy');
+const route = defineResourceRoute({
+  type: 'gate',
+  restrictedTitle: 'Access restricted',
+  restrictedMessage: "You don't have permission to create export policies.",
+  metaTitle: 'Create an Export Policy',
 });
 
-export const loader = withLoaderErrors(async (args: LoaderFunctionArgs) => {
-  const projectId = args.params.projectId;
-  if (!projectId) throw new BadRequestError('Project ID is required');
-
-  const allowed = await gateRouteAccess(projectId, {
+export const loader = (args: LoaderFunctionArgs) =>
+  runRouteGate(args, {
     resource: 'exportpolicies',
     verb: 'create',
     group: 'telemetry.miloapis.com',
     scope: 'project',
   });
+export const meta = route.meta;
 
-  if (!allowed) return data({ restricted: true as const });
-  return data({ restricted: false as const });
-});
-
-export default function ExportPoliciesNewPage() {
-  const loaderData = useLoaderData<typeof loader>();
-
-  if (loaderData.restricted) {
-    return (
-      <RestrictedState
-        title="Access restricted"
-        message="You don't have permission to create export policies."
-      />
-    );
-  }
-
-  return <NewForm />;
-}
+export default route.Page(() => <NewForm />);
 
 function NewForm() {
   const { projectId } = useParams();

--- a/app/routes/project/detail/service-accounts/new.tsx
+++ b/app/routes/project/detail/service-accounts/new.tsx
@@ -1,60 +1,36 @@
-import { RestrictedState } from '@/components/restricted-state/restricted-state';
 import { CiCdCard } from '@/features/service-account/card/ci-cd-card';
 import { ServiceCard } from '@/features/service-account/card/service-card';
 import { CreateServiceAccountWizard } from '@/features/service-account/wizard/create-service-account-wizard';
-import { gateRouteAccess } from '@/modules/rbac/server/check-permission';
+import { defineResourceRoute } from '@/modules/rbac/define-resource-route';
+import { runRouteGate } from '@/modules/rbac/run-resource-loader';
 import {
   useCaseSchema,
   type CreateServiceAccountKeyResponse,
   type UseCase,
 } from '@/resources/service-accounts';
 import { paths } from '@/utils/config/paths.config';
-import { BadRequestError, withLoaderErrors } from '@/utils/errors';
-import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Col, Row } from '@datum-cloud/datum-ui/grid';
 import { useEffect, useRef, useState } from 'react';
-import {
-  data,
-  type LoaderFunctionArgs,
-  MetaFunction,
-  useLoaderData,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from 'react-router';
+import { type LoaderFunctionArgs, useNavigate, useParams, useSearchParams } from 'react-router';
 
-export const meta: MetaFunction = mergeMeta(() => metaObject('Create a Service Account'));
+const route = defineResourceRoute({
+  type: 'gate',
+  restrictedTitle: 'Access restricted',
+  restrictedMessage: "You don't have permission to create service accounts.",
+  metaTitle: 'Create a Service Account',
+});
 
-export const loader = withLoaderErrors(async (args: LoaderFunctionArgs) => {
-  const projectId = args.params.projectId;
-  if (!projectId) throw new BadRequestError('Project ID is required');
-
-  const allowed = await gateRouteAccess(projectId, {
+export const loader = (args: LoaderFunctionArgs) =>
+  runRouteGate(args, {
     resource: 'serviceaccounts',
     verb: 'create',
     group: 'iam.miloapis.com',
     scope: 'project',
   });
+export const meta = route.meta;
 
-  if (!allowed) return data({ restricted: true as const });
-  return data({ restricted: false as const });
-});
-
-export default function ServiceAccountsNewPage() {
-  const loaderData = useLoaderData<typeof loader>();
-
-  if (loaderData.restricted) {
-    return (
-      <RestrictedState
-        title="Access restricted"
-        message="You don't have permission to create service accounts."
-      />
-    );
-  }
-
-  return <NewPageInner />;
-}
+export default route.Page(() => <NewPageInner />);
 
 function NewPageInner() {
   const { projectId } = useParams();

--- a/app/routes/project/detail/service-accounts/new.tsx
+++ b/app/routes/project/detail/service-accounts/new.tsx
@@ -35,6 +35,10 @@ export const loader = withLoaderErrors(async (args: LoaderFunctionArgs) => {
     verb: 'create',
     group: 'iam.miloapis.com',
     scope: 'project',
+    // Required for project-scoped checks: RbacService.resolveBaseURL reads
+    // check.projectId (the first positional arg is ignored for scope:'project').
+    // Omitting it throws "projectId is required…" → the check fails closed.
+    projectId,
   });
 
   if (!allowed) return data({ restricted: true as const });

--- a/cypress/e2e/smoke/export-policy-new.cy.ts
+++ b/cypress/e2e/smoke/export-policy-new.cy.ts
@@ -1,0 +1,29 @@
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+
+/**
+ * Export Policy "New" page — RBAC smoke.
+ *
+ * Verifies the create page renders the create UI for a permitted user (the CI
+ * owner role) rather than RestrictedState. Guards the regression where the
+ * project-scoped route gate dropped `check.projectId` and failed closed, so
+ * even an owner saw "Access restricted" (#1297). The page gates
+ * `exportpolicies:create` via runRouteGate.
+ */
+describe('Export Policy new page', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('renders the create UI (not RestrictedState) for a permitted user', () => {
+    cy.getProjectId().then((projectId) => {
+      cy.visit(getPathWithParams(paths.project.detail.metrics.new, { projectId }));
+    });
+
+    // The Grafana export card only renders when the gate allows access — its
+    // presence proves RBAC did not block the page.
+    cy.contains('h3', 'Export to Grafana Cloud', { timeout: 10000 }).should('be.visible');
+    // Explicit: the restricted state must not be shown for a permitted user.
+    cy.contains('Access restricted').should('not.exist');
+  });
+});

--- a/cypress/e2e/smoke/service-account-new.cy.ts
+++ b/cypress/e2e/smoke/service-account-new.cy.ts
@@ -1,0 +1,30 @@
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+
+/**
+ * Service Account "New" page — RBAC smoke.
+ *
+ * Verifies the create page renders the create UI for a permitted user (the CI
+ * owner role) rather than RestrictedState. Guards the regression where the
+ * project-scoped route gate dropped `check.projectId` and failed closed, so
+ * even an owner saw "Access restricted" (#1297). The page gates
+ * `serviceaccounts:create` via runRouteGate.
+ */
+describe('Service Account new page', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('renders the create UI (not RestrictedState) for a permitted user', () => {
+    cy.getProjectId().then((projectId) => {
+      cy.visit(getPathWithParams(paths.project.detail.serviceAccounts.new, { projectId }));
+    });
+
+    // The create cards only render when the gate allows access — their
+    // presence proves RBAC did not block the page.
+    cy.contains('h3', 'CI/CD Pipeline', { timeout: 10000 }).should('be.visible');
+    cy.contains('h3', 'Service').should('be.visible');
+    // Explicit: the restricted state must not be shown for a permitted user.
+    cy.contains('Access restricted').should('not.exist');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a gate-only variant to the RBAC route DSL so create/"new" and non-`get` settings pages gate access through the same runtime as list/detail routes — and smoke tests that prove those pages aren't wrongly blocked for permitted users.

Previously these pages couldn't use the DSL (it gates **and fetches** a resource), so they hand-rolled `gateRouteAccess` inline. That inline path is error-prone: a project-scoped check must duplicate `projectId` into the check object (the positional arg is ignored for `scope: 'project'`), and forgetting it makes the gate throw → fail closed → even an owner sees `RestrictedState`.

## `runRouteGate`

- **`runRouteGate(args, cfg)`** (server) — gates an explicit `verb` with no fetch; reuses `resolveScopeContext` so `projectId` is always set, plus the shared `rethrowAsResponse` AppError→Response mapping.
- **`defineResourceRoute({ type: 'gate' })`** (client) — `Page(render)` that emits `RestrictedState` on a restricted verdict; render prop takes no args (no fetched resource).
- New types: `GateLoaderData`, `RunRouteGateInput`, `DefineGatePageInput`.

Migrated the three inline-gated routes, removing the bespoke `gateRouteAccess` + manual `RestrictedState`:
- `service-accounts/new` (create)
- `metrics/new` (create)
- `metrics/detail/settings` (patch; keeps its parent-match `meta` + `handle`)

**Every RBAC route gate now flows through the DSL runtime — the missing-`projectId` footgun is structurally impossible.**

## E2E smoke tests

Two specs that visit the create pages as the CI owner role and assert the create UI renders (not `RestrictedState`), so a fail-closed gate regression goes red immediately:
- `cypress/e2e/smoke/service-account-new.cy.ts` — CI/CD + Service cards present, no "Access restricted".
- `cypress/e2e/smoke/export-policy-new.cy.ts` — Export to Grafana Cloud card present, no "Access restricted".

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors
- [x] `bun run build` — succeeds
- [x] E2E smoke (runs on PR) — both new specs green
- [x] Manual (denied user): the three routes show RestrictedState