### PR TITLE
fix(metrics): correct AI Edge overview request-rate query and chart timezone

### DIFF
--- a/app/features/edge/proxy/metrics/edge-requests.tsx
+++ b/app/features/edge/proxy/metrics/edge-requests.tsx
@@ -67,11 +67,10 @@ export const HttpProxyEdgeRequests = ({
               const step = filters.step ?? '15m';
               return (
                 `sum by (envoy_response_code_class) (` +
-                `sum_over_time(` +
                 `label_replace(` +
-                `increase(envoy_vhost_vcluster_upstream_rq${selector}[1m]),` +
+                `rate(envoy_vhost_vcluster_upstream_rq${selector}[${step}]),` +
                 `"envoy_response_code_class","$\{1}XX","envoy_response_code","([0-9]).*"` +
-                `)[${step}:1m]))`
+                `))`
               );
             }}
             chartType="area"

--- a/app/modules/metrics/components/metric-chart.tsx
+++ b/app/modules/metrics/components/metric-chart.tsx
@@ -26,6 +26,8 @@ import {
   type PrometheusQueryOptions,
   ChartSeries,
 } from '@/modules/prometheus';
+import { useApp } from '@/providers/app.provider';
+import { getBrowserTimezone } from '@/utils/helpers/timezone.helper';
 import {
   ChartContainer,
   ChartLegend,
@@ -126,6 +128,8 @@ export function MetricChart({
   children,
 }: MetricChartProps) {
   const { timeRange, step, buildQueryContext, filterState } = useMetrics();
+  const { userPreferences } = useApp();
+  const timezone = userPreferences?.timezone ?? getBrowserTimezone();
 
   // Resolve custom API parameters - include filterState in dependencies to trigger re-evaluation
   const resolvedApiParams = useMemo(() => {
@@ -255,9 +259,9 @@ export function MetricChart({
       if (xAxisFormatter) {
         return xAxisFormatter(tickItem);
       }
-      return formatChartTimeTick(tickItem, timeRangeMs);
+      return formatChartTimeTick(tickItem, timeRangeMs, timezone);
     },
-    [xAxisFormatter, timeRangeMs]
+    [xAxisFormatter, timeRangeMs, timezone]
   );
 
   const tooltipLabelFormatter: any = useCallback((label: string) => {

--- a/app/modules/metrics/utils/chart-axis.ts
+++ b/app/modules/metrics/utils/chart-axis.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 
 const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
 const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
@@ -48,12 +48,15 @@ export function buildUniformYTicks(domain: [number, number], tickCount = 5): num
 
 /**
  * Pick an X-axis time label format based on the selected range width.
+ * Renders in the given timezone so ticks match the picker and tooltips,
+ * which are timezone-aware — falling back to the runtime's local zone
+ * would otherwise silently mislabel every tick.
  */
-export function formatChartTimeTick(timestamp: number, rangeMs: number): string {
+export function formatChartTimeTick(timestamp: number, rangeMs: number, timezone: string): string {
   const date = new Date(timestamp);
-  if (rangeMs < SIX_HOURS_MS) return format(date, 'h:mm a');
-  if (rangeMs < FORTY_EIGHT_HOURS_MS) return format(date, 'MMM d, h:mm a');
-  return format(date, 'MMM d');
+  if (rangeMs < SIX_HOURS_MS) return formatInTimeZone(date, timezone, 'h:mm a');
+  if (rangeMs < FORTY_EIGHT_HOURS_MS) return formatInTimeZone(date, timezone, 'MMM d, h:mm a');
+  return formatInTimeZone(date, timezone, 'MMM d');
 }
 
 type ChartRow = Record<string, number>;


### PR DESCRIPTION
## Summary
- The "Requests per second" chart on the AI Edge overview page used `increase()` + `sum_over_time()` over the full step window, summed across all series — producing a cumulative total (e.g. 40M+) instead of an actual per-second rate. Switched to `rate()`, matching the pattern already used by the P95 latency chart.
- Chart x-axis tick labels were formatted with `date-fns` in the browser's local timezone, while the time-range picker and tooltips already render in the user's configured timezone preference. This produced a fixed-offset mismatch between the axis and the picker/tooltip (e.g. axis showing 7:14 AM while picker showed 14:14 PDT). `formatChartTimeTick` now accepts a timezone and renders with `date-fns-tz`, and `MetricChart` threads through `userPreferences.timezone ?? getBrowserTimezone()`.

## Test plan
- [ ] Open an AI Edge proxy's overview page and confirm "Requests per second" values are in a plausible per-second range
- [ ] Confirm the x-axis tick labels match the selected time range shown in the date-range picker
- [ ] Confirm tooltip timestamps still match axis tick timestamps