### PR TITLE
fix: keep WAF detection paranoia level synced with blocking

### DIFF
--- a/app/features/edge/proxy/proxy-waf-dialog.tsx
+++ b/app/features/edge/proxy/proxy-waf-dialog.tsx
@@ -63,8 +63,9 @@ export const ProxyWafDialog = forwardRef<ProxyWafDialogRef, ProxyWafDialogProps>
       try {
         await updateMutation.mutateAsync({
           trafficProtectionMode: data.trafficProtectionMode,
+          // CRS requires detection >= blocking; keep them locked together.
           paranoiaLevels: data.paranoiaLevelBlocking
-            ? { blocking: data.paranoiaLevelBlocking }
+            ? { blocking: data.paranoiaLevelBlocking, detection: data.paranoiaLevelBlocking }
             : undefined,
         });
         toast.success('AI Edge', {


### PR DESCRIPTION
## Summary
- The Edit Protection dialog only exposed a control for the OWASP CRS `blocking` paranoia level and patched it alone via merge-patch, leaving `detection` at whatever it already was.
- Raising `blocking` without also raising `detection` produces an invalid CRS config (`detection < blocking`), which the gateway rejects, failing closed with HTTP 500 for all traffic on the site.
- Now sends `detection` alongside `blocking` on every update, keeping the two equal, so this dialog can never produce the invalid state.

Fixes #1352

## Test plan
- [x] Enable protection on a proxy with Level 1 (Relaxed), confirm `paranoiaLevels: {blocking: 1, detection: 1}` on the resulting TrafficProtectionPolicy
- [x] Edit an existing enabled proxy from Level 1 → Level 2 (Balanced), confirm both `blocking` and `detection` update to 2 and the policy's `Accepted` condition stays `True`
- [x] `bun run typecheck` and `bun run lint` pass