### PR TITLE
feat: filter Amberflo usage queries by project_id dimension

### DIFF
--- a/app/modules/billing/usage.server.ts
+++ b/app/modules/billing/usage.server.ts
@@ -46,9 +46,11 @@ function aggregateMeterValues(
 export async function fetchUsageForCustomerIds({
   customerIds,
   days = DEFAULT_DAYS,
+  projectId,
 }: {
   customerIds: string[];
   days?: number;
+  projectId?: string;
 }): Promise<MeterSeries[]> {
   const apiKey = env.server.amberfloApiKey;
   if (!apiKey || customerIds.length === 0) {
@@ -72,7 +74,10 @@ export async function fetchUsageForCustomerIds({
           body: JSON.stringify({
             meterApiName: meterName,
             timeRange: { startTimeInSeconds: startSec, endTimeInSeconds: nowSec },
-            filter: { customerId: customerIds },
+            filter: {
+              customerId: customerIds,
+              ...(projectId ? { dimensions: { project_id: [projectId] } } : {}),
+            },
             groupBy: ['customerId'],
           }),
         });
@@ -163,7 +168,7 @@ export async function fetchProjectUsage(
     return { status: 'no-billing-account', meters: [], days };
   }
 
-  const meters = await fetchUsageForCustomerIds({ customerIds: [customerId], days });
+  const meters = await fetchUsageForCustomerIds({ customerIds: [customerId], days, projectId });
   return { status: 'ok', meters, days };
 }
 


### PR DESCRIPTION
## Summary

Usage queries sent to Amberflo are currently scoped only by `customerId` (the billing account UID). When multiple projects share a billing account, or when the per-project billing account binding is absent, there is no way to isolate a single project's consumption in the response. This PR adds `project_id` as an optional dimension filter on all Amberflo `/usage/sparse` requests so the portal can scope results to a specific project once events carry that dimension.

The change is additive and backwards compatible: when `projectId` is undefined (org-wide views), the filter object is unchanged. When set, `dimensions: { project_id: [projectId] }` is spread into the existing `customerId` filter.

Key behaviors:

- `fetchUsageForCustomerIds` accepts an optional `projectId` that is forwarded as an Amberflo dimension filter
- `fetchProjectUsage` threads the `projectId` it already resolves through to the shared fetch helper
- Org-wide queries (`fetchOrgUsage`) are unaffected — no dimension filter when no project is selected

## Test plan

- [ ] Verify project-scoped usage page returns data once milo-os/billing#60 ships `project_id` on events
- [ ] Verify org-wide usage page is unaffected (no `projectId` → no dimension filter in request body)
- [ ] Verify the `no-billing-account` empty state still renders when no binding exists for the project

## Notes for reviewers

This PR is intentionally a no-op until milo-os/billing#60 ships the consumer-side injection of `project_id` as a system dimension. Until that lands, the dimension filter is sent to Amberflo but matches nothing, so results are unchanged from today.

Confirm the Amberflo `/usage/sparse` filter format accepts `dimensions: { key: string[] }` — if the API expects a different shape (e.g. `dimensionFilters: [{ key, values }]`), only the spread in `queryUsage` needs updating.