### PR TITLE
fix: stop Stripe billing address using the company name on autofill

### DIFF
--- a/app/features/organization/billing/org-billing-setup-form.tsx
+++ b/app/features/organization/billing/org-billing-setup-form.tsx
@@ -289,13 +289,11 @@ export const OrgBillingSetupForm = ({
     if (!source.email?.trim()) return undefined;
     return {
       email: source.email.trim(),
-      // Org display name > business name > contact name. The explicit org
-      // name the user entered should appear in the billing address form, not
-      // the legal entity or personal contact name.
-      name: displayName.trim() || source.businessName?.trim() || source.name?.trim() || undefined,
+      // Card billing address uses the contact's personal name, not the org or business name.
+      name: source.name?.trim() || undefined,
       address: buildContactAddressPrefill(source),
     };
-  }, [contactInfo, contactDialogDefaults, displayName]);
+  }, [contactInfo, contactDialogDefaults]);
 
   const handleContactSave = async (values: OrgContactInfoValues) => {
     // First complete setup this session: no billingSetup yet (fresh create or

--- a/app/routes/account/billing/detail.tsx
+++ b/app/routes/account/billing/detail.tsx
@@ -748,7 +748,7 @@ function AccountBillingAccountDetailPageInner() {
             stripePublishableKey={stripePublishableKey}
             billingDetailsPrefill={{
               email: contactInfo?.email,
-              name: contactInfo?.name ?? contactInfo?.businessName,
+              name: contactInfo?.name,
               address: buildContactAddressPrefill(address),
             }}
             onCreatePaymentMethod={createPaymentMethod}


### PR DESCRIPTION
The Stripe Elements address field was pre populating with the contact forms business field as the name. 