### PR TITLE
feat: Show WAF Protected/Monitoring from Programmed

### DIFF
--- a/app/features/edge/proxy/overview/config-card.tsx
+++ b/app/features/edge/proxy/overview/config-card.tsx
@@ -19,31 +19,62 @@ import { ControlPlaneStatus } from '@/resources/base';
 import { useConnector, useConnectorWatch } from '@/resources/connectors';
 import {
   type HttpProxy,
-  formatWafProtectionDisplay,
+  formatWafProtectionStatusDisplay,
   useUpdateHttpProxy,
 } from '@/resources/http-proxies';
 import { DATUM_DESKTOP_DOWNLOAD_URL } from '@/utils/config/query.config';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
 import { Badge } from '@datum-cloud/datum-ui/badge';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
-import { Icon } from '@datum-cloud/datum-ui/icons';
+import { Icon, SpinnerIcon } from '@datum-cloud/datum-ui/icons';
 import { Skeleton } from '@datum-cloud/datum-ui/skeleton';
 import { Switch } from '@datum-cloud/datum-ui/switch';
 import { toast } from '@datum-cloud/datum-ui/toast';
 import { Tooltip } from '@datum-cloud/datum-ui/tooltip';
-import { CircleHelp, PencilIcon, SettingsIcon } from 'lucide-react';
-import { useMemo, useRef } from 'react';
+import {
+  CircleCheckIcon,
+  CircleHelp,
+  PencilIcon,
+  SettingsIcon,
+  TriangleAlertIcon,
+} from 'lucide-react';
+import { useMemo, useRef, type ReactNode } from 'react';
+
+function wafStatusIcon(state: 'pending' | 'error' | 'monitoring' | 'protected'): ReactNode {
+  switch (state) {
+    case 'pending':
+      return (
+        <SpinnerIcon
+          size="xs"
+          aria-hidden="true"
+          indicatorClassName="text-primary"
+          trackClassName="text-muted-foreground/30"
+        />
+      );
+    case 'error':
+      return <Icon icon={TriangleAlertIcon} size={12} className="text-destructive shrink-0" />;
+    case 'monitoring':
+    case 'protected':
+      return <Icon icon={CircleCheckIcon} size={12} className="text-badge-success shrink-0" />;
+  }
+}
 
 export const HttpProxyConfigCard = ({
   proxy,
   projectId,
   canViewWaf = true,
   wafPending = false,
+  wafProgrammed,
+  wafProgrammedMessage,
+  wafProgrammedReason,
 }: {
   proxy: HttpProxy;
   projectId?: string;
   canViewWaf?: boolean;
   wafPending?: boolean;
+  wafProgrammed?: boolean;
+  wafProgrammedMessage?: string;
+  wafProgrammedReason?: string;
 }) => {
   const displayNameDialogRef = useRef<ProxyDisplayNameDialogRef>(null);
   const wafDialogRef = useRef<ProxyWafDialogRef>(null);
@@ -148,52 +179,51 @@ export const HttpProxyConfigCard = ({
               &mdash;
             </Badge>
           </Tooltip>
-        ) : proxy.trafficProtectionMode !== 'Disabled' ||
-          proxy.paranoiaLevels?.blocking !== undefined ||
-          proxy.paranoiaLevels?.detection !== undefined ? (
-          <div className="flex items-center gap-1.5">
-            <Badge type="quaternary" theme="outline" className="rounded-xl text-xs font-normal">
-              {formatWafProtectionDisplay(proxy)}
-            </Badge>
-            {projectId && (
-              <PermissionGate
-                resource="trafficprotectionpolicies"
-                verb="patch"
-                group="networking.datumapis.com"
-                scope="project"
-                mode="disable"
-                deniedReason="You don't have permission to edit WAF protection">
-                <button
-                  type="button"
-                  className="text-muted-foreground hover:text-foreground transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                  onClick={() => wafDialogRef.current?.show(proxy)}>
-                  <Icon icon={PencilIcon} size={12} />
-                </button>
-              </PermissionGate>
-            )}
-          </div>
         ) : (
-          <div className="flex items-center gap-1.5">
-            <Badge type="quaternary" theme="outline" className="rounded-xl text-xs font-normal">
-              Disabled
-            </Badge>
-            {projectId && (
-              <PermissionGate
-                resource="trafficprotectionpolicies"
-                verb="patch"
-                group="networking.datumapis.com"
-                scope="project"
-                mode="disable"
-                deniedReason="You don't have permission to edit WAF protection">
-                <button
-                  type="button"
-                  className="text-muted-foreground hover:text-foreground transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                  onClick={() => wafDialogRef.current?.show(proxy)}>
-                  <Icon icon={PencilIcon} size={12} />
-                </button>
-              </PermissionGate>
-            )}
-          </div>
+          (() => {
+            const { state, statusLabel, configLabel, statusTooltip } =
+              formatWafProtectionStatusDisplay(
+                proxy,
+                wafProgrammed,
+                wafProgrammedReason,
+                wafProgrammedMessage
+              );
+            const statusIcon =
+              state === 'disabled' ? null : (
+                <Tooltip message={statusTooltip || statusLabel} side="bottom">
+                  <span className="inline-flex shrink-0" aria-label={statusLabel}>
+                    {wafStatusIcon(state)}
+                  </span>
+                </Tooltip>
+              );
+            return (
+              <div className="flex items-center gap-1.5">
+                <Badge
+                  type="quaternary"
+                  theme="outline"
+                  className="inline-flex items-center gap-1.5 rounded-xl text-xs font-normal">
+                  {statusIcon}
+                  {configLabel}
+                </Badge>
+                {projectId && (
+                  <PermissionGate
+                    resource="trafficprotectionpolicies"
+                    verb="patch"
+                    group="networking.datumapis.com"
+                    scope="project"
+                    mode="disable"
+                    deniedReason="You don't have permission to edit WAF protection">
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                      onClick={() => wafDialogRef.current?.show(proxy)}>
+                      <Icon icon={PencilIcon} size={12} />
+                    </button>
+                  </PermissionGate>
+                )}
+              </div>
+            );
+          })()
         ),
       },
       {
@@ -306,7 +336,16 @@ export const HttpProxyConfigCard = ({
           ),
       },
     ];
-  }, [proxy, projectId, updateMutation, canViewWaf, wafPending]);
+  }, [
+    proxy,
+    projectId,
+    updateMutation,
+    canViewWaf,
+    wafPending,
+    wafProgrammed,
+    wafProgrammedMessage,
+    wafProgrammedReason,
+  ]);
 
   const connectorBlock = useMemo(() => {
     if (!proxy.connector) return null;

--- a/app/resources/http-proxies/http-proxy.service.ts
+++ b/app/resources/http-proxies/http-proxy.service.ts
@@ -21,6 +21,11 @@ import type {
   BasicAuthUser,
 } from './http-proxy.schema';
 import {
+  getTrafficProtectionProgrammedMessage,
+  getTrafficProtectionProgrammedReason,
+  isTrafficProtectionProgrammed,
+} from './http-proxy.waf-status';
+import {
   listNetworkingDatumapisComV1AlphaNamespacedHttpProxy,
   listNetworkingDatumapisComV1AlphaNamespacedTrafficProtectionPolicy,
   readNetworkingDatumapisComV1AlphaNamespacedHttpProxy,
@@ -61,6 +66,12 @@ export const httpProxyKeys = {
 export interface TrafficProtectionView {
   mode?: TrafficProtectionMode;
   paranoiaLevels?: { blocking?: number; detection?: number };
+  /** True when all ancestors report Accepted+Programmed for the current generation. */
+  programmed?: boolean;
+  /** Programmed condition message while converging (e.g. M/N edges). */
+  programmedMessage?: string;
+  /** Programmed condition reason while not True (Pending / PartialFailure). */
+  programmedReason?: string;
 }
 export interface TrafficProtectionMaps {
   modeByName: Map<string, TrafficProtectionMode>;
@@ -178,9 +189,13 @@ export function createHttpProxyService() {
           baseURL,
           path: { namespace: 'default', name },
         });
+        const data = response.data;
         return {
-          mode: getTrafficProtectionMode(response.data),
-          paranoiaLevels: getParanoiaLevels(response.data),
+          mode: getTrafficProtectionMode(data),
+          paranoiaLevels: getParanoiaLevels(data),
+          programmed: isTrafficProtectionProgrammed(data?.status),
+          programmedMessage: getTrafficProtectionProgrammedMessage(data?.status),
+          programmedReason: getTrafficProtectionProgrammedReason(data?.status),
         };
       } catch (error) {
         // No policy for this proxy is a normal "WAF disabled" state, not an error.

--- a/app/resources/http-proxies/http-proxy.utils.ts
+++ b/app/resources/http-proxies/http-proxy.utils.ts
@@ -1,4 +1,10 @@
 import type { HttpProxy } from './http-proxy.schema';
+import {
+  formatWafProtectionStateLabel,
+  formatWafProtectionStatusTooltip,
+  getWafProtectionState,
+  type WafProtectionState,
+} from './http-proxy.waf-status';
 
 /**
  * Get a human-readable label for a paranoia level number.
@@ -28,4 +34,30 @@ export function formatWafProtectionDisplay(httpProxy: HttpProxy): string {
   const blocking = httpProxy.paranoiaLevels?.blocking ?? 1;
   const levelLabel = getParanoiaLevelLabel(blocking);
   return `${mode} · ${levelLabel}`;
+}
+
+/**
+ * Format Protection for the detail card: readiness state for the in-pill icon,
+ * plus the mode · paranoia config label.
+ */
+export function formatWafProtectionStatusDisplay(
+  httpProxy: HttpProxy,
+  programmed?: boolean,
+  programmedReason?: string,
+  programmedMessage?: string
+): {
+  state: WafProtectionState;
+  statusLabel: string;
+  configLabel: string;
+  statusTooltip?: string;
+} {
+  const mode = httpProxy.trafficProtectionMode || 'Disabled';
+  const state = getWafProtectionState(mode, programmed === true, programmedReason);
+  const configLabel = formatWafProtectionDisplay(httpProxy);
+  return {
+    state,
+    statusLabel: formatWafProtectionStateLabel(state),
+    configLabel,
+    statusTooltip: formatWafProtectionStatusTooltip(state, programmedMessage),
+  };
 }

--- a/app/resources/http-proxies/http-proxy.waf-status.test.ts
+++ b/app/resources/http-proxies/http-proxy.waf-status.test.ts
@@ -1,0 +1,76 @@
+import {
+  formatWafProtectionStateLabel,
+  formatWafProtectionStatusTooltip,
+  getWafProtectionState,
+  isTrafficProtectionProgrammed,
+} from './http-proxy.waf-status';
+import { describe, expect, it } from 'bun:test';
+
+describe('isTrafficProtectionProgrammed', () => {
+  it('returns false when ancestors are missing', () => {
+    expect(isTrafficProtectionProgrammed(undefined)).toBe(false);
+    expect(isTrafficProtectionProgrammed({ ancestors: [] })).toBe(false);
+  });
+
+  it('requires Accepted and Programmed True on every ancestor', () => {
+    expect(
+      isTrafficProtectionProgrammed({
+        ancestors: [
+          {
+            conditions: [
+              { type: 'Accepted', status: 'True' },
+              { type: 'Programmed', status: 'True' },
+            ],
+          },
+        ],
+      })
+    ).toBe(true);
+
+    expect(
+      isTrafficProtectionProgrammed({
+        ancestors: [
+          {
+            conditions: [
+              { type: 'Accepted', status: 'True' },
+              { type: 'Programmed', status: 'False', message: '1/2 edges programmed generation 3' },
+            ],
+          },
+        ],
+      })
+    ).toBe(false);
+  });
+});
+
+describe('getWafProtectionState', () => {
+  it('maps mode and programmed into tenant labels', () => {
+    expect(getWafProtectionState('Enforce', true)).toBe('protected');
+    expect(getWafProtectionState('Observe', true)).toBe('monitoring');
+    expect(getWafProtectionState('Enforce', false)).toBe('pending');
+    expect(getWafProtectionState('Enforce', false, 'PartialFailure')).toBe('error');
+    expect(getWafProtectionState('Disabled', true)).toBe('disabled');
+  });
+});
+
+describe('formatWafProtectionStateLabel', () => {
+  it('returns a short readiness label for tooltips', () => {
+    expect(formatWafProtectionStateLabel('protected')).toBe('Protected');
+    expect(formatWafProtectionStateLabel('monitoring')).toBe('Monitoring');
+    expect(formatWafProtectionStateLabel('pending')).toBe('Pending');
+    expect(formatWafProtectionStateLabel('error')).toBe('Error');
+    expect(formatWafProtectionStateLabel('disabled')).toBe('Disabled');
+  });
+});
+
+describe('formatWafProtectionStatusTooltip', () => {
+  it('prefers the Programmed message while converging or failed', () => {
+    expect(formatWafProtectionStatusTooltip('pending', '1/2 edges programmed generation 3')).toBe(
+      '1/2 edges programmed generation 3'
+    );
+    expect(formatWafProtectionStatusTooltip('error', '1/2 edges programmed generation 3')).toBe(
+      '1/2 edges programmed generation 3'
+    );
+    expect(formatWafProtectionStatusTooltip('protected')).toBe(
+      'WAF is protecting traffic on all edges'
+    );
+  });
+});

--- a/app/resources/http-proxies/http-proxy.waf-status.ts
+++ b/app/resources/http-proxies/http-proxy.waf-status.ts
@@ -1,0 +1,117 @@
+import type { TrafficProtectionMode } from './http-proxy.schema';
+
+export type ConditionLike = {
+  type?: string;
+  status?: string;
+  reason?: string;
+  message?: string;
+  observedGeneration?: number;
+};
+
+export type PolicyAncestorLike = {
+  conditions?: ConditionLike[];
+};
+
+export type TrafficProtectionStatusLike = {
+  ancestors?: PolicyAncestorLike[];
+};
+
+/** Tenant-facing WAF readiness derived from mode + Programmed. */
+export type WafProtectionState = 'disabled' | 'pending' | 'error' | 'monitoring' | 'protected';
+
+/**
+ * True when every ancestor reports Accepted=True and Programmed=True.
+ * Empty ancestors means not yet programmed.
+ */
+export function isTrafficProtectionProgrammed(
+  status: TrafficProtectionStatusLike | null | undefined
+): boolean {
+  const ancestors = status?.ancestors;
+  if (!ancestors?.length) return false;
+  return ancestors.every((ancestor) => {
+    const accepted = ancestor.conditions?.find((c) => c.type === 'Accepted');
+    const programmed = ancestor.conditions?.find((c) => c.type === 'Programmed');
+    return accepted?.status === 'True' && programmed?.status === 'True';
+  });
+}
+
+function findNonTrueProgrammed(
+  status: TrafficProtectionStatusLike | null | undefined
+): ConditionLike | undefined {
+  for (const ancestor of status?.ancestors ?? []) {
+    const programmed = ancestor.conditions?.find((c) => c.type === 'Programmed');
+    if (programmed && programmed.status !== 'True') {
+      return programmed;
+    }
+  }
+  return undefined;
+}
+
+/** First non-True Programmed message, for pending/error tooltips. */
+export function getTrafficProtectionProgrammedMessage(
+  status: TrafficProtectionStatusLike | null | undefined
+): string | undefined {
+  return findNonTrueProgrammed(status)?.message;
+}
+
+/** First non-True Programmed reason (e.g. Pending, PartialFailure). */
+export function getTrafficProtectionProgrammedReason(
+  status: TrafficProtectionStatusLike | null | undefined
+): string | undefined {
+  return findNonTrueProgrammed(status)?.reason;
+}
+
+/**
+ * Compose the portal Protection readiness:
+ * - Disabled when mode is absent/Disabled
+ * - Pending until Programmed (or Error on PartialFailure)
+ * - Monitoring when Observe + Programmed
+ * - Protected when Enforce + Programmed
+ */
+export function getWafProtectionState(
+  mode: TrafficProtectionMode | undefined,
+  programmed: boolean,
+  programmedReason?: string
+): WafProtectionState {
+  if (!mode || mode === 'Disabled') return 'disabled';
+  if (!programmed) {
+    return programmedReason === 'PartialFailure' ? 'error' : 'pending';
+  }
+  if (mode === 'Observe') return 'monitoring';
+  return 'protected';
+}
+
+/** Short readiness label for tooltips / a11y. */
+export function formatWafProtectionStateLabel(state: WafProtectionState): string {
+  switch (state) {
+    case 'disabled':
+      return 'Disabled';
+    case 'pending':
+      return 'Pending';
+    case 'error':
+      return 'Error';
+    case 'monitoring':
+      return 'Monitoring';
+    case 'protected':
+      return 'Protected';
+  }
+}
+
+/** Tooltip copy for the in-pill readiness icon. */
+export function formatWafProtectionStatusTooltip(
+  state: WafProtectionState,
+  programmedMessage?: string
+): string | undefined {
+  switch (state) {
+    case 'disabled':
+      return undefined;
+    case 'pending':
+      return programmedMessage || 'Waiting for WAF to reach the edge';
+    case 'error':
+      return programmedMessage || 'WAF is not programmed on all edges';
+    case 'monitoring':
+      return 'WAF is observing traffic on all edges';
+    case 'protected':
+      return 'WAF is protecting traffic on all edges';
+  }
+}

--- a/app/resources/http-proxies/http-proxy.watch.ts
+++ b/app/resources/http-proxies/http-proxy.watch.ts
@@ -1,11 +1,31 @@
-import { toHttpProxy } from './http-proxy.adapter';
+import { getParanoiaLevels, getTrafficProtectionMode, toHttpProxy } from './http-proxy.adapter';
 import type { HttpProxy } from './http-proxy.schema';
-import { httpProxyKeys } from './http-proxy.service';
-import type { ComDatumapisNetworkingV1AlphaHttpProxy } from '@/modules/control-plane/networking';
+import { httpProxyKeys, type TrafficProtectionView } from './http-proxy.service';
+import {
+  getTrafficProtectionProgrammedMessage,
+  getTrafficProtectionProgrammedReason,
+  isTrafficProtectionProgrammed,
+} from './http-proxy.waf-status';
+import type {
+  ComDatumapisNetworkingV1AlphaHttpProxy,
+  ComDatumapisNetworkingV1AlphaTrafficProtectionPolicy,
+} from '@/modules/control-plane/networking';
 import { useResourceWatch } from '@/modules/watch';
 import { waitForWatch } from '@/modules/watch/watch-wait.helper';
 import { ControlPlaneStatus } from '@/resources/base';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
+
+function toTrafficProtectionView(
+  raw: ComDatumapisNetworkingV1AlphaTrafficProtectionPolicy
+): TrafficProtectionView {
+  return {
+    mode: getTrafficProtectionMode(raw),
+    paranoiaLevels: getParanoiaLevels(raw),
+    programmed: isTrafficProtectionProgrammed(raw?.status),
+    programmedMessage: getTrafficProtectionProgrammedMessage(raw?.status),
+    programmedReason: getTrafficProtectionProgrammedReason(raw?.status),
+  };
+}
 
 /**
  * Watch HTTP proxies list for real-time updates.
@@ -92,6 +112,30 @@ export function useHttpProxyWatch(
           }),
       };
     },
+  });
+}
+
+/**
+ * Watch a proxy's TrafficProtectionPolicy for live mode/Programmed updates.
+ * Updates the permission-gated WAF detail query cache (same key as
+ * useTrafficProtectionPolicy).
+ */
+export function useTrafficProtectionPolicyWatch(
+  projectId: string,
+  name: string,
+  options?: { enabled?: boolean }
+) {
+  const queryKey = httpProxyKeys.wafDetail(projectId, name);
+
+  useResourceWatch<TrafficProtectionView>({
+    resourceType: 'apis/networking.datumapis.com/v1alpha/trafficprotectionpolicies',
+    projectId,
+    namespace: 'default',
+    name,
+    queryKey,
+    transform: (item) =>
+      toTrafficProtectionView(item as ComDatumapisNetworkingV1AlphaTrafficProtectionPolicy),
+    enabled: (options?.enabled ?? true) && !!projectId && !!name,
   });
 }
 

--- a/app/resources/http-proxies/index.ts
+++ b/app/resources/http-proxies/index.ts
@@ -55,11 +55,27 @@ export {
 } from './http-proxy.queries';
 
 // Watch hooks exports
-export { useHttpProxiesWatch, useHttpProxyWatch, waitForHttpProxyReady } from './http-proxy.watch';
+export {
+  useHttpProxiesWatch,
+  useHttpProxyWatch,
+  useTrafficProtectionPolicyWatch,
+  waitForHttpProxyReady,
+} from './http-proxy.watch';
 
 // Utility exports
-export { getParanoiaLevelLabel, formatWafProtectionDisplay } from './http-proxy.utils';
-
+export {
+  getParanoiaLevelLabel,
+  formatWafProtectionDisplay,
+  formatWafProtectionStatusDisplay,
+} from './http-proxy.utils';
+export {
+  getWafProtectionState,
+  isTrafficProtectionProgrammed,
+  getTrafficProtectionProgrammedMessage,
+  getTrafficProtectionProgrammedReason,
+  formatWafProtectionStatusTooltip,
+  type WafProtectionState,
+} from './http-proxy.waf-status';
 // Condition constants and helpers for TLS/certificate status (network-services-operator)
 export {
   HTTP_PROXY_CONDITION_CERTIFICATES_READY,

--- a/app/routes/project/detail/edge/detail/overview.tsx
+++ b/app/routes/project/detail/edge/detail/overview.tsx
@@ -15,6 +15,7 @@ import {
   useHttpProxy,
   useHttpProxyWatch,
   useTrafficProtectionPolicy,
+  useTrafficProtectionPolicyWatch,
 } from '@/resources/http-proxies';
 import { paths } from '@/utils/config/paths.config';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
@@ -78,10 +79,14 @@ export default function HttpProxyOverviewPage() {
     retry: false,
   });
 
-  // Still resolving permission or WAF data (including mount re-validation) — let
-  // the card show a skeleton instead of a possibly-stale verdict.
+  useTrafficProtectionPolicyWatch(projectId, proxyId, { enabled: canViewWaf });
+
+  // Skeleton only while permission or the first WAF fetch is unresolved. Watch
+  // / background refetches update the cache in place and must not flash.
   const wafPending =
-    wafPermLoading || wafPermFetching || (canViewWaf && (wafDataLoading || wafDataFetching));
+    wafPermLoading ||
+    wafPermFetching ||
+    (canViewWaf && waf === undefined && (wafDataLoading || wafDataFetching));
 
   const baseProxy = httpProxy ?? proxy;
   const effectiveProxy = useMemo<HttpProxy | undefined>(
@@ -115,6 +120,9 @@ export default function HttpProxyOverviewPage() {
             projectId={projectId}
             canViewWaf={canViewWaf && !wafError}
             wafPending={wafPending}
+            wafProgrammed={waf?.programmed}
+            wafProgrammedMessage={waf?.programmedMessage}
+            wafProgrammedReason={waf?.programmedReason}
           />
         </Col>
         <Col span={24} lg={12}>


### PR DESCRIPTION
## Summary

The Protection row currently shows WAF mode alone, so Enforce/Observe can look live while the edge still serves an older generation.

Once NSO exposes ancestor `Programmed`, the portal composes tenant labels: Protected (Enforce + Programmed), Monitoring (Observe + Programmed), or Pending until Programmed is True. Depends on the NSO#266 status work.

<img width="715" height="374" alt="Screenshot 2026-08-05 at 11 44 01" src="https://github.com/user-attachments/assets/e777b94d-6fe3-45f0-ae5e-58fb9e086e6e" />

## Test plan

- [x] `bun test app/resources/http-proxies/http-proxy.waf-status.test.ts`
- [x] With NSO Programmed: Pending while converging, then Protected/Monitoring by mode
- [x] Tooltip shows the Programmed message during PartialFailure (M/N)

Related to datum-cloud/network-services-operator#266