### PR TITLE
fix(env): treat blank env values as absent

### DIFF
--- a/app/utils/env/env.server.ts
+++ b/app/utils/env/env.server.ts
@@ -1,4 +1,5 @@
 // app/utils/env/env.server.ts
+import { omitBlankEnv } from './omit-blank-env';
 import type { Env } from './types';
 import { z } from 'zod';
 
@@ -187,7 +188,10 @@ const serverSchema = z.object({
 
 // Zod v4: Use .extend() instead of deprecated .merge()
 const fullSchema = publicSchema.extend(serverSchema.shape);
-const parsed = fullSchema.safeParse(process.env);
+// Blank values are treated as absent so `.default()` / `.optional()` apply —
+// see omitBlankEnv. Without it, an unset CI secret (exported as "") or a bare
+// `KEY=` in .env fails validation and exits(1) below instead of defaulting.
+const parsed = fullSchema.safeParse(omitBlankEnv(process.env));
 
 if (!parsed.success) {
   console.error('❌ Invalid environment variables:');

--- a/app/utils/env/index.ts
+++ b/app/utils/env/index.ts
@@ -1,6 +1,7 @@
 // app/utils/env/index.ts
 // Universal env module - works on both server and client
 // For server secrets, import directly from '@/utils/env/env.server'
+import { omitBlankEnv } from './omit-blank-env';
 import type { PublicEnv } from './types';
 
 declare global {
@@ -42,35 +43,37 @@ function getPublicEnv(): PublicEnv {
     return window.ENV ?? clientDefaults;
   }
 
-  // Server-side (SSR): read from process.env
-  const nodeEnv = (process.env.NODE_ENV as PublicEnv['nodeEnv']) ?? 'development';
+  // Server-side (SSR): read from process.env. Blank values are dropped so the
+  // `??` fallbacks below treat `FOO=` the same as an absent FOO — matching
+  // env.server.ts, which would otherwise disagree with this module.
+  const source = omitBlankEnv(process.env);
+  const nodeEnv = (source.NODE_ENV as PublicEnv['nodeEnv']) ?? 'development';
   return {
     nodeEnv,
-    version: process.env.VERSION,
-    debug: process.env.DEBUG === 'true' || process.env.DEBUG === '1',
-    appUrl: process.env.APP_URL ?? '',
-    apiUrl: process.env.API_URL ?? '',
-    graphqlUrl: process.env.GRAPHQL_URL ?? '',
-    authOidcIssuer: process.env.AUTH_OIDC_ISSUER ?? '',
-    authZitadelProjectId: process.env.AUTH_ZITADEL_PROJECT_ID,
-    sentryDsn: process.env.SENTRY_DSN,
-    sentryEnv: process.env.SENTRY_ENV,
-    rybbitSiteId: process.env.RYBBIT_SITE_ID,
-    rybbitTag: process.env.RYBBIT_TAG,
-    helpscoutBeaconId: process.env.HELPSCOUT_BEACON_ID,
+    version: source.VERSION,
+    debug: source.DEBUG === 'true' || source.DEBUG === '1',
+    appUrl: source.APP_URL ?? '',
+    apiUrl: source.API_URL ?? '',
+    graphqlUrl: source.GRAPHQL_URL ?? '',
+    authOidcIssuer: source.AUTH_OIDC_ISSUER ?? '',
+    authZitadelProjectId: source.AUTH_ZITADEL_PROJECT_ID,
+    sentryDsn: source.SENTRY_DSN,
+    sentryEnv: source.SENTRY_ENV,
+    rybbitSiteId: source.RYBBIT_SITE_ID,
+    rybbitTag: source.RYBBIT_TAG,
+    helpscoutBeaconId: source.HELPSCOUT_BEACON_ID,
     logLevel:
-      (process.env.LOG_LEVEL as PublicEnv['logLevel']) ??
-      (nodeEnv === 'production' ? 'info' : 'debug'),
+      (source.LOG_LEVEL as PublicEnv['logLevel']) ?? (nodeEnv === 'production' ? 'info' : 'debug'),
     logFormat:
-      (process.env.LOG_FORMAT as PublicEnv['logFormat']) ??
+      (source.LOG_FORMAT as PublicEnv['logFormat']) ??
       (nodeEnv === 'production' ? 'json' : 'pretty'),
-    logCurl: process.env.LOG_CURL !== 'false' && nodeEnv === 'development',
-    logRedactTokens: process.env.LOG_REDACT_TOKENS !== 'false' || nodeEnv === 'production',
-    logPayloads: process.env.LOG_PAYLOADS === 'true' || nodeEnv === 'development',
-    otelEnabled: process.env.OTEL_ENABLED === 'true' && !!process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
-    otelLogLevel: process.env.OTEL_LOG_LEVEL as PublicEnv['otelLogLevel'],
-    chatbotEnabled: process.env.CHATBOT_ENABLED === 'true',
-    googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY || undefined,
+    logCurl: source.LOG_CURL !== 'false' && nodeEnv === 'development',
+    logRedactTokens: source.LOG_REDACT_TOKENS !== 'false' || nodeEnv === 'production',
+    logPayloads: source.LOG_PAYLOADS === 'true' || nodeEnv === 'development',
+    otelEnabled: source.OTEL_ENABLED === 'true' && !!source.OTEL_EXPORTER_OTLP_ENDPOINT,
+    otelLogLevel: source.OTEL_LOG_LEVEL as PublicEnv['otelLogLevel'],
+    chatbotEnabled: source.CHATBOT_ENABLED === 'true',
+    googleMapsApiKey: source.GOOGLE_MAPS_API_KEY || undefined,
   };
 }
 

--- a/app/utils/env/omit-blank-env.test.ts
+++ b/app/utils/env/omit-blank-env.test.ts
@@ -1,0 +1,62 @@
+import { omitBlankEnv } from './omit-blank-env';
+import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
+
+describe('omitBlankEnv', () => {
+  it('drops empty-string values', () => {
+    // Arrange — how GitHub Actions exports an unset secret
+    const source = { AUTH_OIDC_ISSUER: '', APP_URL: 'http://localhost:3000' };
+
+    // Act
+    const result = omitBlankEnv(source);
+
+    // Assert
+    expect(result).toEqual({ APP_URL: 'http://localhost:3000' });
+    expect('AUTH_OIDC_ISSUER' in result).toBe(false);
+  });
+
+  it('drops whitespace-only values', () => {
+    expect(omitBlankEnv({ A: '   ', B: '\t\n' })).toEqual({});
+  });
+
+  it('drops undefined values', () => {
+    expect(omitBlankEnv({ A: undefined, B: 'kept' })).toEqual({ B: 'kept' });
+  });
+
+  it('preserves values that only look falsy', () => {
+    // A naive truthiness filter would discard these.
+    expect(omitBlankEnv({ DEBUG: 'false', RETRIES: '0', PREFIX: ' x ' })).toEqual({
+      DEBUG: 'false',
+      RETRIES: '0',
+      PREFIX: ' x ',
+    });
+  });
+
+  it('does not mutate the source', () => {
+    const source = { A: '', B: 'kept' };
+
+    omitBlankEnv(source);
+
+    expect(source).toEqual({ A: '', B: 'kept' });
+  });
+
+  it('lets a Zod default fire for a blank value', () => {
+    // The actual regression: `.default()` only applies to `undefined`, so a
+    // blank value fails `z.url()` and exits(1) instead of defaulting.
+    const schema = z.object({ AUTH_OIDC_ISSUER: z.url().default('http://localhost:8080') });
+
+    expect(schema.safeParse({ AUTH_OIDC_ISSUER: '' }).success).toBe(false);
+    expect(schema.safeParse(omitBlankEnv({ AUTH_OIDC_ISSUER: '' }))).toMatchObject({
+      success: true,
+      data: { AUTH_OIDC_ISSUER: 'http://localhost:8080' },
+    });
+  });
+
+  it('lets a Zod optional stay absent for a blank value', () => {
+    // Mirrors AUTH_OIDC_POST_LOGOUT_REDIRECT_URI= in .env.example
+    const schema = z.object({ POST_LOGOUT: z.url().optional() });
+
+    expect(schema.safeParse({ POST_LOGOUT: '' }).success).toBe(false);
+    expect(schema.safeParse(omitBlankEnv({ POST_LOGOUT: '' })).success).toBe(true);
+  });
+});

--- a/app/utils/env/omit-blank-env.ts
+++ b/app/utils/env/omit-blank-env.ts
@@ -1,0 +1,28 @@
+// app/utils/env/omit-blank-env.ts
+
+/**
+ * Drops keys whose value is blank, so Zod's `.default()` and `.optional()` can
+ * fire on them.
+ *
+ * Zod treats only `undefined` as absent, but blank values reach us routinely:
+ *
+ *   - GitHub Actions exports an unset secret as an empty string, so
+ *     `env: { FOO: ${{ secrets.FOO }} }` yields `FOO=""` when FOO isn't set.
+ *   - `KEY=` in a .env file parses to an empty string the same way — including
+ *     `AUTH_OIDC_POST_LOGOUT_REDIRECT_URI=` in this repo's .env.example.
+ *
+ * Without this, a blank value is validated as present-but-invalid and
+ * env.server.ts exits(1) with a confusing `"Invalid URL"` instead of falling
+ * back to the default. That took out the entire CI unit-test job — zero tests
+ * reported — whenever the AUTH_OIDC_ISSUER secret was absent.
+ *
+ * Whitespace-only values count as blank. Values that merely *look* falsy
+ * (`'0'`, `'false'`) are meaningful and preserved.
+ */
+export function omitBlankEnv(source: Record<string, string | undefined>): Record<string, string> {
+  const present = Object.entries(source).filter(
+    (entry): entry is [string, string] => entry[1] !== undefined && entry[1].trim() !== ''
+  );
+
+  return Object.fromEntries(present);
+}


### PR DESCRIPTION
A blank env var currently kills the process instead of falling back to its declared default.

## Cause

GitHub Actions exports an unset secret as an **empty string**, so this yields `AUTH_OIDC_ISSUER=""` when the secret is missing:

```yaml
- run: bun run test:coverage
  env:
    AUTH_OIDC_ISSUER: ${{ secrets.AUTH_OIDC_ISSUER }}
```

A bare `KEY=` in a `.env` file parses the same way — including `AUTH_OIDC_POST_LOGOUT_REDIRECT_URI=` in our own `.env.example`.

Zod's `.default()` and `.optional()` fire only on `undefined`. A blank value is therefore validated as *present but invalid*, and `env.server.ts` does:

```
❌ Invalid environment variables: { "AUTH_OIDC_ISSUER": ["Invalid URL"] }
```

then `process.exit(1)`. In the Bun unit-test job this killed the whole run before a single test reported — zero tests, and no failing assertion to point at the cause.

## Fix

Drop blank keys before validation so the declared fallbacks apply. Applied in **both** `env.server.ts` (Zod input) and `index.ts` (the SSR `??` fallbacks), so the two modules cannot disagree about whether a var is set. Whitespace-only counts as blank; values that merely look falsy (`0`, `false`) are preserved.

## Test plan

- [x] 7 unit tests for `omitBlankEnv`, including that a Zod `.default()` now fires and an `.optional()` stays absent for a blank value
- [x] `AUTH_OIDC_ISSUER=""` — **before:** exit 1, zero tests; **after:** 441 tests run
- [x] Normal dev config (loads `.env`): 472 pass / 0 fail
- [x] CI config (valid issuer, no `.env`): 472 pass / 0 fail
- [x] `typecheck` clean

## Known limitation

Blank is not yet fully equivalent to *unset*: with `AUTH_OIDC_ISSUER=""` the suite reports 436 pass / 5 fail, versus 472 pass / 0 fail when the var is genuinely absent. The 5 are unhandled OIDC-discovery rejections (`ConnectionRefused` on `localhost:8080/.well-known/openid-configuration`), reproducible and not flaky. I have not identified what still distinguishes the two cases — `zitadel.server.ts:8` uses `??`, which does not catch `''`, and is a likely suspect worth a follow-up.

This PR is still a strict improvement: the confusing hard-exit is gone and the suite runs. CI supplies a real issuer, so it never hits the residual path.