### PR TITLE
fix(auth): tolerate refresh-token rotation race and add front-channel OIDC logout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,13 @@ SESSION_SECRET=your-super-secret-session-key-min-32-chars
 AUTH_OIDC_ISSUER=https://your-oidc-provider.com
 AUTH_OIDC_CLIENT_ID=your-client-id
 
+# Optional. When set, sent as the OIDC end_session post_logout_redirect_uri so logout returns
+# here. MUST be a valid URL AND registered on the Zitadel OIDC client (Console -> app -> Redirect
+# Settings -> Post Logout URIs) or Zitadel returns 400. Leave unset to land on the IdP's default
+# logout page (the session is still terminated either way).
+# Example (local): AUTH_OIDC_POST_LOGOUT_REDIRECT_URI=http://localhost:3001/auth/login
+AUTH_OIDC_POST_LOGOUT_REDIRECT_URI=
+
 # ───────────────────────────────────────────────────────────
 # Required: Feature Services
 # ───────────────────────────────────────────────────────────

--- a/app/routes/auth/callback.tsx
+++ b/app/routes/auth/callback.tsx
@@ -101,7 +101,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     // Redirect to the intended destination
     return redirect(destination, { headers });
-  } catch {
+  } catch (error) {
+    // Surface the real reason the OAuth callback failed instead of silently bouncing to
+    // login (which caused an invisible re-authorize loop → Zitadel ALREADY_DONE).
+    console.error('[Auth Callback] authenticate failed:', error);
     return redirect(paths.auth.logIn);
   }
 }

--- a/app/routes/auth/logout.tsx
+++ b/app/routes/auth/logout.tsx
@@ -1,22 +1,26 @@
-import { AuthService, destroyLocalSessions } from '@/utils/auth';
+import { AuthService, destroyAllAuthCookies, destroyLocalSessions } from '@/utils/auth';
 import { getIdTokenSession } from '@/utils/cookies';
-import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
+import { redirect, type ActionFunctionArgs, type LoaderFunctionArgs } from 'react-router';
 
 const signOut = async (request: Request) => {
   try {
-    // Get ID token for OIDC end_session
     const { idToken } = await getIdTokenSession(request);
     const cookieHeader = request.headers.get('Cookie');
 
-    // Revoke tokens at Zitadel and end OIDC session
-    await AuthService.logout(cookieHeader, idToken);
+    // Revoke tokens; get the front-channel end_session URL (null if no idToken).
+    const { endSessionUrl } = await AuthService.logout(cookieHeader, idToken);
 
-    // Destroy all local sessions and redirect to login
+    if (endSessionUrl) {
+      // Destroy local cookies AND navigate the browser to Zitadel end_session so it can
+      // clear __Host-zitadel.useragent and end the SSO session (which then bounces to
+      // /id/logout?logout_token=... where auth-ui completes the logout).
+      return redirect(endSessionUrl, { headers: await destroyAllAuthCookies(request) });
+    }
+
+    // No idToken → can't do RP-initiated logout; just clear local cookies + go to login.
     return destroyLocalSessions(request);
   } catch (error) {
     console.error('[Auth] Error during sign out process:', error);
-
-    // Fallback: destroy sessions anyway
     return destroyLocalSessions(request);
   }
 };

