### PR TITLE
fix: point assistant Service producer to datum-cloud

### DIFF
--- a/config/services/services_v1alpha1_service_assistant.yaml
+++ b/config/services/services_v1alpha1_service_assistant.yaml
@@ -16,4 +16,4 @@ spec:
     meter family declared by this service.
   owner:
     producerProjectRef:
-      name: cloud-portal
+      name: datum-cloud


### PR DESCRIPTION
## What

Repoint the `assistant.miloapis.com` Service's `owner.producerProjectRef.name` from `cloud-portal` to `datum-cloud`.

## Why

The `cloud-portal` producer project does not exist in any environment's resourcemanager (`get project cloud-portal` → `NotFound`). The `service-entitlement` controller resolves the producer control plane by that name to upsert each consumer's `ServiceConsumer`, so every AI Assistant `ServiceEntitlement` stalls with:

```
INFO  provider cluster not yet available, requeuing
  controller: service-entitlement
  cluster:         <consumer-project>
  providerProject: cloud-portal
  err: "cluster cloud-portal not found"
```

It never reaches `PendingApproval`/`Active`.

The other two first-party Services both use the existing `datum-cloud` producer project, and their entitlements activate normally:

| Service | producerProjectRef | project exists | entitlements |
|---|---|---|---|
| compute.datumapis.com | datum-cloud | yes | Active |
| billing.miloapis.com | datum-cloud | yes | Active |
| assistant.miloapis.com | cloud-portal | **no** | stuck |

Pointing assistant at `datum-cloud` makes it consistent with billing/compute and lets entitlements provision against an existing control plane.

## Verified (staging)

- `assistant-miloapis-com` Service `owner.producerProjectRef.name: cloud-portal`; `kubectl get project cloud-portal` → NotFound; only `datum-cloud` matches.
- A `ServiceEntitlement` for assistant in a real consumer project loops on `cluster cloud-portal not found` on the `services-controller-manager` leader.
- Bundle is applied to clusters by Flux from infra (`apps/cloud-portal/base/milo-services.yaml`); no env overlays, so this base change covers staging and prod.