### PR TITLE
fix: guard WAF events increase() against counter resets

### DIFF
--- a/app/features/edge/proxy/metrics/waf-events.test.ts
+++ b/app/features/edge/proxy/metrics/waf-events.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test';
+
+import { resetGuardedIncrease } from './waf-events';
+
+describe('resetGuardedIncrease', () => {
+  it('multiplies increase() by a resets()-equals-zero guard over the same series and window', () => {
+    const query = resetGuardedIncrease(
+      'coraza_envoy_filter_request_events_total',
+      '{coraza_outcome="allowed"}',
+      '30m'
+    );
+
+    expect(query).toBe(
+      '(increase(coraza_envoy_filter_request_events_total{coraza_outcome="allowed"}[30m]) * ' +
+        '(resets(coraza_envoy_filter_request_events_total{coraza_outcome="allowed"}[30m]) == bool 0))'
+    );
+  });
+
+  it('applies the same window to both increase() and resets()', () => {
+    const query = resetGuardedIncrease('some_counter_total', '{label="value"}', '1m');
+
+    const incWindow = query.match(/increase\([^[]+\[(\w+)\]\)/)?.[1];
+    const resetsWindow = query.match(/resets\([^[]+\[(\w+)\]\)/)?.[1];
+
+    expect(incWindow).toBe('1m');
+    expect(resetsWindow).toBe('1m');
+  });
+});

--- a/app/features/edge/proxy/metrics/waf-events.tsx
+++ b/app/features/edge/proxy/metrics/waf-events.tsx
@@ -33,7 +33,7 @@ function windowDuration(ctx: QueryBuilderContext): string {
 // A counter reset inside the range makes increase() extrapolate a bogus,
 // wildly inflated delta. Zero out any window where a reset occurred instead
 // of reporting it.
-function resetGuardedIncrease(metric: string, selector: string, window: string): string {
+export function resetGuardedIncrease(metric: string, selector: string, window: string): string {
   const series = `${metric}${selector}`;
   return `(increase(${series}[${window}]) * (resets(${series}[${window}]) == bool 0))`;
 }

--- a/app/features/edge/proxy/metrics/waf-events.tsx
+++ b/app/features/edge/proxy/metrics/waf-events.tsx
@@ -30,6 +30,14 @@ function windowDuration(ctx: QueryBuilderContext): string {
   return formatDurationFromMs(ctx.timeRange.end.getTime() - ctx.timeRange.start.getTime());
 }
 
+// A counter reset inside the range makes increase() extrapolate a bogus,
+// wildly inflated delta. Zero out any window where a reset occurred instead
+// of reporting it.
+function resetGuardedIncrease(metric: string, selector: string, window: string): string {
+  const series = `${metric}${selector}`;
+  return `(increase(${series}[${window}]) * (resets(${series}[${window}]) == bool 0))`;
+}
+
 function WafStat({ label, query }: { label: string; query: (ctx: QueryBuilderContext) => string }) {
   const { timeRange, step, buildQueryContext, filterState } = useMetrics();
   const resolvedQuery = useMemo(
@@ -77,7 +85,7 @@ export const HttpProxyWafEvents = ({
         },
         filters: [regionFilter],
       });
-      return `sum(increase(coraza_envoy_filter_request_events_total${selector}[${windowDuration(ctx)}]))`;
+      return `sum(${resetGuardedIncrease('coraza_envoy_filter_request_events_total', selector, windowDuration(ctx))})`;
     },
     [projectId, proxyId]
   );
@@ -95,7 +103,7 @@ export const HttpProxyWafEvents = ({
         customLabels: { label_topology_kubernetes_io_region: '!=""' },
         filters: [regionFilter],
       });
-      return `sum(increase(coraza_envoy_filter_request_events_total${selector}[${windowDuration(ctx)}]))`;
+      return `sum(${resetGuardedIncrease('coraza_envoy_filter_request_events_total', selector, windowDuration(ctx))})`;
     },
     [projectId, proxyId, trafficProtectionMode]
   );
@@ -140,7 +148,7 @@ export const HttpProxyWafEvents = ({
           return (
             `sum by (coraza_outcome) (` +
             `sum_over_time(` +
-            `increase(coraza_envoy_filter_request_events_total${selector}[1m])` +
+            `${resetGuardedIncrease('coraza_envoy_filter_request_events_total', selector, '1m')}` +
             `[${step}:1m]))`
           );
         }}


### PR DESCRIPTION
## Summary

- The AI Edge proxy overview page's **Traffic Protection Events** panel could show wildly inflated numbers — a proxy with near-zero traffic showed **Allowed: 116M** for a 30-minute window, driven almost entirely by two adjacent 1-minute chart buckets (20.8M and 95.2M "allowed" events).
- Root cause: a reset in the underlying `coraza_envoy_filter_request_events_total` counter inside a query window makes PromQL's `increase()` extrapolate a bogus, wildly inflated delta instead of the real (small) count.
- Fix: gate every `increase()` on this metric with `resets()` — if a reset occurred inside the window, report `0` for that window instead of the spurious extrapolated value.

Related to #1362

## Test plan

- [x] `bun run typecheck` passes
- [x] Verified against production VictoriaMetrics that the reset-guard doesn't disturb legitimate (no-reset) data — matched the unguarded baseline value exactly
- [ ] Confirm the Traffic Protection Events panel no longer spikes on `kev1n-proxy` / other affected proxies after deploy