### PR TITLE
fix(usage): emit assistant model as resource label, not meter dimension

### DIFF
--- a/app/modules/usage/assistant-events.ts
+++ b/app/modules/usage/assistant-events.ts
@@ -51,7 +51,12 @@ export function buildAssistantUsageEvents(input: BuildAssistantUsageInput): Usag
   const timestamp = new Date(now).toISOString();
   const projectRef = { name: projectName };
 
-  const dimensions: Record<string, string> = { model };
+  // No meter dimensions: the assistant MeterDefinitions declare none, and
+  // the central validator quarantines any event whose data.dimensions key
+  // isn't a declared subset (billing/internal/controller/consumer/validate.go).
+  // `model` is carried as a resource label instead — it's declared on the
+  // assistant.miloapis.com/Conversation MonitoredResourceType.
+  const dimensions: Record<string, string> = {};
 
   const labels: Record<string, string> = { model };
 

--- a/cypress/component/usage-emitter.cy.ts
+++ b/cypress/component/usage-emitter.cy.ts
@@ -105,7 +105,10 @@ describe('buildAssistantUsageEvents', () => {
     expect(evt.timestamp).to.equal('2026-04-27T17:00:00.000Z');
     expect(evt.projectRef).to.deep.equal({ name: 'proj-abc' });
     expect(evt.value).to.equal('10');
-    expect(evt.dimensions).to.deep.equal({ model: 'claude-sonnet-4-6' });
+    // `model` is a resource label, not a meter dimension: the assistant
+    // MeterDefinitions declare no dimensions, so the central validator
+    // quarantines any event that carries one.
+    expect(evt.dimensions).to.deep.equal({});
     expect(evt.resource).to.deep.equal({
       ref: {
         projectRef: { name: 'proj-abc' },
@@ -155,7 +158,9 @@ describe('toCloudEvent', () => {
     expect(ce.datacontenttype).to.equal('application/json');
     expect(ce.time).to.equal('2026-04-27T17:00:00.000Z');
     expect(ce.data.value).to.equal('1200');
-    expect(ce.data.dimensions).to.deep.equal({ model: 'claude-sonnet-4-6' });
+    // Builder emits empty dimensions (model is a resource label), so the
+    // envelope drops the key entirely rather than sending `{}`.
+    expect(ce.data.dimensions).to.equal(undefined);
     expect(ce.data.resource).to.deep.equal({
       group: ASSISTANT_RESOURCE_GROUP,
       kind: ASSISTANT_RESOURCE_KIND,
@@ -175,8 +180,7 @@ describe('toCloudEvent', () => {
   });
 
   it('omits dimensions when empty rather than emitting `{}`', () => {
-    // Manual UsageEvent with no dimensions — the builder always sets
-    // model, but downstream callers may not. Empty dimensions confuse
+    // Manual UsageEvent with no dimensions. Empty dimensions confuse
     // gateway log analysis, so we drop the key.
     const ce = toCloudEvent(
       {


### PR DESCRIPTION
## Problem

AI assistant usage never appears on the staff-portal usage page, even though the portal emits events and the billing gateway accepts them.

Verified end-to-end in **staging**: every assistant usage event is **quarantined** by the billing central validator with reason `invalid_dimensions`, routed to `billing.usage.<project>.quarantine.invalid_dimensions`. Quarantined events never reach `.valid` → never submitted to Amberflo → invisible on the usage page.

```
usage-consumer  event quarantined  project=first-project-znu0kx
  reason=invalid_dimensions  eventType=assistant.miloapis.com/conversation/input-tokens
```

## Root cause

The portal stamps `data.dimensions = { model }` on every assistant usage event (`assistant-events.ts`). The billing validator (`billing/internal/controller/consumer/validate.go`) quarantines any event whose `data.dimensions` key isn't a declared subset of the meter's `Measurement.Dimensions` — and the assistant `MeterDefinition`s declare **no** dimensions. So 100% of assistant usage fails validation.

`model` *is* a declared attribute, but as a **MonitoredResourceType label** (`assistant.miloapis.com/Conversation`), which is a different field the validator doesn't check against meter dimensions.

## Fix

Emit `model` only as a `resource.labels` entry; leave meter `dimensions` empty. `to-cloud-event` already omits empty dimensions, so the wire event carries no `data.dimensions` and passes validation. Per-model attribution is preserved via the resource label.

> Carrying `model` as a true meter dimension (for provider-side grouping) would require adding a `Dimensions` field to `MetricSpec` in the **service-catalog** repo + fan-out controller + a release — that schema field does not exist today. Tracked separately; out of scope here.

## Changes

- `app/modules/usage/assistant-events.ts` — `dimensions` is now empty; `model` stays in `resource.labels`.
- `cypress/component/usage-emitter.cy.ts` — updated assertions + a stale comment.

## Test plan

- [x] `cypress run --component --spec cypress/component/usage-emitter.cy.ts` — 11 passing
- [x] pre-commit prettier / eslint / typecheck pass
- [ ] After deploy to staging: send a project-scoped chat and confirm the validator no longer logs `invalid_dimensions` for the project (events should reach `.valid`).

## Caveats (post-merge)

1. **No backfill** — already-quarantined events won't replay (no replay tool yet). Only chats sent after deploy will show.
2. **Downstream gates now exercised for the first time** — watch for `attribution_failure` (project needs an Active `BillingAccountBinding` + Ready `BillingAccount`) or Amberflo `ErrCustomerNotFound` (account not yet synced as a customer).