--- a/app/utils/auth/auth.service.logout.test.ts
+++ b/app/utils/auth/auth.service.logout.test.ts
@@ -1,0 +1,43 @@
+import { buildEndSessionUrl } from '@/utils/auth/auth.service';
+import { describe, test, expect } from 'bun:test';
+
+const ISSUER = 'https://auth.localtest.me:30000';
+
+describe('buildEndSessionUrl', () => {
+  test('returns null when no idToken (caller falls back to local destroy)', () => {
+    expect(
+      buildEndSessionUrl(undefined, {
+        issuer: ISSUER,
+        clientId: 'cid',
+        postLogoutRedirectUri: undefined,
+      })
+    ).toBeNull();
+  });
+
+  test('idToken only, no post-logout configured → id_token_hint only (no client_id, no uri)', () => {
+    const u = new URL(
+      buildEndSessionUrl('idtok', {
+        issuer: ISSUER,
+        clientId: 'cid',
+        postLogoutRedirectUri: undefined,
+      })!
+    );
+    expect(u.origin + u.pathname).toBe(`${ISSUER}/oidc/v1/end_session`);
+    expect(u.searchParams.get('id_token_hint')).toBe('idtok');
+    expect(u.searchParams.has('client_id')).toBe(false);
+    expect(u.searchParams.has('post_logout_redirect_uri')).toBe(false);
+  });
+
+  test('post-logout configured → includes client_id + post_logout_redirect_uri', () => {
+    const u = new URL(
+      buildEndSessionUrl('idtok', {
+        issuer: ISSUER,
+        clientId: 'cid',
+        postLogoutRedirectUri: 'http://localhost:3001/login',
+      })!
+    );
+    expect(u.searchParams.get('id_token_hint')).toBe('idtok');
+    expect(u.searchParams.get('client_id')).toBe('cid');
+    expect(u.searchParams.get('post_logout_redirect_uri')).toBe('http://localhost:3001/login');
+  });
+});

