### PR TITLE
fix: Keep incomplete-org billing setup on soft navigation

### DIFF
--- a/app/features/onboarding/legacy-setup/org-setup-status.server.ts
+++ b/app/features/onboarding/legacy-setup/org-setup-status.server.ts
@@ -1,62 +1,48 @@
-import { evaluateOrgSetupComplete } from './org-setup-status';
+import { isOrgSetupCompleteFromLoadResult, type OrgSetupLoadResult } from './org-setup-status';
 import { logger } from '@/modules/logger';
 import { createBillingAccountService } from '@/resources/billing-accounts';
 import { createOrganizationService } from '@/resources/organizations';
 import { createPaymentMethodService } from '@/resources/payment-methods';
 import { AuthenticationError, AuthorizationError } from '@/utils/errors';
 
-async function loadOrgSetupInputs(orgId: string) {
-  const org = await createOrganizationService().get(orgId);
+/** Sentinel: a transient auth error while checking billing/payment inputs. */
+const TRANSIENT_ERROR = Symbol('transient-error');
 
-  let billingAccounts: Awaited<ReturnType<ReturnType<typeof createBillingAccountService>['list']>> =
-    [];
-  let paymentMethods: Awaited<ReturnType<ReturnType<typeof createPaymentMethodService>['list']>> =
-    [];
-
-  try {
-    billingAccounts = await createBillingAccountService().list(orgId);
-  } catch (error) {
+function handleTransientError(orgId: string, label: string) {
+  return (error: unknown): typeof TRANSIENT_ERROR => {
     if (error instanceof AuthorizationError || error instanceof AuthenticationError) {
-      logger.warn(`Could not list billing accounts for ${orgId} during setup check`, {
+      logger.warn(`Could not list ${label} for ${orgId} during setup check`, {
         error: error instanceof Error ? error.message : String(error),
       });
-      return null;
+      return TRANSIENT_ERROR;
     }
     throw error;
+  };
+}
+
+/**
+ * Org, billing accounts, and payment methods fetched concurrently. Billing /
+ * payment 401/403 become `billing-indeterminate` so the caller can still
+ * evaluate contact incompleteness (definitive) without pretending the whole
+ * org is set up.
+ */
+async function loadOrgSetupInputs(orgId: string): Promise<OrgSetupLoadResult> {
+  const [org, billingAccounts, paymentMethods] = await Promise.all([
+    createOrganizationService().get(orgId),
+    createBillingAccountService()
+      .list(orgId)
+      .catch(handleTransientError(orgId, 'billing accounts')),
+    createPaymentMethodService().list(orgId).catch(handleTransientError(orgId, 'payment methods')),
+  ]);
+
+  if (billingAccounts === TRANSIENT_ERROR || paymentMethods === TRANSIENT_ERROR) {
+    return { status: 'billing-indeterminate', org };
   }
 
-  try {
-    paymentMethods = await createPaymentMethodService().list(orgId);
-  } catch (error) {
-    if (error instanceof AuthorizationError || error instanceof AuthenticationError) {
-      logger.warn(`Could not list payment methods for ${orgId} during setup check`, {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return null;
-    }
-    throw error;
-  }
-
-  return { org, billingAccounts, paymentMethods };
+  return { status: 'ready', input: { org, billingAccounts, paymentMethods } };
 }
 
 /** Returns true when the org has contact info, a billing account, and an active payment method. */
 export async function isOrgSetupComplete(orgId: string): Promise<boolean> {
-  const inputs = await loadOrgSetupInputs(orgId);
-  if (!inputs) {
-    return true;
-  }
-
-  return evaluateOrgSetupComplete(inputs);
-}
-
-/** First org id (in list order) that still needs billing setup, or null when all are complete. */
-export async function findFirstIncompleteOrg(orgIds: readonly string[]): Promise<string | null> {
-  for (const orgId of orgIds) {
-    const complete = await isOrgSetupComplete(orgId);
-    if (!complete) {
-      return orgId;
-    }
-  }
-  return null;
+  return isOrgSetupCompleteFromLoadResult(await loadOrgSetupInputs(orgId));
 }

--- a/app/features/onboarding/legacy-setup/org-setup-status.test.ts
+++ b/app/features/onboarding/legacy-setup/org-setup-status.test.ts
@@ -2,6 +2,7 @@ import {
   evaluateOrgSetupComplete,
   hasActivePaymentMethodForAccount,
   isOrgContactSetupComplete,
+  isOrgSetupCompleteFromLoadResult,
 } from './org-setup-status';
 import { describe, expect, it } from 'bun:test';
 
@@ -99,5 +100,41 @@ describe('evaluateOrgSetupComplete', () => {
         ] as never,
       })
     ).toBe(true);
+  });
+});
+
+describe('isOrgSetupCompleteFromLoadResult', () => {
+  it('treats missing contact as incomplete even when billing listing is indeterminate', () => {
+    // Ryan-shaped: org.get succeeds with empty contact, billing/payment list 403s.
+    // Previously fail-open treated the whole check as complete and skipped the
+    // /onboarding/billing redirect when clicking the org from the list.
+    expect(
+      isOrgSetupCompleteFromLoadResult({
+        status: 'billing-indeterminate',
+        org: { contactInfo: undefined },
+      })
+    ).toBe(false);
+  });
+
+  it('fails open when contact is complete but billing listing is indeterminate', () => {
+    expect(
+      isOrgSetupCompleteFromLoadResult({
+        status: 'billing-indeterminate',
+        org: { contactInfo: { email: 'a@b.com', name: 'Jane' } } as never,
+      })
+    ).toBe(true);
+  });
+
+  it('delegates ready inputs to evaluateOrgSetupComplete', () => {
+    expect(
+      isOrgSetupCompleteFromLoadResult({
+        status: 'ready',
+        input: {
+          org: { contactInfo: undefined },
+          billingAccounts: [],
+          paymentMethods: [],
+        },
+      })
+    ).toBe(false);
   });
 });

