### PR TITLE
fix: make dev server killable with Ctrl+C

### DIFF
--- a/observability/dev-start.js
+++ b/observability/dev-start.js
@@ -7,6 +7,16 @@
 
 /* global process */
 
+// How long the dev server gets to exit on its own before we force the issue.
+// vite normally exits within ~1s of SIGTERM; this is the backstop, not the
+// expected path.
+const SHUTDOWN_GRACE_MS = 5000;
+
+// The TTY delivers SIGINT to every process in the foreground group, and
+// `bun run` forwards it again, so a single Ctrl+C can arrive here twice.
+// Signals closer together than this are treated as one interrupt.
+const DUPLICATE_SIGNAL_MS = 500;
+
 /**
  * Start the React Router development server
  */
@@ -19,6 +29,10 @@ async function startDevServer() {
     env: { ...process.env },
   });
 
+  let shuttingDown = false;
+  let shutdownStartedAt = 0;
+  let forceKillTimer = null;
+
   const forwardSignal = (signal) => {
     try {
       devProcess.kill(signal);
@@ -27,14 +41,59 @@ async function startDevServer() {
     }
   };
 
-  process.on('SIGTERM', () => forwardSignal('SIGTERM'));
-  process.on('SIGINT', () => forwardSignal('SIGINT'));
+  const hardKill = () => {
+    if (forceKillTimer) clearTimeout(forceKillTimer);
+    forwardSignal('SIGKILL');
+    // Registering a signal listener opts this process out of the default
+    // terminate-on-signal behavior, so the exit has to be explicit.
+    process.exit(0);
+  };
+
+  const handleSignal = () => {
+    if (shuttingDown) {
+      // Same interrupt arriving twice via different paths, not a new one.
+      if (Date.now() - shutdownStartedAt < DUPLICATE_SIGNAL_MS) return;
+
+      // A genuinely later interrupt means "I'm done waiting" — skip the grace period.
+      console.log('⏹️ Second interrupt received, force killing dev server...');
+      hardKill();
+      return;
+    }
+
+    shuttingDown = true;
+    shutdownStartedAt = Date.now();
+
+    // Always ask with SIGTERM, whichever signal we received. vite ignores
+    // SIGINT — observability installs a SIGINT listener inside that process
+    // which suppresses default termination — but it exits promptly on SIGTERM.
+    forwardSignal('SIGTERM');
+
+    forceKillTimer = setTimeout(() => {
+      console.warn(`⚠️ Dev server did not exit within ${SHUTDOWN_GRACE_MS}ms, force killing...`);
+      hardKill();
+    }, SHUTDOWN_GRACE_MS);
+    // Don't let the grace timer itself hold the process open.
+    forceKillTimer.unref?.();
+  };
+
+  process.on('SIGTERM', () => handleSignal());
+  process.on('SIGINT', () => handleSignal());
 
   const exitCode = await devProcess.exited;
+  if (forceKillTimer) clearTimeout(forceKillTimer);
+
+  // A signal-initiated shutdown is a normal exit, not a failure. Reporting the
+  // child's code here is what surfaced the confusing "exited with code 7".
+  if (shuttingDown) {
+    process.exit(0);
+  }
+
   if (exitCode !== 0) {
     console.error(`❌ Development server exited with code ${exitCode}`);
     process.exit(exitCode);
   }
+
+  process.exit(0);
 }
 
 /**

--- a/observability/index.ts
+++ b/observability/index.ts
@@ -14,6 +14,9 @@ const PROVIDER_REGISTRY = {
 type ProviderName = keyof typeof PROVIDER_REGISTRY;
 type ProviderInstance = InstanceType<(typeof PROVIDER_REGISTRY)[ProviderName]>;
 
+const SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
+type ShutdownSignal = (typeof SHUTDOWN_SIGNALS)[number];
+
 // ============================================================================
 // MAIN OBSERVABILITY MANAGER
 // ============================================================================
@@ -250,14 +253,23 @@ export class ObservabilityManager {
   }
 
   private setupGracefulShutdown(): void {
-    // Do not force-exit the process here. The process entrypoint (e.g. `observability/start.js`)
-    // is responsible for orchestrating graceful shutdown (stop server, drain, flush telemetry, exit).
+    // Prefer not to force-exit here: when an entrypoint owns the process
+    // lifecycle (e.g. `observability/start.js`) it is responsible for
+    // orchestrating shutdown — stop server, drain, flush telemetry, exit — and
+    // exiting from under it would cut in-flight requests short.
     //
-    // We still shut down providers on termination signals as a best-effort fallback.
+    // But registering a listener at all opts the process out of Node's default
+    // terminate-on-signal behavior. Where this module is loaded without such an
+    // entrypoint (e.g. `app/server/entry.ts` running inside vite), deferring to
+    // an owner that does not exist leaves the process unkillable. So we check at
+    // signal time whether anyone else is listening; if we are alone, nobody owns
+    // the exit and we restore the default by re-raising the signal.
     let handled = false;
-    const handler = (signal: string) => {
+
+    const onSignal = (signal: ShutdownSignal, listener: () => void): void => {
       if (handled) return;
       handled = true;
+
       console.log(`🛑 Received ${signal}, shutting down observability services...`);
       try {
         this.shutdown();
@@ -265,10 +277,17 @@ export class ObservabilityManager {
         const msg = e instanceof Error ? e.message : String(e);
         console.warn('⚠️ Error while shutting down observability services:', msg);
       }
+
+      if (process.listenerCount(signal) <= 1) {
+        process.removeListener(signal, listener);
+        process.kill(process.pid, signal);
+      }
     };
 
-    process.on('SIGTERM', () => handler('SIGTERM'));
-    process.on('SIGINT', () => handler('SIGINT'));
+    for (const signal of SHUTDOWN_SIGNALS) {
+      const listener = (): void => onSignal(signal, listener);
+      process.on(signal, listener);
+    }
   }
 
   private setupUncaughtExceptionHandler(): void {
@@ -281,8 +300,13 @@ export class ObservabilityManager {
         return;
       }
 
-      console.error('❌ Non-observability uncaught exception, re-throwing:', error.message);
-      throw error;
+      // Terminate the way Node would have if this handler were not installed:
+      // report the error, then exit non-zero. Re-throwing here does not
+      // propagate — there is no frame above an uncaughtException handler — it
+      // just aborts with a misleading exit code and no stack.
+      console.error('❌ Non-observability uncaught exception:', error);
+      this.captureException(error);
+      process.exit(1);
     });
   }
 


### PR DESCRIPTION
## Problem

`bun run dev` couldn't be stopped with Ctrl+C. The interrupt printed shutdown messages twice, then crashed with `EIO: i/o error, read` and exit `code 7`. Stopping the server usually needed repeated Ctrl+C or a `pkill` on the port.

## Cause

Registering a SIGINT listener opts a process out of Node's default terminate-on-signal behavior. `dev-start.js` forwarded the signal to vite but never exited, and `observability/index.ts` defers exiting to the entrypoint — which in dev is `dev-start.js`. Neither side owned the exit, so nothing terminated.

The same issue applied inside the vite process, where observability also registered a listener without owning the exit. That's why vite ignored SIGINT while still exiting normally on SIGTERM.

The `EIO` crash was the only thing actually killing the server, and since it's timing-dependent, shutdown behaved unpredictably.

## Changes

**`observability/dev-start.js`**
- Exit explicitly once the child process is gone
- Forward SIGTERM, which vite acts on, instead of SIGINT
- SIGKILL backstop after 5s, or immediately on a second interrupt
- Debounce duplicate signal delivery (the TTY signals the process group and `bun run` forwards it again)
- Treat signal-initiated shutdown as success rather than an error exit code

**`observability/index.ts`**
- Only defer the exit when another handler owns it; otherwise restore the default termination behavior
- Stop re-throwing from the `uncaughtException` handler, which produced no stack and no Sentry report. Log, capture, and exit 1 instead

## Testing

| Scenario | Before | After |
|---|---|---|
| Ctrl+C | never exits, port held | exits in ~1s |
| Double Ctrl+C | — | exits in ~1s |
| SIGTERM | — | exits in ~1s |
| Lone vite + SIGINT | alive after 20s | exits in ~1s |
| Uncaught exception | opaque abort | exits 1 with stack |
| Production `bun run start` + SIGTERM | — | drains and exits in ~1s |

No stray processes; port 3000 released in every case. The production path was verified against a real build to confirm in-flight requests still drain fully before exit.

`bun run typecheck`, `bun run build`, ESLint and Prettier all pass.