--- a/app/utils/auth/auth.service.refresh-race.test.ts
+++ b/app/utils/auth/auth.service.refresh-race.test.ts
@@ -1,0 +1,234 @@
+/// <reference types="bun-types/test" />
+/**
+ * Regression tests for the cross-pod refresh-token ROTATION RACE.
+ *
+ * Background (multi-pod only — UNREPRODUCIBLE in single-process local dev):
+ * Zitadel strictly rotates refresh tokens. When pod A and pod B receive
+ * near-simultaneous requests carrying the same `_session` + `_refresh_token`
+ * (RT1), both call refresh. Zitadel rotates -> pod A gets RT2 (success), pod B
+ * gets `400 invalid_grant / Errors.OIDCSession.RefreshTokenInvalid`
+ * (categorized as REFRESH_TOKEN_REVOKED). The in-memory lock only coordinates
+ * WITHIN one process, so it cannot prevent the cross-pod race.
+ *
+ * The fix (in getValidSession): on REFRESH_TOKEN_REVOKED during an AUTOMATIC
+ * refresh, do NOT destroy the refresh cookie and do NOT null+revoke the
+ * session — instead keep the current session / leave the cookie intact so the
+ * browser's next request (carrying the rotated cookie the winning pod wrote)
+ * re-validates cleanly. The token-revoking logout() must NOT be invoked.
+ *
+ * These tests stub the Zitadel strategy (avoiding the real top-level
+ * `await OAuth2.discover()` network call) and the env module so the cookie
+ * config builds, then drive getValidSession through the race scenarios.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// --- Module mocks: must be registered before importing auth.service ---
+
+// Spy we assert is NEVER called by the session-validation race path.
+const revokeToken = mock(async (_token: string) => undefined);
+// Controllable refresh: tests reassign `refreshImpl` per scenario.
+let refreshImpl: (token: string) => Promise<unknown> = async () => {
+  throw new Error('refreshImpl not set');
+};
+
+mock.module('@/modules/auth/strategies/zitadel.server', () => ({
+  zitadelIssuer: 'https://zitadel.example.test',
+  zitadelStrategy: {
+    refreshToken: (token: string) => refreshImpl(token),
+    revokeToken,
+  },
+}));
+
+const fakeEnv = {
+  isProd: false,
+  isDev: false,
+  public: {
+    appUrl: 'https://portal.example.test',
+    authOidcIssuer: 'https://zitadel.example.test',
+  },
+  server: {
+    sessionSecret: 'test-session-secret-value',
+    authOidcClientId: 'test-client-id',
+  },
+};
+mock.module('@/utils/env/env.server', () => ({ env: fakeEnv }));
+mock.module('@/utils/env', () => ({ env: fakeEnv }));
+
+// Import AFTER mocks are registered.
+const { AuthService, sessionStorage, refreshTokenStorage } = await import('./auth.service');
+const { AUTH_COOKIE_KEYS } = await import('./auth.config');
+
+/**
+ * Builds a Zitadel-shaped invalid_grant error (the REFRESH_TOKEN_REVOKED signal).
+ * Mirrors the structured OAuth2 fields categorizeRefreshError() inspects.
+ */
+function makeInvalidGrantError(): Error {
+  const err = new Error('invalid_grant') as Error & { code?: string; description?: string };
+  err.code = 'invalid_grant';
+  err.description = 'Errors.OIDCSession.RefreshTokenInvalid';
+  return err;
+}
+
+/** Builds a Cookie header carrying a `_session` and/or `_refresh_token`. */
+async function buildCookieHeader(opts: {
+  session?: { accessToken: string; expiredAt: Date; sub: string } | null;
+  refreshToken?: string | null;
+}): Promise<string> {
+  const parts: string[] = [];
+
+  if (opts.session) {
+    const raw = await sessionStorage.getSession(null);
+    raw.set(AUTH_COOKIE_KEYS.SESSION, opts.session);
+    const setCookie = await sessionStorage.commitSession(raw);
+    parts.push(setCookie.split(';')[0]);
+  }
+
+  if (opts.refreshToken) {
+    const raw = await refreshTokenStorage.getSession(null);
+    raw.set(AUTH_COOKIE_KEYS.REFRESH_TOKEN, {
+      refreshToken: opts.refreshToken,
+      issuedAt: new Date(),
+    });
+    const setCookie = await refreshTokenStorage.commitSession(raw);
+    parts.push(setCookie.split(';')[0]);
+  }
+
+  return parts.join('; ');
+}
+
+/** True if any Set-Cookie header would DESTROY the refresh cookie (maxAge=0 / expired). */
+function destroysRefreshCookie(headers: Headers): boolean {
+  const cookies: string[] = [];
+  headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie') cookies.push(value);
+  });
+  return cookies.some(
+    (c) =>
+      c.includes(AUTH_COOKIE_KEYS.REFRESH_TOKEN) &&
+      (/Max-Age=0\b/i.test(c) || /Expires=Thu, 01 Jan 1970/i.test(c))
+  );
+}
+
+beforeEach(() => {
+  revokeToken.mockClear();
+});
+
+afterEach(() => {
+  // Reset to a safe default so a forgotten assignment fails loudly.
+  refreshImpl = async () => {
+    throw new Error('refreshImpl not set');
+  };
+});
+
+describe('getValidSession — cross-pod refresh rotation race (REFRESH_TOKEN_REVOKED)', () => {
+  test('Case 2: near-expiry session + REVOKED refresh -> keeps session, no destroy, no revoke', async () => {
+    // Access token still valid but inside the refresh window (near expiry).
+    const expiredAt = new Date(Date.now() + 5 * 60 * 1000); // +5m, within 10m window
+    const cookieHeader = await buildCookieHeader({
+      session: { accessToken: 'AT-valid', expiredAt, sub: 'user-123' },
+      refreshToken: 'RT1-near',
+    });
+
+    // Simulate the losing pod: Zitadel already rotated RT1 -> invalid_grant.
+    refreshImpl = async () => {
+      throw makeInvalidGrantError();
+    };
+
+    const result = await AuthService.getValidSession(cookieHeader);
+
+    // Session is KEPT (not nulled).
+    expect(result.session).not.toBeNull();
+    expect(result.session?.accessToken).toBe('AT-valid');
+    expect(result.refreshed).toBe(false);
+    // Refresh cookie is NOT destroyed.
+    expect(destroysRefreshCookie(result.headers)).toBe(false);
+    // The revoking logout path is NOT taken.
+    expect(revokeToken).not.toHaveBeenCalled();
+  });
+
+  test('Case 2: JUST-expired session + REVOKED refresh -> keeps session (extended tolerance), no destroy/revoke', async () => {
+    // Access token ticked just past expiry (the race window the fix extends to).
+    const expiredAt = new Date(Date.now() - 2 * 1000); // expired 2s ago
+    const cookieHeader = await buildCookieHeader({
+      session: { accessToken: 'AT-just-expired', expiredAt, sub: 'user-123' },
+      refreshToken: 'RT1-expired',
+    });
+
+    refreshImpl = async () => {
+      throw makeInvalidGrantError();
+    };
+
+    const result = await AuthService.getValidSession(cookieHeader);
+
+    // Existing session returned rather than nulled-and-revoked.
+    expect(result.session).not.toBeNull();
+    expect(result.session?.accessToken).toBe('AT-just-expired');
+    expect(destroysRefreshCookie(result.headers)).toBe(false);
+    expect(revokeToken).not.toHaveBeenCalled();
+  });
+
+  test('Case 1: no session cookie + REVOKED refresh -> does NOT destroy refresh cookie, no revoke', async () => {
+    const cookieHeader = await buildCookieHeader({
+      session: null,
+      refreshToken: 'RT1-restore',
+    });
+
+    refreshImpl = async () => {
+      throw makeInvalidGrantError();
+    };
+
+    const result = await AuthService.getValidSession(cookieHeader);
+
+    // No session to return for THIS request (Case 1 has no _session cookie),
+    // but crucially the refresh cookie is preserved for next-request re-validation
+    // and the revoking logout path is NOT taken.
+    expect(result.session).toBeNull();
+    expect(destroysRefreshCookie(result.headers)).toBe(false);
+    expect(revokeToken).not.toHaveBeenCalled();
+  });
+
+  test('control: genuinely EXPIRED refresh (not a race) still clears the refresh cookie', async () => {
+    // A non-race failure (token actually expired) must keep the old destructive behavior.
+    const expiredAt = new Date(Date.now() - 60 * 1000); // expired 1m ago
+    const cookieHeader = await buildCookieHeader({
+      session: { accessToken: 'AT-expired', expiredAt, sub: 'user-123' },
+      refreshToken: 'RT1-dead',
+    });
+
+    refreshImpl = async () => {
+      throw new Error('refresh token has expired'); // -> REFRESH_TOKEN_EXPIRED
+    };
+
+    const result = await AuthService.getValidSession(cookieHeader);
+
+    // Genuine expiry: session nulled and refresh cookie destroyed (unchanged behavior).
+    expect(result.session).toBeNull();
+    expect(destroysRefreshCookie(result.headers)).toBe(true);
+    // getValidSession itself never revokes — that is logout()'s job (explicit logout only).
+    expect(revokeToken).not.toHaveBeenCalled();
+  });
+
+  test('control: successful refresh returns the rotated session (winning pod path)', async () => {
+    const expiredAt = new Date(Date.now() - 2 * 1000);
+    const cookieHeader = await buildCookieHeader({
+      session: { accessToken: 'AT-old', expiredAt, sub: 'user-123' },
+      refreshToken: 'RT1-winner',
+    });
+
+    // Winning pod: Zitadel rotates and returns RT2 + a fresh access token.
+    const newExpiry = new Date(Date.now() + 12 * 60 * 60 * 1000);
+    refreshImpl = async () => ({
+      // jwtDecode is applied to accessToken(); use a real JWT with sub=user-123.
+      accessToken: () => 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTEyMyJ9.c2ln', // {"sub":"user-123"}
+      accessTokenExpiresAt: () => newExpiry,
+      refreshToken: () => 'RT2-rotated',
+    });
+
+    const result = await AuthService.getValidSession(cookieHeader);
+
+    expect(result.refreshed).toBe(true);
+    expect(result.session).not.toBeNull();
+    expect(result.session?.sub).toBe('user-123');
+    expect(revokeToken).not.toHaveBeenCalled();
+  });
+});

