### PR TITLE
fix: improve onboarding org deletion

### DIFF
--- a/app/features/onboarding/billing/billing-form.tsx
+++ b/app/features/onboarding/billing/billing-form.tsx
@@ -208,7 +208,7 @@ export const BillingForm = ({
       </OnboardingEntrance>
 
       {isLegacySetupResume && resumeOrgId ? (
-        <BillingLegacyResumeNotice orgId={resumeOrgId} />
+        <BillingLegacyResumeNotice orgId={resumeOrgId} orgDisplayName={orgDisplayName} />
       ) : null}
     </div>
   );

--- a/app/features/onboarding/components/billing-legacy-resume-notice.tsx
+++ b/app/features/onboarding/components/billing-legacy-resume-notice.tsx
@@ -1,9 +1,9 @@
-import { DeleteOrganizationDialog } from '@/features/organization/delete-organization-dialog';
 import { HandwritingText } from '@/features/onboarding/components/handwriting-text';
 import {
   OnboardingEntrance,
   OnboardingStagger,
 } from '@/features/onboarding/components/onboarding-entrance';
+import { DeleteOrganizationDialog } from '@/features/organization/delete-organization-dialog';
 import { helpScoutAPI } from '@/modules/helpscout';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
 import { cn } from '@datum-cloud/datum-ui/utils';

--- a/app/features/onboarding/components/billing-legacy-resume-notice.tsx
+++ b/app/features/onboarding/components/billing-legacy-resume-notice.tsx
@@ -1,15 +1,13 @@
+import { DeleteOrganizationDialog } from '@/features/organization/delete-organization-dialog';
 import { HandwritingText } from '@/features/onboarding/components/handwriting-text';
 import {
   OnboardingEntrance,
   OnboardingStagger,
 } from '@/features/onboarding/components/onboarding-entrance';
 import { helpScoutAPI } from '@/modules/helpscout';
-import { paths } from '@/utils/config/paths.config';
-import { getPathWithParams } from '@/utils/helpers/path.helper';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
 import { cn } from '@datum-cloud/datum-ui/utils';
 import { useCallback, useState } from 'react';
-import { Link } from 'react-router';
 
 const PLATFORM_CHANGES = [
   {
@@ -37,10 +35,17 @@ const linkClassName = 'text-foreground underline underline-offset-2 hover:opacit
 /**
  * Right-hand notice shown to returning users resuming legacy org setup on the
  * onboarding billing page. Explains the platform changes that require them to
- * add a payment method, with escape hatches (deactivate the org, support).
+ * add a payment method, with escape hatches (delete the org, support).
  */
-export const BillingLegacyResumeNotice = ({ orgId }: { orgId: string }) => {
+export const BillingLegacyResumeNotice = ({
+  orgId,
+  orgDisplayName,
+}: {
+  orgId: string;
+  orgDisplayName?: string;
+}) => {
   const [contentVisible, setContentVisible] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const revealContent = useCallback((progress: number) => {
     if (progress >= NOTICE_REVEAL_PROGRESS) {
@@ -77,12 +82,13 @@ export const BillingLegacyResumeNotice = ({ orgId }: { orgId: string }) => {
             <OnboardingStagger visible={contentVisible} index={PLATFORM_CHANGES.length + 1}>
               <p className={bodyTextClassName}>
                 Don’t want to add a payment method? Please click{' '}
-                <Link
-                  to={getPathWithParams(paths.org.detail.settings.general, { orgId })}
+                <button
+                  type="button"
+                  onClick={() => setDeleteDialogOpen(true)}
                   className={linkClassName}>
                   here
-                </Link>{' '}
-                to deactivate your organization. If you need help or have questions, please email{' '}
+                </button>{' '}
+                to delete your organization. If you need help or have questions, please email{' '}
                 <a href="mailto:support@datum.net" className={linkClassName}>
                   support@datum.net
                 </a>{' '}
@@ -99,6 +105,12 @@ export const BillingLegacyResumeNotice = ({ orgId }: { orgId: string }) => {
           </div>
         </CardContent>
       </Card>
+      <DeleteOrganizationDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        orgId={orgId}
+        orgDisplayName={orgDisplayName}
+      />
     </OnboardingEntrance>
   );
 };

--- a/app/features/organization/delete-organization-dialog.tsx
+++ b/app/features/organization/delete-organization-dialog.tsx
@@ -1,0 +1,93 @@
+import { ConfirmationDialogProvider } from '@/components/confirmation-dialog/confirmation-dialog.provider';
+import { RestrictedOverlay } from '@/components/restricted-overlay/restricted-overlay';
+import { useDeleteOrganizationConfirmation } from '@/features/organization/use-delete-organization-confirmation';
+import { RbacProvider } from '@/modules/rbac';
+import { paths } from '@/utils/config/paths.config';
+import { Button } from '@datum-cloud/datum-ui/button';
+import { Dialog } from '@datum-cloud/datum-ui/dialog';
+import { LoaderOverlay } from '@datum-cloud/datum-ui/loader-overlay';
+import { useNavigate } from 'react-router';
+
+interface DeleteOrganizationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orgId: string;
+  orgDisplayName?: string;
+}
+
+function DeleteOrganizationDialogContent({
+  open,
+  onOpenChange,
+  orgId,
+  orgDisplayName,
+}: DeleteOrganizationDialogProps) {
+  const navigate = useNavigate();
+  const onClose = () => onOpenChange(false);
+
+  const { canDelete, permLoading, isDeleting, confirmDelete } = useDeleteOrganizationConfirmation({
+    orgId,
+    orgDisplayName,
+    onSuccess: () => {
+      onClose();
+      navigate(paths.account.organizations.root);
+    },
+  });
+
+  const displayLabel = orgDisplayName?.trim() || orgId;
+  const deleteDisabled = permLoading || !canDelete || isDeleting;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content className="w-full sm:max-w-lg">
+        <Dialog.Header className="mb-0 border-b" title="Delete organization" onClose={onClose} />
+        <Dialog.Body className="relative mb-0 px-5 py-4">
+          {permLoading ? <LoaderOverlay /> : null}
+          {!permLoading && !canDelete ? (
+            <RestrictedOverlay message="You don't have permission to delete this organization" />
+          ) : null}
+          <div className="flex flex-col gap-3">
+            <p className="text-foreground text-sm">
+              Are you sure you want to delete <strong>{displayLabel}</strong>?
+            </p>
+            <p className="text-foreground text-sm font-medium">
+              Deleting this organization will also remove its projects
+            </p>
+            <p className="text-muted-foreground text-sm">
+              Make sure you have made a backup of your projects if you want to keep your data.
+            </p>
+          </div>
+        </Dialog.Body>
+        <Dialog.Footer className="border-t">
+          <Button htmlType="button" type="quaternary" theme="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            htmlType="button"
+            type="danger"
+            theme="solid"
+            loading={isDeleting}
+            disabled={deleteDisabled}
+            data-e2e="delete-organization-dialog-button"
+            onClick={() => {
+              void confirmDelete();
+            }}>
+            Delete organization
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}
+
+/**
+ * Self-contained delete dialog for contexts without org-scoped RBAC/confirmation
+ * providers (e.g. onboarding billing). Org settings pages already inherit both
+ * from the private layout.
+ */
+export const DeleteOrganizationDialog = (props: DeleteOrganizationDialogProps) => (
+  <RbacProvider organizationId={props.orgId}>
+    <ConfirmationDialogProvider>
+      <DeleteOrganizationDialogContent {...props} />
+    </ConfirmationDialogProvider>
+  </RbacProvider>
+);

--- a/app/features/organization/settings/danger-card.tsx
+++ b/app/features/organization/settings/danger-card.tsx
@@ -1,62 +1,31 @@
-import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
 import { DangerCard } from '@/components/danger-card/danger-card';
 import { RestrictedOverlay } from '@/components/restricted-overlay/restricted-overlay';
-import { useAccessReview } from '@/modules/rbac';
-import { type Organization, useDeleteOrganization } from '@/resources/organizations';
+import { useDeleteOrganizationConfirmation } from '@/features/organization/use-delete-organization-confirmation';
+import { type Organization } from '@/resources/organizations';
 import { paths } from '@/utils/config/paths.config';
 import { LoaderOverlay } from '@datum-cloud/datum-ui/loader-overlay';
-import { toast } from '@datum-cloud/datum-ui/toast';
 import { useNavigate } from 'react-router';
 
 export const OrganizationDangerCard = ({ organization }: { organization: Organization }) => {
   const navigate = useNavigate();
 
-  const { allowed: canDelete, isLoading: permLoading } = useAccessReview(
-    'organizations',
-    'delete',
-    { group: 'resourcemanager.miloapis.com', name: organization?.name, scope: 'user' }
-  );
-
-  const deleteOrganization = useDeleteOrganization({
+  const { canDelete, permLoading, isDeleting, confirmDelete } = useDeleteOrganizationConfirmation({
+    orgId: organization?.name ?? '',
+    orgDisplayName: organization?.displayName || organization?.name,
     onSuccess: () => {
       navigate(paths.account.organizations.root);
     },
-    onError: (error) => {
-      toast.error('Organization', {
-        description: error.message || 'Failed to delete organization',
-      });
-    },
   });
-  const { confirm } = useConfirmationDialog();
-
-  const handleDeleteOrganization = async () => {
-    const displayLabel = organization?.displayName || organization?.name;
-
-    await confirm({
-      title: 'Delete Organization',
-      description: (
-        <span>
-          Are you sure you want to delete&nbsp;
-          <strong>{displayLabel}</strong>?
-        </span>
-      ),
-      submitText: 'Delete',
-      cancelText: 'Cancel',
-      variant: 'destructive',
-      showConfirmInput: true,
-      onSubmit: async () => {
-        deleteOrganization.mutate(organization?.name ?? '');
-      },
-    });
-  };
 
   return (
     <DangerCard
       title="Deleting this organization will also remove its projects"
       description="Make sure you have made a backup of your projects if you want to keep your data."
       deleteText="Delete organization"
-      loading={deleteOrganization.isPending}
-      onDelete={handleDeleteOrganization}
+      loading={isDeleting}
+      onDelete={() => {
+        void confirmDelete();
+      }}
       data-e2e="delete-organization-button"
       actionHidden={permLoading || !canDelete}>
       {permLoading ? (

--- a/app/features/organization/use-delete-organization-confirmation.tsx
+++ b/app/features/organization/use-delete-organization-confirmation.tsx
@@ -1,0 +1,62 @@
+import { useConfirmationDialog } from '@/components/confirmation-dialog/confirmation-dialog.provider';
+import { useAccessReview } from '@/modules/rbac';
+import { useDeleteOrganization } from '@/resources/organizations';
+import { toast } from '@datum-cloud/datum-ui/toast';
+import { useCallback } from 'react';
+
+interface UseDeleteOrganizationConfirmationOptions {
+  orgId: string;
+  orgDisplayName?: string;
+  onSuccess?: () => void;
+}
+
+export function useDeleteOrganizationConfirmation({
+  orgId,
+  orgDisplayName,
+  onSuccess,
+}: UseDeleteOrganizationConfirmationOptions) {
+  const { allowed: canDelete, isLoading: permLoading } = useAccessReview(
+    'organizations',
+    'delete',
+    { group: 'resourcemanager.miloapis.com', name: orgId, scope: 'user' }
+  );
+
+  const deleteOrganization = useDeleteOrganization({
+    onSuccess,
+    onError: (error) => {
+      toast.error('Organization', {
+        description: error.message || 'Failed to delete organization',
+      });
+    },
+  });
+
+  const { confirm } = useConfirmationDialog();
+
+  const confirmDelete = useCallback(async () => {
+    const displayLabel = orgDisplayName?.trim() || orgId;
+
+    await confirm({
+      title: 'Delete Organization',
+      description: (
+        <span>
+          Are you sure you want to delete&nbsp;
+          <strong>{displayLabel}</strong>?
+        </span>
+      ),
+      submitText: 'Delete',
+      cancelText: 'Cancel',
+      variant: 'destructive',
+      showConfirmInput: true,
+      onSubmit: async () => {
+        deleteOrganization.mutate(orgId);
+      },
+    });
+  }, [confirm, deleteOrganization, orgDisplayName, orgId]);
+
+  return {
+    canDelete,
+    permLoading,
+    isDeleting: deleteOrganization.isPending,
+    confirmDelete,
+  };
+}


### PR DESCRIPTION
Instead of navigating the user to org settings in the onboarding "delete org" action, we now throw up a dialog that does the action in line and then routes them back to the orgs list.