### PR TITLE
fix(quotas): group compute service quotas with readable names

### DIFF
--- a/app/features/quotas/quotas-table.tsx
+++ b/app/features/quotas/quotas-table.tsx
@@ -1,5 +1,5 @@
 import { groupQuotas, type QuotaRow } from './quotas-grouping';
-import { resolveServiceDisplayName } from './service-catalog';
+import { resolveResourceDisplayName, resolveServiceDisplayName } from './service-catalog';
 import { sortableHeader, TableSearch } from '@/components/table';
 import type { AllowanceBucket } from '@/resources/allowance-buckets';
 import type { Organization } from '@/resources/organizations';
@@ -78,7 +78,7 @@ export const QuotasTable = ({
         const { percentage } = calculateUsage(b.status ?? { allocated: 0n, limit: 0n });
         return {
           resourceType: b.resourceType,
-          displayName: reg?.displayName ?? b.resourceType,
+          displayName: resolveResourceDisplayName(reg?.displayName, b.resourceType),
           group: resolveServiceDisplayName(reg?.service, b.resourceType),
           percentage,
           description: reg?.description,

--- a/app/features/quotas/service-catalog.test.ts
+++ b/app/features/quotas/service-catalog.test.ts
@@ -1,4 +1,8 @@
-import { resolveServiceDisplayName, OTHER_GROUP } from './service-catalog';
+import {
+  resolveResourceDisplayName,
+  resolveServiceDisplayName,
+  OTHER_GROUP,
+} from './service-catalog';
 import { describe, expect, it } from 'bun:test';
 
 describe('resolveServiceDisplayName', () => {
@@ -18,7 +22,31 @@ describe('resolveServiceDisplayName', () => {
     );
   });
 
+  it('groups compute fan-out registrations under Compute via the owner label', () => {
+    expect(
+      resolveServiceDisplayName('compute.datumapis.com', 'compute.datumapis.com/instances')
+    ).toBe('Compute');
+  });
+
   it('returns the Other group when nothing matches', () => {
     expect(resolveServiceDisplayName(undefined, 'unknown.example.com/widgets')).toBe(OTHER_GROUP);
+  });
+});
+
+describe('resolveResourceDisplayName', () => {
+  it('prefers the server-authored display name', () => {
+    expect(resolveResourceDisplayName('Compute Instances', 'compute.datumapis.com/instances')).toBe(
+      'Compute Instances'
+    );
+  });
+
+  it('falls back to the interim resourceType map when the annotation is missing', () => {
+    expect(resolveResourceDisplayName(undefined, 'compute.datumapis.com/vcpus')).toBe('vCPUs');
+  });
+
+  it('returns the raw resourceType when nothing matches', () => {
+    expect(resolveResourceDisplayName(undefined, 'unknown.example.com/widgets')).toBe(
+      'unknown.example.com/widgets'
+    );
   });
 });

--- a/app/features/quotas/service-catalog.ts
+++ b/app/features/quotas/service-catalog.ts
@@ -17,6 +17,22 @@ const SERVICE_DISPLAY_NAMES: Record<string, string> = {
   'dns.networking.miloapis.com': 'DNS',
   'networking.datumapis.com': 'Networking',
   'resourcemanager.miloapis.com': 'Organization & Projects',
+  'compute.datumapis.com': 'Compute',
+};
+
+/**
+ * INTERIM resourceType → row display name, for registrations the server emits
+ * without a `kubernetes.io/display-name` annotation. The milo service-catalog
+ * quota fan-out (compute, and future fan-out services) stamps no display
+ * annotations — its `QuotaLimitSpec` has no displayName/description field — so
+ * rows would otherwise read as raw `compute.datumapis.com/instances`. Remove
+ * entries as the fan-out learns to emit display metadata.
+ */
+const RESOURCE_DISPLAY_NAMES: Record<string, string> = {
+  'compute.datumapis.com/instances': 'Instances',
+  'compute.datumapis.com/vcpus': 'vCPUs',
+  'compute.datumapis.com/memory': 'Memory',
+  'compute.datumapis.com/workloads': 'Workloads',
 };
 
 /**
@@ -51,4 +67,16 @@ export function resolveServiceDisplayName(owner: string | undefined, resourceTyp
     return OTHER_GROUP;
   }
   return SERVICE_DISPLAY_NAMES[serviceName] ?? OTHER_GROUP;
+}
+
+/**
+ * Resolve a quota row's display name. Prefers the server-authored
+ * `kubernetes.io/display-name` annotation, then the interim resourceType map,
+ * then the raw resourceType key as a last resort.
+ */
+export function resolveResourceDisplayName(
+  serverDisplayName: string | undefined,
+  resourceType: string
+): string {
+  return serverDisplayName ?? RESOURCE_DISPLAY_NAMES[resourceType] ?? resourceType;
 }

--- a/app/resources/resource-registrations/resource-registration.adapter.ts
+++ b/app/resources/resource-registrations/resource-registration.adapter.ts
@@ -18,6 +18,11 @@ export function toResourceRegistration(
     type: raw.spec.type,
     displayName: annotations['kubernetes.io/display-name'],
     description: annotations['kubernetes.io/description'] ?? raw.spec.description,
-    service: labels['services.miloapis.com/owner'],
+    // Two registration-authoring patterns stamp different owner-label keys:
+    // hand-written registrations use `services.miloapis.com/owner`, while the
+    // milo service-catalog quota fan-out stamps `services.miloapis.com/service`.
+    // Read both so fan-out services (e.g. compute) group correctly.
+    service:
+      labels['services.miloapis.com/owner'] ?? labels['services.miloapis.com/service'],
   };
 }


### PR DESCRIPTION
## Problem
Compute quotas (`compute.datumapis.com/instances`, `/vcpus`, `/memory`, `/workloads`) render in the **Other** group with raw `resourceType` labels instead of a **Compute** section with readable names.

## Root cause
These registrations are produced by the **milo service-catalog quota fan-out** (`milo-os/service-catalog`), a different path than the hand-written dns/networking registrations:
- It stamps the owner label under **`services.miloapis.com/service`**, but the portal adapter only read `services.miloapis.com/owner` → no owner resolved → "Other".
- It emits **no `kubernetes.io/display-name`/`description` annotations** (its `QuotaLimitSpec` has no display fields) → rows show raw keys.

## Changes (portal, interim)
- Adapter reads **both** owner-label keys (`/owner` ?? `/service`) so all fan-out services group correctly — not just compute.
- Add `compute.datumapis.com → Compute` to the service map.
- Add an interim `resourceType → display-name` map (Instances / vCPUs / Memory / Workloads) via a new `resolveResourceDisplayName` helper, used for the row label.

## Durable fix (backend, separate)
Tracked in `milo-os/service-catalog`: add `DisplayName`/`Description` to `QuotaLimitSpec` and stamp `kubernetes.io/display-name`/`description` annotations in the quota fan-out; then populate them in `datum-cloud/compute`'s `service-configuration.yaml`. Once that lands, the interim resourceType map can be removed.