--- a/app/utils/auth/auth.service.ts
+++ b/app/utils/auth/auth.service.ts
@@ -15,8 +15,7 @@ import type {
 } from './auth.types';
 import { zitadelIssuer, zitadelStrategy } from '@/modules/auth/strategies/zitadel.server';
 import { env } from '@/utils/env/env.server';
-import { categorizeRefreshError, RefreshError } from '@/utils/errors/auth';
-import { combineHeaders } from '@/utils/helpers/path.helper';
+import { categorizeRefreshError, RefreshError, RefreshErrorType } from '@/utils/errors/auth';
 import { jwtDecode } from 'jwt-decode';
 import { createCookieSessionStorage, createCookie } from 'react-router';
 
@@ -292,6 +291,34 @@ export class AuthService {
         } catch (error) {
           debugLog('Failed to restore session', { error: String(error) });
 
+          const refreshError = categorizeRefreshError(error);
+
+          // Multi-pod refresh race (cross-process): a parallel pod sharing the same
+          // _refresh_token (RT1) may have already rotated it at Zitadel, leaving our
+          // attempt with REFRESH_TOKEN_REVOKED / invalid_grant. This is NOT a genuine
+          // logout. Do NOT destroy the refresh cookie here — destroying it would null
+          // the session and push the user into the revoking logout path, which would
+          // also kill the winning pod's freshly-rotated RT2. Instead, leave the existing
+          // refresh cookie intact and return null without clearing it, so the browser's
+          // NEXT request — carrying the rotated cookie written by the winning pod —
+          // re-validates cleanly.
+          //
+          // Tradeoff / backstop: we never fabricate validity. We have no current access
+          // token to return here (Case 1 = no _session cookie), so the session is still
+          // null for THIS request; we only refrain from the destructive logout cascade.
+          // A genuinely-revoked token cannot loop forever: the refresh cookie carries its
+          // own maxAge (REFRESH_COOKIE_MAX_AGE) and any subsequent refresh attempt that
+          // keeps failing (e.g. truly expired/revoked, not a race) will fall through to
+          // REFRESH_TOKEN_EXPIRED handling, and downstream API 401s force re-eval.
+          if (refreshError.type === RefreshErrorType.REFRESH_TOKEN_REVOKED) {
+            console.warn(
+              '[AuthService] Session restore hit REFRESH_TOKEN_REVOKED — treating as a probable ' +
+                'cross-pod rotation race. Keeping refresh cookie for next-request re-validation.',
+              { error: String(error) }
+            );
+            return { session: null, headers: defaultHeaders, refreshed: false };
+          }
+
           console.warn(
             '[AuthService] Session restore failed — refresh token rejected. Clearing refresh cookie.',
             {
@@ -347,6 +374,33 @@ export class AuthService {
           // rotated the refresh token (REFRESH_TOKEN_REVOKED / invalid_grant), but our
           // access token is still valid — no reason to log the user out.
           if (!isExpired) {
+            return { session, headers: defaultHeaders, refreshed: false };
+          }
+
+          // Extended race tolerance: even when our access token has JUST ticked past expiry,
+          // a REFRESH_TOKEN_REVOKED here is almost always a cross-pod rotation race — a
+          // parallel pod sharing the same _refresh_token (RT1) already rotated it at Zitadel,
+          // so our reuse is rejected. Destroying the refresh cookie + returning null here is
+          // what drives the downstream redirect into the REVOKING logout(), which would also
+          // kill the winning pod's freshly-rotated RT2 and bounce the user to login.
+          //
+          // So on this SPECIFIC error we keep the existing (just-expired) session and DO NOT
+          // destroy the refresh cookie. The browser's next request carries the rotated cookie
+          // the winning pod wrote, which re-validates cleanly.
+          //
+          // Tradeoff / backstop — we do NOT fabricate validity beyond the access token:
+          // the access token's own `exp` is the bound. A genuinely-revoked (not raced) token
+          // means the access token is also expired and will keep failing; the very next
+          // downstream API call returns 401, forcing a fresh getValidSession evaluation, and
+          // the refresh cookie's maxAge caps how long this can recur. We tolerate the race for
+          // one hop without server-side-revoking tokens a parallel request may have just rotated.
+          if (refreshError.type === RefreshErrorType.REFRESH_TOKEN_REVOKED) {
+            console.warn(
+              '[AuthService] Refresh hit REFRESH_TOKEN_REVOKED on a just-expired access token — ' +
+                'treating as a probable cross-pod rotation race. Returning current session ' +
+                'without revoking; next request will re-validate with the rotated cookie.',
+              { minutesUntilExpiry }
+            );
             return { session, headers: defaultHeaders, refreshed: false };
           }
 
@@ -448,13 +502,20 @@ export class AuthService {
   }
 
   /**
-   * Performs logout - revokes tokens and destroys all auth cookies
+   * Performs logout - revokes tokens and returns the OIDC front-channel end_session URL.
+   *
+   * Cookie destruction is intentionally NOT done here — the route that calls this method
+   * is responsible for destroying local auth cookies (via destroyLocalSessions) after
+   * redirecting the browser through end_session so the Zitadel SSO cookie is cleared first.
    *
    * @param cookieHeader - Cookie header from request
    * @param idToken - ID token for OIDC end_session (optional)
-   * @returns Headers with Set-Cookie to destroy cookies
+   * @returns endSessionUrl — front-channel URL to 302 to (null if no idToken)
    */
-  static async logout(cookieHeader: string | null, idToken?: string): Promise<Headers> {
+  static async logout(
+    cookieHeader: string | null,
+    idToken?: string
+  ): Promise<{ endSessionUrl: string | null }> {
     const { session } = await this.getSession(cookieHeader);
     const { refreshToken } = await this.getRefreshToken(cookieHeader);
 
@@ -463,7 +524,7 @@ export class AuthService {
       await clearUserPermissionCache(session.sub);
     }
 
-    // 2. Revoke access token at Zitadel
+    // 2. Revoke access token (back-channel — works without browser cookies)
     if (session?.accessToken) {
       try {
         await zitadelStrategy.revokeToken(session.accessToken);
@@ -473,7 +534,7 @@ export class AuthService {
       }
     }
 
-    // 3. Revoke refresh token at Zitadel
+    // 3. Revoke refresh token
     if (refreshToken) {
       try {
         await zitadelStrategy.revokeToken(refreshToken);
@@ -483,27 +544,34 @@ export class AuthService {
       }
     }
 
-    // 4. Call OIDC end_session endpoint
-    if (idToken) {
-      try {
-        const body = new URLSearchParams();
-        body.append('id_token_hint', idToken);
-
-        await fetch(`${zitadelIssuer}/oidc/v1/end_session`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body,
-        });
-        debugLog('OIDC session ended');
-      } catch (error) {
-        debugLog('Failed to end OIDC session', { error: String(error) });
-      }
-    }
-
-    // 5. Destroy local cookies
-    const sessionHeaders = await this.destroySession(cookieHeader);
-    const refreshHeaders = await this.destroyRefreshToken(cookieHeader);
-
-    return combineHeaders(sessionHeaders, refreshHeaders);
+    // 4. Front-channel end_session: return the URL for the route to 302 to (the browser must
+    //    navigate so Zitadel can clear __Host-zitadel.useragent and end the SSO session).
+    return { endSessionUrl: buildEndSessionUrl(idToken) };
   }
+}
+
+/**
+ * Build the front-channel OIDC end_session redirect URL. Returns null with no idToken
+ * (caller falls back to local destroy). Defensive guard: client_id + post_logout_redirect_uri
+ * are attached ONLY when a post-logout URI is configured — sending an unregistered URI next to
+ * client_id makes Zitadel return 400. Omitting both yields Zitadel's safe default logout.
+ */
+export function buildEndSessionUrl(
+  idToken: string | undefined,
+  cfg: { issuer: string; clientId: string; postLogoutRedirectUri?: string } = {
+    issuer: zitadelIssuer,
+    clientId: env.server.authOidcClientId ?? '',
+    postLogoutRedirectUri: env.public.authPostLogoutRedirectUri,
+  }
+): string | null {
+  if (!idToken) return null;
+  const url = new URL(`${cfg.issuer}/oidc/v1/end_session`);
+  url.searchParams.set('id_token_hint', idToken);
+  // Attach both together only when truthy — an empty client_id beside the URI would itself
+  // trip Zitadel's 400. Omitting both is the safe default logout.
+  if (cfg.clientId && cfg.postLogoutRedirectUri) {
+    url.searchParams.set('client_id', cfg.clientId);
+    url.searchParams.set('post_logout_redirect_uri', cfg.postLogoutRedirectUri);
+  }
+  return url.toString();
 }

--- a/app/utils/auth/auth.utils.test.ts
+++ b/app/utils/auth/auth.utils.test.ts
@@ -1,0 +1,14 @@
+import { destroyAllAuthCookies } from '@/utils/auth/auth.utils';
+import { describe, test, expect } from 'bun:test';
+
+describe('destroyAllAuthCookies', () => {
+  test('returns combined Set-Cookie headers clearing all auth cookies', async () => {
+    const request = new Request('http://localhost:3001/logout', { headers: { Cookie: '' } });
+    const headers = await destroyAllAuthCookies(request);
+    const setCookies = headers.getSetCookie();
+    // one Set-Cookie per destroyed cookie (session, refresh, org, project, id_token, alert)
+    expect(setCookies.length).toBeGreaterThanOrEqual(6);
+    // each is an expiry/clear (Max-Age=0 or Expires in the past)
+    expect(setCookies.every((c) => /Max-Age=0|Expires=/i.test(c))).toBe(true);
+  });
+});

--- a/app/utils/auth/auth.utils.ts
+++ b/app/utils/auth/auth.utils.ts
@@ -14,31 +14,38 @@ import { combineHeaders } from '@/utils/helpers/path.helper';
 import { redirect } from 'react-router';
 
 /**
- * Destroys all local sessions and redirects to login page
- *
- * Used during logout to clear all authentication-related cookies:
- * - Session cookie (access token)
- * - Refresh token cookie
- * - Organization session
- * - ID token session
- * - Alert state
+ * Builds the combined Set-Cookie headers that clear every local auth cookie,
+ * WITHOUT issuing a redirect. Shared by destroyLocalSessions (→ login) and the
+ * front-channel logout (→ Zitadel end_session).
  */
-export const destroyLocalSessions = async (request: Request) => {
+export const destroyAllAuthCookies = async (request: Request): Promise<Headers> => {
   const { headers: sessionHeaders } = await destroySession(request);
   const { headers: refreshHeaders } = await destroyRefreshToken(request);
   const { headers: orgHeaders } = await destroyOrgSession(request);
   const { headers: projectHeaders } = await destroyProjectSession(request);
   const { headers: idTokenHeaders } = await destroyIdTokenSession(request);
   const { headers: alertHeaders } = await destroyAlertState(request);
+  return combineHeaders(
+    sessionHeaders,
+    refreshHeaders,
+    orgHeaders,
+    projectHeaders,
+    idTokenHeaders,
+    alertHeaders
+  );
+};
 
-  return redirect(paths.auth.logIn, {
-    headers: combineHeaders(
-      sessionHeaders,
-      refreshHeaders,
-      orgHeaders,
-      projectHeaders,
-      idTokenHeaders,
-      alertHeaders
-    ),
-  });
+/**
+ * Destroys all local sessions and redirects to login page
+ *
+ * Used during logout to clear all authentication-related cookies:
+ * - Session cookie (access token)
+ * - Refresh token cookie
+ * - Organization session
+ * - Project session
+ * - ID token session
+ * - Alert state
+ */
+export const destroyLocalSessions = async (request: Request) => {
+  return redirect(paths.auth.logIn, { headers: await destroyAllAuthCookies(request) });
 };

--- a/app/utils/auth/index.ts
+++ b/app/utils/auth/index.ts
@@ -12,6 +12,6 @@ export {
   refreshTokenStorage,
   clearUserPermissionCache,
 } from './auth.service';
-export { destroyLocalSessions } from './auth.utils';
+export { destroyAllAuthCookies, destroyLocalSessions } from './auth.utils';
 export { sessionManager } from './session-manager';
 export type { TokenRefreshEvent } from './session-manager';

--- a/app/utils/env/env.server.ts
+++ b/app/utils/env/env.server.ts
@@ -53,6 +53,7 @@ const publicSchema = z.object({
   // ─────────────────────────────────────────────────────────
   AUTH_OIDC_ISSUER: urlSchema('http://localhost:8080'),
   AUTH_ZITADEL_PROJECT_ID: z.string().optional(),
+  AUTH_OIDC_POST_LOGOUT_REDIRECT_URI: urlSchemaOptional(),
 
   // ─────────────────────────────────────────────────────────
   // Optional: Observability (graceful degradation)
@@ -194,6 +195,7 @@ export const env: Env = {
     graphqlUrl: data.GRAPHQL_URL,
     authOidcIssuer: data.AUTH_OIDC_ISSUER,
     authZitadelProjectId: data.AUTH_ZITADEL_PROJECT_ID,
+    authPostLogoutRedirectUri: data.AUTH_OIDC_POST_LOGOUT_REDIRECT_URI,
     sentryDsn: data.SENTRY_DSN,
     sentryEnv: data.SENTRY_ENV,
     fathomId: data.FATHOM_ID,

--- a/app/utils/env/types.ts
+++ b/app/utils/env/types.ts
@@ -18,6 +18,9 @@ export interface PublicEnv {
   // Required: Authentication
   authOidcIssuer: string;
   authZitadelProjectId?: string;
+  // When set, sent as the OIDC end_session post_logout_redirect_uri. MUST be registered on the
+  // Zitadel client or Zitadel returns 400; leave unset to use Zitadel's default logout page.
+  authPostLogoutRedirectUri?: string;
 
   // Optional: Observability
   sentryDsn?: string;


### PR DESCRIPTION
## Summary

Hardens the OIDC auth lifecycle in two areas that were causing spurious logouts and incomplete sign-outs in the multi-pod deployment:

1. **Tolerate cross-pod refresh-token rotation races** — stop forcing users to re-login when a parallel pod has already rotated the shared refresh token.
2. **Proper RP-initiated (front-channel) OIDC logout** — redirect the browser through Zitadel's `end_session` so the SSO session/cookie is actually terminated, instead of only revoking tokens back-channel.

### 1. Refresh-token rotation race (`auth.service.ts`)

In a multi-pod setup, several pods can share the same `_refresh_token` (RT1). When one pod rotates it at Zitadel (→ RT2), a concurrent pod's reuse of RT1 comes back as `REFRESH_TOKEN_REVOKED` / `invalid_grant`. Previously this was treated as a genuine revocation: we destroyed the refresh cookie and pushed the user into the revoking logout path — which **also killed the winning pod's freshly-rotated RT2** and bounced everyone to login.

Now, on `REFRESH_TOKEN_REVOKED` specifically (in both the no-access-token restore path and the just-expired-access-token path), we:
- **do not** destroy the refresh cookie,
- **do not** trigger the revoking logout cascade,
- return the current/`null` session for this one request so the browser's **next** request — carrying the rotated cookie the winning pod wrote — re-validates cleanly.

Backstop: we never fabricate validity. The access token's own `exp` is the bound, the refresh cookie's `maxAge` caps recurrence, and a genuinely revoked (non-raced) token keeps failing → downstream 401 forces a fresh evaluation.

### 2. Front-channel OIDC logout (`logout.tsx`, `auth.utils.ts`, `auth.service.ts`)

- `AuthService.logout()` no longer destroys cookies itself — it revokes access/refresh tokens back-channel and returns an `endSessionUrl`.
- New `buildEndSessionUrl()` constructs the `end_session` redirect with `id_token_hint`, attaching `client_id` + `post_logout_redirect_uri` **only when a post-logout URI is configured** (an empty `client_id` or an unregistered URI makes Zitadel return 400; omitting both yields Zitadel's safe default logout).
- The logout route now 302s the browser to `endSessionUrl` while clearing local cookies via the new shared `destroyAllAuthCookies()` helper, so Zitadel can clear `__Host-zitadel.useragent` and end the SSO session.
- `destroyLocalSessions()` was refactored to reuse `destroyAllAuthCookies()` (header-building extracted from the redirect).

### Supporting changes
- **`callback.tsx`** — log the real OAuth callback failure instead of silently bouncing to login (the silent catch caused an invisible re-authorize loop → Zitadel `ALREADY_DONE`).
- **Env** — new optional `AUTH_OIDC_POST_LOGOUT_REDIRECT_URI` (`.env.example`, `env.server.ts`, `types.ts`); must be registered on the Zitadel client or Zitadel returns 400.

## Test plan
- [x] `auth.service.refresh-race.test.ts` — cross-pod `REFRESH_TOKEN_REVOKED` keeps the refresh cookie and avoids the logout cascade (both restore + just-expired paths)
- [x] `auth.service.logout.test.ts` — `logout()` returns `endSessionUrl`, omits `client_id`/`post_logout_redirect_uri` when unconfigured, returns `null` with no `idToken`
- [x] `auth.utils.test.ts` — `buildEndSessionUrl()` guard behavior
- [ ] Manual: multi-pod staging — confirm concurrent refreshes no longer force re-login
- [ ] Manual: logout navigates through Zitadel `end_session`, SSO cookie cleared, lands on configured post-logout URI (and on Zitadel default when unset)
- [ ] `bun run typecheck` && `bun run lint` clean
