### PR TITLE
fix(ui): global guard for stuck body pointer-events (Radix modal layers)

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -223,6 +223,31 @@ export default function AppWithProviders() {
     }
   }, [state]);
 
+  // Global safety net for a Radix limitation: `@radix-ui/react-dismissable-layer`
+  // stores the body's original `pointer-events` in a single module-level global
+  // shared across independent modal layers. Opening a modal Dialog while another
+  // modal layer (e.g. a Popover/dropdown) is still open corrupts that value to
+  // "none", so on close the body stays `pointer-events: none` and the entire app
+  // becomes unclickable. When the body is stuck at "none" while no Radix modal
+  // layer is actually open, clear it so interaction is restored.
+  // TODO: Remove once fixed centrally in @datum-cloud/datum-ui's Dialog (the
+  // library is under audit; this guard is the interim app-wide fix).
+  useEffect(() => {
+    const body = document.body;
+    const clearIfStuck = () => {
+      if (body.style.pointerEvents !== 'none') return;
+      const modalLayerOpen = document.querySelector(
+        '[data-radix-popper-content-wrapper], [role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]'
+      );
+      if (!modalLayerOpen) {
+        body.style.pointerEvents = '';
+      }
+    };
+    const observer = new MutationObserver(clearIfStuck);
+    observer.observe(body, { attributes: true, attributeFilter: ['style'] });
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <Document nonce={nonce}>
       <AuthenticityTokenProvider token={csrfToken}>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -119,7 +119,7 @@ export default defineConfig(async (config): Promise<UserConfig> => {
       alias: aliases,
     },
     server: {
-      port: 3000,
+      port: process.env.PORT ? Number(process.env.PORT) : 3000,
     },
     optimizeDeps: {
       include: [


### PR DESCRIPTION
## Problem

After closing certain dialogs (repro: DNS Records → **Import & Export** → drop a BIND file → close the *Import DNS Records* dialog), the **entire app became unclickable**. Root cause: `<body style="pointer-events: none">` was left stuck.

This is a limitation in `@radix-ui/react-dismissable-layer`: it stores the body's original `pointer-events` in a **single module-level global** shared across independent modal layers. Opening a modal **Dialog** while another modal layer (e.g. the Import/Export dropdown — a modal **Popover** since datum-ui 1.3.2) is still open corrupts that saved value to `"none"`. On close, neither layer restores it, so the body stays `pointer-events: none`.

The trigger is generic (modal-over-modal: dropdown→dialog, dialog→dialog, popover→dialog), so this can strand other flows too — not just DNS import.

## Fix

App-wide safety net in the root component: a `MutationObserver` on `document.body`'s `style` that clears `pointer-events: none` **only** when no Radix modal layer is actually open (`[data-radix-popper-content-wrapper]`, `[role=dialog|alertdialog][data-state=open]`).

- One file (`app/root.tsx`), client-side only.
- Safe: Radix sets the body **after** the modal content mounts, so during a legitimate open the observer always finds an open-modal element and leaves it alone — it only acts in the genuinely-stuck state.
- `TODO` in code: the durable fix belongs in datum-ui's shared `Dialog`; this guard is interim while that library is under audit, and can be removed (or kept as cheap insurance) afterward.

Also includes a minor dev-only change: allow overriding the dev server port via `PORT` env (defaults to 3000).

## Test plan

- [x] Repro fixed: DNS Records → Import & Export → drop a `.zone` file → close the dialog → page stays fully clickable
- [x] Legitimate modals still block the background while open (dialog, dropdown, select) and restore correctly on close
- [x] Spot-check row-action (⋯) menus that open edit/delete dialogs — no stuck state
- [x] Typecheck / lint green (verified locally)