### PR TITLE
fix: register feature flag provider at server boot

### DIFF
--- a/app/server/entry.ts
+++ b/app/server/entry.ts
@@ -9,6 +9,7 @@ import type { Variables } from './types';
 // This allows generated OpenAPI functions to work on server-side
 // Token and requestId will be auto-injected via AsyncLocalStorage
 import '@/modules/control-plane/setup.server';
+import { ensureFeatureFlagProvider } from '@/modules/feature-flags/setup.server';
 import { Logger } from '@/modules/logger';
 // Side-effect import: registers RBAC prom-client metrics into the global registry
 // at module-load time so they appear on the /metrics endpoint.
@@ -40,6 +41,11 @@ process.once('SIGINT', beginShutdown);
 sessionManager.registerRefreshHook(({ userId, accessToken }) => {
   watchHub.updateTokensByUserId(userId, accessToken);
 });
+
+// Register the OpenFeature provider at startup. Called explicitly (rather than
+// relying on a bare side-effect import) so `"sideEffects": false` tree-shaking
+// can't drop the registration from the production server bundle.
+ensureFeatureFlagProvider();
 
 // Initialize observability (OTEL + Sentry + error handlers)
 initializeObservability().catch((error: unknown) => {


### PR DESCRIPTION
The OpenFeature MiloFeatureFlagProvider was registered only via a bare side-effect import (`import './setup.server'` in evaluate.server.ts, which self-invokes ensureFeatureFlagProvider at module load). With `"sideEffects": false` in package.json, the production Rollup build tree-shakes that unused import away, so the provider is never registered in the deployed server bundle. OpenFeature then falls back to its no-op default and every flag resolves to false — with no HTTP call and no error — even when the org holds a valid entitlement.

The Vite dev server does not tree-shake, so the provider registers and flags work locally, masking the issue.

Call ensureFeatureFlagProvider() explicitly from the server entry so the registration is a used binding that survives tree-shaking, mirroring how entry.ts already initializes observability and control-plane setup.

Verified against a production build: MiloFeatureFlagProvider is absent from build/server/ before this change and present after.