### PR TITLE
fix(quotas): group billing quota with a readable name

### DIFF
--- a/app/features/quotas/service-catalog.test.ts
+++ b/app/features/quotas/service-catalog.test.ts
@@ -28,6 +28,12 @@ describe('resolveServiceDisplayName', () => {
     ).toBe('Compute');
   });
 
+  it('groups billing fan-out registrations under Billing via the owner label', () => {
+    expect(
+      resolveServiceDisplayName('billing.miloapis.com', 'billing.miloapis.com/billingaccount/count')
+    ).toBe('Billing');
+  });
+
   it('returns the Other group when nothing matches', () => {
     expect(resolveServiceDisplayName(undefined, 'unknown.example.com/widgets')).toBe(OTHER_GROUP);
   });
@@ -42,6 +48,9 @@ describe('resolveResourceDisplayName', () => {
 
   it('falls back to the interim resourceType map when the annotation is missing', () => {
     expect(resolveResourceDisplayName(undefined, 'compute.datumapis.com/vcpus')).toBe('vCPUs');
+    expect(resolveResourceDisplayName(undefined, 'billing.miloapis.com/billingaccount/count')).toBe(
+      'Billing Accounts'
+    );
   });
 
   it('returns the raw resourceType when nothing matches', () => {

--- a/app/features/quotas/service-catalog.ts
+++ b/app/features/quotas/service-catalog.ts
@@ -18,6 +18,7 @@ const SERVICE_DISPLAY_NAMES: Record<string, string> = {
   'networking.datumapis.com': 'Networking',
   'resourcemanager.miloapis.com': 'Organization & Projects',
   'compute.datumapis.com': 'Compute',
+  'billing.miloapis.com': 'Billing',
 };
 
 /**
@@ -33,6 +34,7 @@ const RESOURCE_DISPLAY_NAMES: Record<string, string> = {
   'compute.datumapis.com/vcpus': 'vCPUs',
   'compute.datumapis.com/memory': 'Memory',
   'compute.datumapis.com/workloads': 'Workloads',
+  'billing.miloapis.com/billingaccount/count': 'Billing Accounts',
 };
 
 /**


### PR DESCRIPTION
## Problem
The `billing.miloapis.com/billingaccount/count` quota renders in the **Other** group with its raw key instead of a **Billing** section with a readable name.

## Root cause
Same pattern as compute — it's produced by the milo **service-catalog quota fan-out** (`milo-os/billing`'s `ServiceConfiguration`):
- Owner label is stamped under `services.miloapis.com/service`, which the adapter already reads (since #1310), but the portal had **no `billing.miloapis.com` mapping** → "Other".
- The fan-out emits **no `kubernetes.io/display-name` annotation** on the generated registration (the quota *limit* carries no display metadata — only the *metric* does), so the row shows the raw key.

## Changes (portal, interim)
- `billing.miloapis.com → Billing` in the service map.
- Interim `billing.miloapis.com/billingaccount/count → Billing Accounts` row name.

## Durable fix (backend)
`milo-os/billing` populates the quota limit's `displayName`/`description` (now supported by the merged milo-os/service-catalog#41). Once that deploys, the server provides the name and the interim row-name entry can be removed.