### PR TITLE
fix(e2e): match typeless org cards in Cypress selectors

### DIFF
--- a/cypress/e2e/regression/auth.cy.ts
+++ b/cypress/e2e/regression/auth.cy.ts
@@ -22,7 +22,8 @@ describe('Authentication — regression', () => {
     // After reload the session cookie is re-validated server-side.
     // The page must still render the authenticated view.
     cy.url().should('include', paths.account.organizations.root);
-    cy.get('[data-e2e="organization-card-personal"]').should('be.visible');
+    // Org cards are typeless for unified orgs — match any card variant.
+    cy.get('[data-e2e^="organization-card"]').first().should('be.visible');
   });
 
   it('should block unauthenticated access to protected routes', () => {

--- a/cypress/e2e/smoke/organisations.cy.ts
+++ b/cypress/e2e/smoke/organisations.cy.ts
@@ -43,14 +43,13 @@ describe('Load org list', () => {
 
   it('should render a list of the users orgs and store personal org ID', () => {
     cy.visit(paths.account.organizations.root);
-    cy.get('[data-e2e="organization-card-personal"]').should('be.visible');
-    cy.get('[data-e2e="organization-card-standard"]').should('be.visible');
+    // Org cards render regardless of type (unified orgs are typeless), so match
+    // any card variant with the prefix selector.
+    cy.get('[data-e2e^="organization-card"]').first().should('be.visible');
 
-    // Extract the personal org ID from the BadgeCopy component
-    // Find the personal org card, then find the badge with the org ID
-    cy.get('[data-e2e="organization-card-personal"]')
-      .find('[data-e2e="organization-card-id-copy"]')
-      .first()
+    // Extract the personal org ID from its BadgeCopy. The personal org is
+    // identified by its stable `personal-org-…` resource name, not its type.
+    cy.contains('[data-e2e="organization-card-id-copy"]', /personal-org-[a-z0-9]+/)
       .invoke('text')
       .then((orgId) => {
         const trimmedId = orgId.trim();

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -240,19 +240,21 @@ Cypress.Commands.add('getPersonalOrgId', (): Cypress.Chainable<string> => {
     return cy.wrap(storedId, { log: false });
   }
 
-  // If not in env, fetch it from the page
+  // If not in env, fetch it from the page.
+  // Orgs are now typeless (unified orgs omit `type`), so the legacy
+  // `organization-card-personal` hook is unreliable. Identify the personal org
+  // by its stable resource name (`personal-org-…`) via its id badge instead.
   cy.visit(paths.account.organizations.root);
   return cy
-    .get('[data-e2e="organization-card-personal"]', { timeout: 10000 })
+    .contains('[data-e2e="organization-card-id-copy"]', /personal-org-[a-z0-9]+/, {
+      timeout: 10000,
+    })
     .should('be.visible')
-    .find('[data-e2e="organization-card-id-copy"]')
-    .should('be.visible')
-    .first()
     .invoke('text')
     .then((orgId: string) => {
       const trimmedId = orgId.trim();
-      if (!trimmedId) {
-        throw new Error('Failed to extract personal org ID from page');
+      if (!/^personal-org-[a-z0-9]+$/.test(trimmedId)) {
+        throw new Error(`Failed to extract personal org ID from page (got: "${trimmedId}")`);
       }
       Cypress.env('personalOrgId', trimmedId);
       return trimmedId;
@@ -326,7 +328,9 @@ Cypress.Commands.add('logout', () => {
  */
 Cypress.Commands.add('createStandardOrg', (displayName: string): Cypress.Chainable<string> => {
   cy.visit(paths.account.organizations.root);
-  cy.get('[data-e2e="organization-card-personal"]', { timeout: 10_000 }).should('be.visible');
+  // Wait for the org list to render. Cards are typeless for unified orgs, so
+  // match any card variant with the prefix selector.
+  cy.get('[data-e2e^="organization-card"]', { timeout: 10_000 }).first().should('be.visible');
   cy.get('[data-e2e="create-organization-button"]').should('be.visible').click();
 
   cy.contains('Create organization', { timeout: 10_000 }).should('be.visible');


### PR DESCRIPTION
## Problem

**E2E Smoke** has been failing intermittently across PRs (e.g. [run on #1338](https://github.com/datum-cloud/cloud-portal/actions/runs/29062376687/job/86269152684)):

```
Service Account new page › renders the create UI (not RestrictedState) for a permitted user
  AssertionError: Timed out retrying after 10000ms:
  Expected to find element: `[data-e2e="organization-card-personal"]`, but never found it.
  at cypress/support/e2e.ts   ← the shared getPersonalOrgId command
```

The failing assertion is in the shared `getPersonalOrgId` command — the **cascade root** that nearly every smoke/regression spec depends on — so a single missing hook fails the whole suite.

## Root cause

The onboarding **"unified org"** work made organizations typeless. `organization.adapter.ts` now returns an `undefined` `type` for them:

```ts
/** Legacy org types only — unified orgs omit type or send empty values. */
function normalizeOrganizationType(type: unknown): Organization['type'] | undefined {
  return type === 'Personal' || type === 'Standard' ? type : undefined;
}
```

…and the org card derives its hook from that type:

```tsx
data-e2e={ org.type ? `organization-card-${org.type.toLowerCase()}` : 'organization-card' }
```

So a typeless org renders `data-e2e="organization-card"`, never `-personal`. The tests still waited on `organization-card-personal` and timed out.

## Fix

This **completes a migration the team already started** — `cypress/e2e/regression/organisations.cy.ts` and `cypress/support/e2e.ts:737` already use the `[data-e2e^="organization-card"]` prefix selector (as documented in the regression spec's selector reference). It was just missed in these spots:

- **`getPersonalOrgId`** + smoke render test → identify the personal org by its stable `personal-org-…` **resource name** (`cy.contains` on the id badge), independent of the removed type. This is the suite's own invariant (`/^personal-org-[a-z0-9]+$/`).
- **`createStandardOrg`** + auth regression → wait for any card variant via `[data-e2e^="organization-card"]`.

No app code or dependency changes — test-only.

## Scope & validation

- Local: `prettier` ✓, `eslint` ✓, `typecheck` ✓ (pre-commit gate green).
- These specs run against the live **staging** backend with CI secrets, so they can't be executed locally — **CI on this PR is the real validation**. Since the failure was intermittent (the type appears to populate asynchronously in staging), keying off the resource name rather than the type also removes that flake source.
- Unrelated to the Renovate batch in #1338 — this pre-existing E2E drift affects `main` and all open PRs.