--- a/app/features/onboarding/legacy-setup/org-setup-status.ts
+++ b/app/features/onboarding/legacy-setup/org-setup-status.ts
@@ -49,6 +49,29 @@ export function evaluateOrgSetupComplete(input: OrgSetupEvaluationInput): boolea
   return hasActivePaymentMethodForAccount(input.paymentMethods, billingAccountName);
 }
 
+/**
+ * Result of loading org setup inputs when billing/payment listing may have
+ * hit a transient auth error (401/403). Contact incompleteness is always
+ * definitive; only fail-open when contact is already complete and billing
+ * state can't be determined.
+ */
+export type OrgSetupLoadResult =
+  | { status: 'ready'; input: OrgSetupEvaluationInput }
+  | { status: 'billing-indeterminate'; org: Pick<Organization, 'contactInfo'> };
+
+/**
+ * Resolve completeness from a load result. Missing contact → incomplete even
+ * when billing/payment lists 403; complete contact + indeterminate billing →
+ * fail-open (treat as complete) so a broken billing API doesn't trap users.
+ */
+export function isOrgSetupCompleteFromLoadResult(result: OrgSetupLoadResult): boolean {
+  if (result.status === 'billing-indeterminate') {
+    return isOrgContactSetupComplete(result.org);
+  }
+
+  return evaluateOrgSetupComplete(result.input);
+}
+
 /** Resolve the default billing account used for setup checks. */
 export function resolveDefaultBillingAccountName(accounts: BillingAccount[]): string | undefined {
   return selectDefaultOrgBillingAccount(accounts)?.metadata?.name;

--- a/app/features/onboarding/onboarding-layout-redirect.test.ts
+++ b/app/features/onboarding/onboarding-layout-redirect.test.ts
@@ -1,0 +1,62 @@
+import { resolveOnboardingLayoutRedirect } from './onboarding-layout-redirect';
+import { paths } from '@/utils/config/paths.config';
+import { getDocumentPathname, getPathWithParams } from '@/utils/helpers/path.helper';
+import { describe, expect, it } from 'bun:test';
+
+describe('resolveOnboardingLayoutRedirect (legacy resume / #1415)', () => {
+  it('keeps owners on billing after soft-nav when pathname is normalized', () => {
+    const request = new Request(
+      'http://localhost/onboarding/billing.data?orgId=personal-org-02f2388c&_routes=routes/onboarding/layout,routes/onboarding/billing'
+    );
+    const pathname = getDocumentPathname(request);
+
+    expect(pathname).toBe(paths.onboarding.billing);
+    expect(
+      resolveOnboardingLayoutRedirect({
+        pathname,
+        hasExistingOrgs: true,
+        nameReviewRequired: false,
+        requestedOrgId: 'personal-org-02f2388c',
+        isOwnerOfRequestedOrg: true,
+      })
+    ).toBeNull();
+  });
+
+  it('bounces to home if a raw *.data pathname is compared (the pre-fix bug)', () => {
+    expect(
+      resolveOnboardingLayoutRedirect({
+        pathname: '/onboarding/billing.data',
+        hasExistingOrgs: true,
+        nameReviewRequired: false,
+        requestedOrgId: 'personal-org-02f2388c',
+        isOwnerOfRequestedOrg: true,
+      })
+    ).toBe(paths.home);
+  });
+
+  it('sends non-owners to setup-required when resuming a specific org', () => {
+    const pathname = getDocumentPathname(
+      new Request('http://localhost/onboarding/billing.data?orgId=acme')
+    );
+
+    expect(
+      resolveOnboardingLayoutRedirect({
+        pathname,
+        hasExistingOrgs: true,
+        nameReviewRequired: false,
+        requestedOrgId: 'acme',
+        isOwnerOfRequestedOrg: false,
+      })
+    ).toBe(getPathWithParams(paths.org.detail.setupRequired, { orgId: 'acme' }));
+  });
+
+  it('sends existing-org users home when they hit billing with no orgId', () => {
+    expect(
+      resolveOnboardingLayoutRedirect({
+        pathname: paths.onboarding.billing,
+        hasExistingOrgs: true,
+        nameReviewRequired: false,
+      })
+    ).toBe(paths.home);
+  });
+});

--- a/app/features/onboarding/onboarding-layout-redirect.ts
+++ b/app/features/onboarding/onboarding-layout-redirect.ts
@@ -1,0 +1,72 @@
+import { paths } from '@/utils/config/paths.config';
+import { getPathWithParams } from '@/utils/helpers/path.helper';
+
+export type OnboardingLayoutRedirectInput = {
+  /** Document pathname (use {@link getDocumentPathname} — not the raw `*.data` URL). */
+  pathname: string;
+  hasExistingOrgs: boolean;
+  nameReviewRequired: boolean;
+  requestedOrgId?: string;
+  /**
+   * Ownership of `requestedOrgId`. Only consulted when finishing billing/provisioning
+   * for a specific org; pass `true` when no owner check applies.
+   */
+  isOwnerOfRequestedOrg?: boolean;
+};
+
+/**
+ * Where the onboarding layout should send the user, or `null` to render the
+ * requested onboarding step.
+ *
+ * Existing-org users resuming billing setup must stay on billing when
+ * `pathname` is the document path (`/onboarding/billing`). Comparing a
+ * single-fetch `*.data` path here incorrectly returns home — that was the
+ * soft-nav bounce in #1415.
+ */
+export function resolveOnboardingLayoutRedirect(
+  input: OnboardingLayoutRedirectInput
+): string | null {
+  const {
+    pathname,
+    hasExistingOrgs,
+    nameReviewRequired,
+    requestedOrgId,
+    isOwnerOfRequestedOrg = true,
+  } = input;
+
+  const finishingOnboarding =
+    pathname === paths.onboarding.billing || pathname === paths.onboarding.provisioning;
+
+  if (!hasExistingOrgs) {
+    if (nameReviewRequired) {
+      if (pathname !== paths.onboarding.profile) {
+        return paths.onboarding.profile;
+      }
+    } else if (pathname === paths.onboarding.profile) {
+      return paths.onboarding.account;
+    }
+    return null;
+  }
+
+  if (nameReviewRequired) {
+    if (pathname !== paths.onboarding.profile) {
+      return paths.onboarding.profile;
+    }
+    return null;
+  }
+
+  if (finishingOnboarding) {
+    if (requestedOrgId) {
+      if (!isOwnerOfRequestedOrg) {
+        return getPathWithParams(paths.org.detail.setupRequired, { orgId: requestedOrgId });
+      }
+      return null;
+    }
+    if (pathname === paths.onboarding.billing) {
+      return paths.home;
+    }
+    return null;
+  }
+
+  return paths.home;
+}

--- a/app/routes/account/organizations/index.tsx
+++ b/app/routes/account/organizations/index.tsx
@@ -51,6 +51,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
     // A user with no orgs belongs in onboarding. This guard handles
     // client-side navigation that bypasses the middleware redirect.
+    // Incomplete billing setup is gated when entering a specific org
+    // (orgLegacySetupMiddleware), not on this list — users should always
+    // see their organizations here.
     if (orgs.items.length === 0) {
       return redirect(onboardingEntryPath(user));
     }

--- a/app/routes/onboarding/layout.tsx
+++ b/app/routes/onboarding/layout.tsx
@@ -1,4 +1,5 @@
 import { isOnboardingDevBypassEnabled } from '@/features/onboarding/onboarding-dev-bypass';
+import { resolveOnboardingLayoutRedirect } from '@/features/onboarding/onboarding-layout-redirect';
 import { useNonce } from '@/hooks/useNonce';
 import { HelpScoutBeacon } from '@/modules/helpscout';
 import { RybbitProvider } from '@/modules/rybbit';
@@ -10,7 +11,7 @@ import { getSession } from '@/utils/cookies';
 import { env } from '@/utils/env';
 import { env as serverEnv } from '@/utils/env/env.server';
 import { appendSetCookieHeaders, getUserWithAccessRetry } from '@/utils/fraud/user-access';
-import { getPathWithParams } from '@/utils/helpers/path.helper';
+import { getDocumentPathname } from '@/utils/helpers/path.helper';
 import { resolveUserFraudRedirectPath } from '@/utils/middlewares/fraud-redirect';
 import { createHmac } from 'crypto';
 import type { ReactNode } from 'react';
@@ -41,7 +42,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const redirectWithCookies = (path: string) => redirect(path, { headers: responseHeaders });
 
   const url = new URL(request.url);
-  const pathname = url.pathname;
+  // Soft navigations request `*.data`; compare against the document path.
+  const pathname = getDocumentPathname(request);
   const fraudRedirect = resolveUserFraudRedirectPath(user, pathname);
   if (fraudRedirect) {
     return redirectWithCookies(fraudRedirect);
@@ -57,33 +59,18 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     if (!devBypass) {
       const finishingOnboarding =
         pathname === paths.onboarding.billing || pathname === paths.onboarding.provisioning;
+      const isOwnerOfRequestedOrg =
+        finishingOnboarding && requestedOrgId ? await isUserOrgOwner(requestedOrgId) : true;
 
-      if (!hasExistingOrgs) {
-        if (user.nameReviewRequired) {
-          if (pathname !== paths.onboarding.profile) {
-            return redirectWithCookies(paths.onboarding.profile);
-          }
-        } else if (pathname === paths.onboarding.profile) {
-          return redirectWithCookies(paths.onboarding.account);
-        }
-      } else if (user.nameReviewRequired) {
-        if (pathname !== paths.onboarding.profile) {
-          return redirectWithCookies(paths.onboarding.profile);
-        }
-      } else if (finishingOnboarding) {
-        // Finishing setup for a specific org: only its owners may do so.
-        if (requestedOrgId) {
-          if (!(await isUserOrgOwner(requestedOrgId))) {
-            return redirectWithCookies(
-              getPathWithParams(paths.org.detail.setupRequired, { orgId: requestedOrgId })
-            );
-          }
-        } else if (pathname === paths.onboarding.billing) {
-          // Existing-org user hit billing with no target org — nothing to set up.
-          return redirectWithCookies(paths.home);
-        }
-      } else {
-        return redirectWithCookies(paths.home);
+      const layoutRedirect = resolveOnboardingLayoutRedirect({
+        pathname,
+        hasExistingOrgs,
+        nameReviewRequired: Boolean(user.nameReviewRequired),
+        requestedOrgId,
+        isOwnerOfRequestedOrg,
+      });
+      if (layoutRedirect) {
+        return redirectWithCookies(layoutRedirect);
       }
     }
 

--- a/app/utils/helpers/path.helper.test.ts
+++ b/app/utils/helpers/path.helper.test.ts
@@ -1,0 +1,32 @@
+import { getDocumentPathname } from './path.helper';
+import { describe, expect, it } from 'bun:test';
+
+describe('getDocumentPathname', () => {
+  it('strips the single-fetch .data suffix', () => {
+    expect(
+      getDocumentPathname(new Request('http://localhost/onboarding/billing.data?orgId=acme'))
+    ).toBe('/onboarding/billing');
+  });
+
+  it('strips nested route .data suffixes', () => {
+    expect(getDocumentPathname(new Request('http://localhost/org/acme/projects.data'))).toBe(
+      '/org/acme/projects'
+    );
+    expect(getDocumentPathname(new Request('http://localhost/org/acme/setup-required.data'))).toBe(
+      '/org/acme/setup-required'
+    );
+  });
+
+  it('strips the root /_.data single-fetch path', () => {
+    expect(getDocumentPathname(new Request('http://localhost/_.data'))).toBe('/');
+  });
+
+  it('leaves document pathnames unchanged', () => {
+    expect(getDocumentPathname(new Request('http://localhost/onboarding/billing?orgId=acme'))).toBe(
+      '/onboarding/billing'
+    );
+    expect(getDocumentPathname(new Request('http://localhost/account/organizations'))).toBe(
+      '/account/organizations'
+    );
+  });
+});

--- a/app/utils/helpers/path.helper.ts
+++ b/app/utils/helpers/path.helper.ts
@@ -23,6 +23,24 @@ export function getDomainPathname(request: Request): string | null {
 }
 
 /**
+ * Document pathname for route comparisons in loaders/middleware.
+ *
+ * React Router single-fetch requests hit `*.data` / `/_.data`, but
+ * `request.url` keeps that suffix — only match location uses the stripped
+ * path. Comparing `url.pathname === '/onboarding/billing'` against
+ * `/onboarding/billing.data` fails and can bounce users off onboarding.
+ */
+export function getDocumentPathname(request: Request): string {
+  let pathname = new URL(request.url).pathname;
+  if (pathname.endsWith('/_.data')) {
+    pathname = pathname.replace(/_\.data$/, '');
+  } else {
+    pathname = pathname.replace(/\.data$/, '');
+  }
+  return pathname || '/';
+}
+
+/**
  * Combines multiple header objects into one (Headers are appended not overwritten)
  * @param headers - Array of header objects to combine
  * @returns Combined Headers object

--- a/app/utils/middlewares/legacy-setup.middleware.test.ts
+++ b/app/utils/middlewares/legacy-setup.middleware.test.ts
@@ -116,4 +116,31 @@ describe('legacy-setup gate unchanged when the dev bypass is off (prod behavior)
     expect(res).toBe(NEXT);
     expect(isOrgSetupComplete).not.toHaveBeenCalled();
   });
+
+  it('org gate still exempts setup-required on single-fetch .data URLs', async () => {
+    bypass = false;
+    orgComplete = false;
+
+    const res = await orgLegacySetupMiddleware(
+      ctx('http://localhost/org/acme/setup-required.data'),
+      next
+    );
+
+    expect(res).toBe(NEXT);
+    expect(isOrgSetupComplete).not.toHaveBeenCalled();
+  });
+
+  it('org gate still redirects incomplete orgs on single-fetch .data URLs', async () => {
+    bypass = false;
+    orgComplete = false;
+    isOwner = true;
+
+    const res = await orgLegacySetupMiddleware(
+      ctx('http://localhost/org/acme/projects.data'),
+      next
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toContain(paths.onboarding.billing);
+  });
 });

--- a/app/utils/middlewares/legacy-setup.middleware.ts
+++ b/app/utils/middlewares/legacy-setup.middleware.ts
@@ -4,7 +4,7 @@ import { isOnboardingDevBypassEnabled } from '@/features/onboarding/onboarding-d
 import { isUserOrgOwner } from '@/resources/members/member-owner';
 import { createProjectService } from '@/resources/projects';
 import { paths } from '@/utils/config/paths.config';
-import { getPathWithParams } from '@/utils/helpers/path.helper';
+import { getDocumentPathname, getPathWithParams } from '@/utils/helpers/path.helper';
 import { redirect } from 'react-router';
 
 /** `/org/{orgId}/...` — the org detail layout param. */
@@ -57,7 +57,8 @@ export async function orgLegacySetupMiddleware(
     return next();
   }
 
-  const pathname = new URL(ctx.request.url).pathname;
+  // Soft navigations use `*.data` URLs; exemptions must match the document path.
+  const pathname = getDocumentPathname(ctx.request);
   const orgId = orgIdFromPathname(pathname);
   if (!orgId) {
     return next();
@@ -102,7 +103,7 @@ export async function projectLegacySetupMiddleware(
     return next();
   }
 
-  const pathname = new URL(ctx.request.url).pathname;
+  const pathname = getDocumentPathname(ctx.request);
   const projectId = projectIdFromPathname(pathname);
   if (!projectId) {
     return next();


### PR DESCRIPTION
## Summary

Clicking an incomplete org from `/account/organizations` briefly hit billing setup, then bounced straight back to the org list. Session replay looked like “click does nothing.”

Fixes #1415

## Root cause

`orgLegacySetupMiddleware` correctly redirected owners to `/onboarding/billing?orgId=…`. Soft navigations then requested `/onboarding/billing.data`. The onboarding layout compared `request.url.pathname` to `/onboarding/billing` literally, failed the check, and redirected to `/` → org list.

React Router strips `.data` for route matching, but loaders still see the raw URL.

## Changes

- Add `getDocumentPathname()` to normalize `*.data` / `/_.data` before pathname comparisons
- Extract `resolveOnboardingLayoutRedirect` and use it from the onboarding layout
- Use document pathnames in legacy-setup middleware exemptions
- Keep the earlier fail-open fix for `isOrgSetupComplete` (contact incompleteness is definitive)
- Keep org list ungated — redirect only on org/project entry

## Test plan

- [x] `bun test app/utils/helpers/path.helper.test.ts`
- [x] `bun test app/features/onboarding/onboarding-layout-redirect.test.ts` — Ryan soft-nav case + pre-fix `.data` bounce
- [x] `bun test app/utils/middlewares/legacy-setup.middleware.test.ts`
- [x] `bun test app/features/onboarding/legacy-setup`
- [ ] Manual: incomplete org → click from list → stay on `/onboarding/billing?orgId=…` (soft nav)
- [ ] Manual: fully set-up org still opens normally
- [ ] Manual: non-owner incomplete org → setup-required via soft nav