### PR TITLE
feat: track profile and account steps in onboarding funnel

### DIFF
--- a/app/features/onboarding/account/account-page.tsx
+++ b/app/features/onboarding/account/account-page.tsx
@@ -7,6 +7,7 @@ import {
   type OnboardingAccountValues,
 } from '@/features/onboarding/schemas/onboarding-account-schema';
 import { useTransitionNavigate } from '@/hooks/useTransitionNavigate';
+import { AnalyticsAction, useAnalytics } from '@/modules/rybbit';
 import { useUpdateUserPreferences, type LastLoginProviderValue } from '@/resources/users';
 import { paths } from '@/utils/config/paths.config';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
@@ -35,8 +36,12 @@ export const AccountPage = ({
   country = '',
 }: AccountPageProps) => {
   const { submitAndNavigate, isNavigating } = useTransitionNavigate();
+  const { trackAction } = useAnalytics();
 
   const updateProfileMutation = useUpdateUserPreferences(userId, {
+    onSuccess: () => {
+      trackAction(AnalyticsAction.AccountDetailsSaved);
+    },
     onError: (error) => {
       toast.error('Account information', {
         description: error.message ?? 'Failed to save your country',

--- a/app/features/onboarding/profile/profile-page.tsx
+++ b/app/features/onboarding/profile/profile-page.tsx
@@ -1,6 +1,7 @@
 import { OnboardingEntrance } from '@/features/onboarding/components/onboarding-entrance';
 import { onboardingCardClassName } from '@/features/onboarding/onboarding-layout';
 import { useTransitionNavigate } from '@/hooks/useTransitionNavigate';
+import { AnalyticsAction, useAnalytics } from '@/modules/rybbit';
 import { userKeys, userSchema, useUpdateUser, type User } from '@/resources/users';
 import { paths } from '@/utils/config/paths.config';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
@@ -30,11 +31,13 @@ export const ProfilePage = ({
 }: ProfilePageProps) => {
   const { submitAndNavigate, isNavigating } = useTransitionNavigate();
   const queryClient = useQueryClient();
+  const { trackAction } = useAnalytics();
 
   const updateMutation = useUpdateUser(userId, {
     onSuccess: (updatedUser) => {
       const next = userAfterSuccessfulNameSave(updatedUser);
       queryClient.setQueryData(userKeys.detail(userId), next);
+      trackAction(AnalyticsAction.ProfileDetailsSaved);
     },
     onError: (error) => {
       toast.error('Profile', {

--- a/app/modules/rybbit/analytics.types.ts
+++ b/app/modules/rybbit/analytics.types.ts
@@ -10,6 +10,8 @@ export const AnalyticsAction = {
   InviteCollaborator: 'invite_collaborator',
   CreateOrg: 'create_org',
   DownloadDesktopApp: 'download_desktop_app',
+  ProfileDetailsSaved: 'profile_details_saved',
+  AccountDetailsSaved: 'account_details_saved',
   ContactDetailsSaved: 'contact_details_saved',
   PaymentDetailsSaved: 'payment_details_saved',
   FirstProjectView: 'first_project_view',


### PR DESCRIPTION
## Summary

The onboarding funnel tracked `contact_details_saved`, `payment_details_saved`, and `first_project_view`, but not the two steps that happen before them — name entry and country selection — so early drop-off in the funnel was invisible.

## Changes

Two new events, following the same pattern as the existing billing-step events: `profile_details_saved` fires from `profile-page.tsx`'s update-user mutation `onSuccess`, and `account_details_saved` fires from `account-page.tsx`'s update-preferences mutation `onSuccess`. Both are added to `AnalyticsAction` in `analytics.types.ts`.

Typecheck, lint, and prettier all pass.
