### PR TITLE
fix(assistant): serialize tool outputs to JSON-safe values

### DIFF
--- a/app/modules/assistant/tools/index.ts
+++ b/app/modules/assistant/tools/index.ts
@@ -1,5 +1,6 @@
 import { createActivityTools } from './activity-tools';
 import { createBillingTools } from './billing-tools';
+import { withJsonSafeOutput } from './json-safe';
 import { createMetricsTools } from './metrics-tools';
 import { createResourceTools } from './resource-tools';
 import { createUtilityTools } from './utility-tools';
@@ -9,11 +10,11 @@ interface ToolDeps {
 }
 
 export function createAssistantTools({ accessToken }: ToolDeps) {
-  return {
+  return withJsonSafeOutput({
     ...createResourceTools(),
     ...createMetricsTools({ accessToken }),
     ...createActivityTools(),
     ...createBillingTools(),
     ...createUtilityTools(),
-  };
+  });
 }

--- a/app/modules/assistant/tools/json-safe.test.ts
+++ b/app/modules/assistant/tools/json-safe.test.ts
@@ -1,0 +1,98 @@
+import { toJsonSafe, withJsonSafeOutput } from './json-safe';
+import type { Tool } from 'ai';
+import { describe, expect, it } from 'bun:test';
+
+describe('toJsonSafe', () => {
+  it('converts a top-level Date to an ISO string', () => {
+    const date = new Date('2024-01-01T00:00:00.000Z');
+    expect(toJsonSafe(date)).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('converts nested Dates — the activity-log tool-output shape that broke chat', () => {
+    const output = {
+      items: [
+        { verb: 'create', timestamp: new Date('2024-01-01T00:00:00.000Z') },
+        { verb: 'delete', timestamp: new Date('2024-01-02T12:30:00.000Z') },
+      ],
+      hasMore: false,
+      window: '24h',
+    };
+
+    expect(toJsonSafe(output)).toEqual({
+      items: [
+        { verb: 'create', timestamp: '2024-01-01T00:00:00.000Z' },
+        { verb: 'delete', timestamp: '2024-01-02T12:30:00.000Z' },
+      ],
+      hasMore: false,
+      window: '24h',
+    });
+  });
+
+  it('leaves already-JSON values unchanged', () => {
+    const value = { a: 1, b: 'two', c: [true, null], d: { e: 3 } };
+    expect(toJsonSafe(value)).toEqual(value);
+  });
+
+  it('drops undefined object properties (matches what the model receives)', () => {
+    expect(toJsonSafe({ a: 1, b: undefined })).toEqual({ a: 1 });
+  });
+
+  it('passes through a bare undefined', () => {
+    expect(toJsonSafe(undefined)).toBeUndefined();
+  });
+});
+
+// Minimal tool stubs — withJsonSafeOutput only touches `.execute` structurally.
+function fakeTool(execute?: (...args: unknown[]) => unknown): Tool {
+  return { execute } as unknown as Tool;
+}
+
+// Invoke a stub tool's (wrapped) execute without wrestling the AI SDK's Tool type.
+function runTool(t: Tool, ...args: unknown[]): Promise<unknown> {
+  const execute = (t as unknown as { execute: (...a: unknown[]) => Promise<unknown> }).execute;
+  return execute(...args);
+}
+
+describe('withJsonSafeOutput', () => {
+  it('normalizes a tool output containing a Date to an ISO string', async () => {
+    const tools = withJsonSafeOutput({
+      queryActivityLogs: fakeTool(async () => ({
+        items: [{ verb: 'update', timestamp: new Date('2024-03-04T05:06:07.000Z') }],
+      })),
+    });
+
+    const result = await runTool(tools.queryActivityLogs);
+    expect(result).toEqual({
+      items: [{ verb: 'update', timestamp: '2024-03-04T05:06:07.000Z' }],
+    });
+  });
+
+  it('passes plain JSON output through unchanged (does not break existing tools)', async () => {
+    const payload = { enabled: true, accounts: ['a', 'b'] };
+    const tools = withJsonSafeOutput({ getBilling: fakeTool(async () => payload) });
+
+    const result = await runTool(tools.getBilling);
+    expect(result).toEqual(payload);
+  });
+
+  it('forwards arguments to the wrapped execute', async () => {
+    const tools = withJsonSafeOutput({
+      echo: fakeTool(async (input: unknown) => ({ received: input })),
+    });
+
+    const result = await runTool(tools.echo, { projectId: 'proj-1' });
+    expect(result).toEqual({ received: { projectId: 'proj-1' } });
+  });
+
+  it('leaves a tool without an execute function untouched', () => {
+    const noExec = fakeTool(undefined);
+    const tools = withJsonSafeOutput({ noExec });
+    expect(tools.noExec).toBe(noExec);
+    expect((tools.noExec as { execute?: unknown }).execute).toBeUndefined();
+  });
+
+  it('returns the same tools object it was given (mutates in place)', () => {
+    const input = { t: fakeTool(async () => ({})) };
+    expect(withJsonSafeOutput(input)).toBe(input);
+  });
+});

--- a/app/modules/assistant/tools/json-safe.ts
+++ b/app/modules/assistant/tools/json-safe.ts
@@ -1,0 +1,28 @@
+import type { Tool } from 'ai';
+
+/**
+ * Round-trip a value through JSON so it only ever contains JSON values.
+ * Tool outputs are replayed into the model prompt on the next step, and the AI
+ * SDK validates that prompt (`standardizePrompt`): a non-JSON value such as a
+ * `Date` fails validation and aborts the entire conversation. Serializing turns
+ * Dates into ISO strings and drops `undefined`/functions — exactly what the
+ * model would have received anyway.
+ */
+export function toJsonSafe(value: unknown): unknown {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * Wrap each tool's `execute` so its output is JSON-safe. Applied centrally so no
+ * individual tool has to remember to serialize Dates (resource `createdAt`,
+ * activity-log `timestamp`, …) before returning.
+ */
+export function withJsonSafeOutput<T extends Record<string, Tool>>(tools: T): T {
+  for (const t of Object.values(tools)) {
+    const execute = (t as { execute?: (...args: unknown[]) => unknown }).execute;
+    if (typeof execute !== 'function') continue;
+    (t as { execute: (...args: unknown[]) => unknown }).execute = async (...args) =>
+      toJsonSafe(await execute(...args));
+  }
+  return tools;
+}


### PR DESCRIPTION
## Summary

After the project chat migration (#1368), chatting could fail with a generic **"Something went wrong — An error occurred"** whenever the assistant invoked certain tools.

### Root cause

Some assistant tools return objects containing raw JavaScript `Date` values — e.g. `queryActivityLogs` items carry a `timestamp` (`activity-log.schema.ts`, `z.coerce.date()`), and the resource-list tools spread `...rest` which includes `createdAt` (`base.schema.ts` / `secret.schema.ts` / `dns-zone.adapter.ts`).

Tool results are replayed into the model prompt on the next agent step, and the AI SDK validates that prompt via `standardizePrompt` (Zod). A `Date` is **not a valid JSON value** (not null/string/number/boolean/record/array), so validation threw and aborted the whole turn:

```
ZodError: Invalid input: expected string, received Date
  path: [ ..., "output", "value", "items", 18, "timestamp" ]
  at standardizePrompt (node_modules/ai/dist/index.js:2452)
  at streamLanguageModelCall (...)
```

**Why the migration surfaced it:** these tools have always returned `Date`s. #1368 bumped `ai` `^6.0.208 → ^7` (and `@ai-sdk/anthropic` `^3 → ^4`) to meet datum-ui's peer range, and AI SDK **v7 tightened `standardizePrompt`** to strictly validate a tool result's `output.value` as JSON. v6 tolerated the `Date`; v7 rejects it. So the bug is latent-until-now, exposed by the SDK major bump the migration carried — not by the UI change itself.

It's intermittent by design — it only fires when the model actually calls a tool whose output holds a `Date`, so unrelated chat topics keep working.

## Fix

Normalize tool output centrally rather than per-tool (which would be whack-a-mole across ~10 tools). A new dependency-free helper wraps every tool's `execute` in `createAssistantTools`, round-tripping its result through JSON:

- `Date` → ISO string
- `undefined` / functions dropped — exactly what the model receives over the wire anyway

This covers every current tool and prevents future tools from reintroducing the bug.

### Files
- `app/modules/assistant/tools/json-safe.ts` (new) — `toJsonSafe` + `withJsonSafeOutput`
- `app/modules/assistant/tools/index.ts` — `createAssistantTools` now returns `withJsonSafeOutput({ ... })`
- `app/modules/assistant/tools/json-safe.test.ts` (new) — unit tests

## Testing

- New unit tests (10 cases, `bun:test`): reproduces the exact `items[].timestamp` Date shape as a regression guard, confirms plain-JSON output passes through **unchanged**, plus arg forwarding, `undefined` dropping, and tools without `execute`.
- `bun test app/modules/assistant app/resources/activity-logs` — all pass (existing + new).
- `tsc --noEmit` clean (0 errors); eslint + prettier clean (pre-commit hooks pass).
- Manually: asking the assistant "what changed recently?" (activity logs) and "list my domains" (`createdAt`) now complete instead of erroring.