### PR TITLE
fix(test): stop user-access mock from clobbering the auth barrel

### DIFF
--- a/app/utils/fraud/user-access.test.ts
+++ b/app/utils/fraud/user-access.test.ts
@@ -11,8 +11,18 @@ mock.module('@/resources/users', () => ({
   createUserService: () => ({ get }),
 }));
 
+// Partial mock. `mock.module` is process-global in Bun and every test file
+// shares one module registry, so replacing the whole '@/utils/auth' barrel here
+// strips exports that later test files still need — session.server.ts imports
+// AUTH_COOKIE_KEYS, AuthService and sessionStorage from this same barrel, while
+// only getRefreshToken/getSession/refreshTokens were stubbed. Spreading the real
+// module keeps the rest intact so this stub cannot leak past this file.
+const actualAuth = await import('@/utils/auth');
+
 mock.module('@/utils/auth', () => ({
+  ...actualAuth,
   AuthService: {
+    ...actualAuth.AuthService,
     getRefreshToken: async () => ({ refreshToken: 'refresh', rawSession: {} }),
     getSession: async () => ({ rawSession: {} }),
     refreshTokens,


### PR DESCRIPTION
Fixes the `Bun Unit Tests` job, which has been failing on **every** branch (#1370, #1380, #1381, `iam-platformaccess-migration`) with 6 identical failures while passing locally on macOS.

## Root cause

`mock.module` is process-global in Bun and all test files share one module registry. `app/utils/fraud/user-access.test.ts` replaced the **entire** `@/utils/auth` barrel with a 3-method stub:

```ts
mock.module("@/utils/auth", () => ({
  AuthService: { getRefreshToken, getSession, refreshTokens },
}));
```

`app/utils/cookies/session.server.ts:8` imports `AUTH_COOKIE_KEYS`, `AuthService` and `sessionStorage` from that same barrel, so every test file running after it receives a crippled module:

```
TypeError: AuthService.getValidSession is not a function
TypeError: AuthService.destroySession is not a function
```

The stub defines exactly the three methods that survive, and the two that error are precisely the ones it omits.

Why it hid: it only bites when discovery order puts the stubbing file before its victims, and that order comes from the filesystem — which differs between macOS and Linux.

## Fix

Spread the real module into the mock so only the three methods under test are overridden.

## Test plan

- [x] `bun test --coverage` locally — 465 pass, 0 fail
- [ ] CI `Bun Unit Tests` green (the only environment that reproduces)
- [ ] Re-run a blocked PR (e.g. #1370) to confirm it unblocks