### PR TITLE
chore(deps): adopt typescript 7 native tsc

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,6 +136,7 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.1",
+        "typescript-native": "npm:typescript@^7.0.2",
         "vite": "^8.2.0",
       },
     },
@@ -1334,6 +1335,46 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.61.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/types": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.1", "", { "dependencies": { "@typescript-eslint/types": "8.61.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
@@ -3060,6 +3101,8 @@
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-eslint": ["typescript-eslint@8.61.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.61.1", "@typescript-eslint/parser": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1", "@typescript-eslint/utils": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw=="],
+
+    "typescript-native": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 

--- a/docs/development/code-quality.md
+++ b/docs/development/code-quality.md
@@ -146,7 +146,54 @@ bun run typecheck
 This runs:
 
 1. `react-router typegen` - Generate route types
-2. `tsc` - TypeScript compiler
+2. `./node_modules/typescript-native/bin/tsc` - the native TypeScript 7 compiler
+
+### Native Compiler (`typescript-native`)
+
+Two TypeScript packages are installed side by side:
+
+| devDependency      | Resolves to                        | Used for                                                            |
+| ------------------- | ----------------------------------- | --------------------------------------------------------------------- |
+| `typescript`         | real `typescript@^6.0.3` (classic)  | `typescript-eslint` and editor/language-server integrations           |
+| `typescript-native`  | `npm:typescript@^7.0.2` (native, Go) | `bun run typecheck` and the Lefthook pre-commit `typecheck` hook       |
+
+`typescript` stays on 6.x deliberately: `typescript-eslint` (and VS Code's
+built-in TypeScript language server) need the classic JS compiler API, which
+TypeScript 7 removed. `typescript-native` gives us the ~5x faster native `tsc`
+for the type-check gate without touching that API surface.
+
+**Both packages declare a `tsc` (and `tsserver`) bin**, so
+`node_modules/.bin/tsc` and `bunx tsc` are **nondeterministic** — they resolve
+to whichever package happened to install its bin symlink last, not
+necessarily the one you want. Never call `tsc` or `bunx tsc` bare. Always use
+an explicit path:
+
+```bash
+./node_modules/typescript-native/bin/tsc   # fast native 7.x compiler
+./node_modules/typescript/bin/tsc          # classic 6.x compiler
+```
+
+This is why `package.json`'s `typecheck` script and `lefthook.yml`'s
+`typecheck` hook both call `./node_modules/typescript-native/bin/tsc`
+explicitly instead of plain `tsc`.
+
+**Why not Microsoft's official dual-alias pattern** (`typescript: npm:@typescript/typescript6@^6.x` + `@typescript/native: npm:typescript@^7.x`)?
+That's the pattern Microsoft documents for this transition, but it hits a
+reproducible Bun 1.3.14 bug: the `@typescript/typescript6` shim's own nested
+dependency (`@typescript/old: npm:typescript@^6`, meant to point at the real
+classic compiler) gets resolved by Bun back to the shim itself, in a circular
+loop. The practical effect: `require('typescript')` returns an empty object
+and the `tsc6` fallback binary silently no-ops on every invocation. See the
+"Record: the Bun bug (minimal repro)" section in PR
+[#1401](https://github.com/datum-cloud/cloud-portal/pull/1401) for the full
+repro (reproduced in an isolated scratch project, independent of this repo's
+other dependencies). The two-separate-packages setup above sidesteps the bug
+entirely by never aliasing `typescript` itself.
+
+**Collapse plan:** once `typescript-eslint` supports the TypeScript 7.1 API
+(tracked for ~Oct 2026), drop `typescript-native` and move `typescript` to
+`^7.1` directly. Optional in the meantime: install the "TypeScript (Native
+Preview)" VS Code extension for a faster native editor LSP.
 
 ### Strict Mode Rules
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,5 +11,5 @@ pre-commit:
       auto_add: true
     typecheck:
       glob: '*.{ts,tsx}'
-      run: bunx tsc --noEmit
+      run: ./node_modules/typescript-native/bin/tsc --noEmit
       stage_fixed: false

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint \"{app,lib}/**/*.{ts,tsx}\" --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
-    "typecheck": "react-router typegen && tsc",
+    "typecheck": "react-router typegen && ./node_modules/typescript-native/bin/tsc",
+    "typecheck:watch": "react-router typegen && ./node_modules/typescript-native/bin/tsc --noEmit --watch",
     "clean": "rm -rf node_modules && rm -rf .react-router && rm -rf build",
     "openapi": "bun scripts/openapi.ts",
     "graphql": "bun run scripts/graphql.ts",
@@ -160,6 +161,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",
+    "typescript-native": "npm:typescript@^7.0.2",
     "vite": "^8.2.0"
   },
   "engines": {


### PR DESCRIPTION
## What

Adopts the TypeScript 7 native (Go) compiler for typechecking while keeping `typescript@6.0.3` for the JS compiler API:

- New devDependency alias `typescript-native` (`npm:typescript@^7.0.2`) provides the native `tsc`
- `bun run typecheck` and the lefthook pre-commit hook invoke it by explicit path — **typecheck is ~5× faster** (19.3s → 3.7s cold)
- `typescript@^6.0.3` stays unchanged: typescript-eslint and editors need the JS compiler API, which typescript 7 removed entirely (returns redesigned in TS 7.1)

## Why not the official dual-alias pattern

Microsoft's `@typescript/typescript6` shim breaks under Bun 1.3.14 — its internal `npm:typescript@^6` alias resolves circularly back to the shim, leaving `require('typescript')` an empty object and `tsc6` a silent no-op. Verified with an isolated repro. Keeping `typescript` as a real package sidesteps the bug entirely.

Details, the `.bin/tsc` ambiguity warning, and the TS 7.1 collapse plan are documented in `docs/development/code-quality.md`.

## Verification

- `typescript-native/bin/tsc --version` → 7.0.2; `require('typescript').version` → 6.0.3
- typecheck exit 0 (native path); lefthook hook live-fired with a staged file: passes
- Lint parity: 0 errors, 1 pre-existing warning (typescript-eslint on the 6.x API, unchanged)
- Unit suite 66/66; component suite 378 assertions, 0 failures
- `tsc` (7, native) vs classic 6 both exit 0 on the full codebase — no diagnostic drift

Closes #1345.

## Record: the Bun bug (minimal repro)

Verified against Bun **1.3.14 — the latest release** (npm + GitHub, 2026-05-13), in full isolation and with `--no-cache`:

```jsonc
// package.json — Microsoft's official TS6/TS7 transition pattern
{
  "devDependencies": {
    "@typescript/native": "npm:typescript@^7.0.2",
    "typescript": "npm:@typescript/typescript6@^6.0.2"
  }
}
```

```console
$ bun install            # succeeds, no warnings
$ bunx tsc --version     # Version 7.0.2  ✅ (native half works)
$ bunx tsc6 --version    # (empty output, exit 0)  ❌ silent no-op
$ node -e "console.log(Object.keys(require('typescript')).length)"
0                        # ❌ compiler API is an empty object
```

Cause: the `@typescript/typescript6` shim's own dependency `"@typescript/old": "npm:typescript@^6"` should resolve to the real 24 MB `typescript` compiler, but `bun.lock` resolves it circularly back to the shim itself. The resulting `require` loop (`typescript/lib/tsc.js` → `@typescript/old/lib/tsc.js` → itself) degrades to an empty module instead of erroring — so type-aware linting dies **silently** (exit 0, checks nothing).

This PR's `typescript-native` design never aliases the `typescript` package name, so the shim (and the bug) are out of the picture. Revisit if/when Bun fixes the alias resolution — and moot after the TS 7.1 single-package collapse.
