### PR TITLE
feat(billing): declare model dimension on assistant meters

### DIFF
--- a/config/services/services_v1alpha1_serviceconfiguration_assistant.yaml
+++ b/config/services/services_v1alpha1_serviceconfiguration_assistant.yaml
@@ -41,6 +41,11 @@ spec:
         here.
       kind: Delta
       unit: "{token}"
+      # Per-model unit economics: each model has a different cost, so the
+      # rating engine prices on this dimension. The producer emits `model`
+      # in data.dimensions; the central validator requires it declared here.
+      dimensions:
+        - model
     - name: assistant.miloapis.com/conversation/output-tokens
       displayName: Assistant Output Tokens
       description: |
@@ -50,6 +55,8 @@ spec:
         model.
       kind: Delta
       unit: "{token}"
+      dimensions:
+        - model
     - name: assistant.miloapis.com/conversation/cache-read-tokens
       displayName: Assistant Cache-Read Tokens
       description: |
@@ -59,6 +66,8 @@ spec:
         metered as a distinct dimension.
       kind: Delta
       unit: "{token}"
+      dimensions:
+        - model
     - name: assistant.miloapis.com/conversation/cache-write-tokens
       displayName: Assistant Cache-Write Tokens
       description: |
@@ -69,6 +78,8 @@ spec:
         are metered as a distinct dimension.
       kind: Delta
       unit: "{token}"
+      dimensions:
+        - model
     - name: assistant.miloapis.com/conversation/messages
       displayName: Assistant Messages
       description: |
@@ -78,6 +89,8 @@ spec:
         when token data is unavailable.
       kind: Delta
       unit: "{message}"
+      dimensions:
+        - model
   billing:
     consumerDestinations:
       - monitoredResourceType: assistant.miloapis.com/Conversation


### PR DESCRIPTION
## Why

AI assistant usage never reaches the billing rating engine. Verified in **staging**: every assistant usage event is quarantined by the billing central validator with reason `invalid_dimensions` (subject `billing.usage.<project>.quarantine.invalid_dimensions`), so nothing flows to `.valid` → nothing is submitted to Amberflo → nothing on the usage page.

Root cause: the portal emits `model` in `data.dimensions` (correct — each model has a different cost and must be priced per model), but the assistant MeterDefinitions declare **no** dimensions. The validator quarantines any event whose dimension keys aren't declared on the meter.

Why a dimension and not a resource label: the amberflo-provider submission-consumer forwards only `data.dimensions` to Amberflo and drops `data.resource.labels` entirely (`internal/submission/submission.go:60-66, 293-300`). A label-only `model` would never reach the rating engine, so per-model pricing requires a true meter dimension.

## What

Declare `dimensions: [model]` on all five assistant conversation meters in the ServiceConfiguration (input-tokens, output-tokens, cache-read-tokens, cache-write-tokens, messages). No producer change needed — `assistant-events.ts` on `main` already emits the `model` dimension.

## Depends on

⚠️ **Merge + release order matters.** This requires `MetricSpec.dimensions` support in service-catalog: **milo-os/service-catalog#39**. Until that CRD ships, the `metrics[].dimensions` field is pruned/rejected by the API server. Do not merge/deploy this until #39 is released and deployed.

## Test plan

- [x] YAML parses; all five metrics carry `dimensions: [model]`
- [ ] After service-catalog#39 is deployed: apply this ServiceConfiguration and confirm the generated MeterDefinitions show `spec.measurement.dimensions: [model]`
- [ ] Send a project-scoped chat in staging and confirm the validator no longer logs `invalid_dimensions` (events reach `.valid`)
- [ ] Confirm per-model usage appears in Amberflo / the staff-portal usage page

## Caveats

- **No backfill** — already-quarantined events won't replay (no replay tool yet); only post-deploy chats appear.
- **Downstream attribution gates** are now exercised for the first time: the project needs an Active `BillingAccountBinding` + Ready `BillingAccount`, and that account must be synced as an Amberflo customer, or you'll see `attribution_failure` / `ErrCustomerNotFound`.