### PR TITLE
feat: implement the platform registry source (watches ConsumerPortalPlugin)

### DIFF
--- a/app/modules/plugins/server/index.ts
+++ b/app/modules/plugins/server/index.ts
@@ -1,16 +1,17 @@
 /**
  * Server-side plugin registry singleton + wiring.
  *
- * The registry is instantiated once with the server and populated by
- * development-only sources (static + kubeconfig). Loaders and routes read it
- * through {@link getPlugins} / {@link getPlugin}. The `platform` source
- * (production watch of the control plane) is intentionally out of scope for v1;
- * its precedence slot exists in {@link PluginRegistry}.
+ * The registry is instantiated once with the server and populated from up to
+ * three sources: development-only static + kubeconfig sources, and the
+ * `platform` source (watches ConsumerPortalPlugin on milo's control plane —
+ * the real path for staging/production). Loaders and routes read the
+ * registry through {@link getPlugins} / {@link getPlugin}.
  */
 import type { PluginRegistryEntry } from '../types';
 import { planDevSources } from './dev-sources';
 import { KubeClient, parseKubeconfig, resolveKubeContext } from './kubeconfig';
 import { KubeconfigSource } from './kubeconfig-source';
+import { PlatformSource } from './platform-source';
 import { PluginRegistry } from './registry';
 import { StaticSource } from './static-source';
 import { env } from '@/utils/env/env.server';
@@ -61,7 +62,6 @@ export function initPluginRegistry(): void {
       '[plugins] PORTAL_PLUGINS / PORTAL_PLUGINS_JSON / PLUGIN_REGISTRY_KUBECONFIG are dev-only ' +
         'registry sources and are ignored outside NODE_ENV=development'
     );
-    return;
   }
 
   if (plan.static) {
@@ -77,6 +77,22 @@ export function initPluginRegistry(): void {
       console.info(`[plugins] kubeconfig source watching ${context.server}`);
     } catch (err) {
       console.error(`[plugins] failed to start kubeconfig source: ${String(err)}`);
+    }
+  }
+
+  // Platform source: not dev-gated (the opposite — meant for real
+  // deployments). Independent of planDevSources, which only governs the two
+  // dev-only sources above.
+  const platformKubeconfigPath = env.server.platformRegistryKubeconfig;
+  if (platformKubeconfigPath) {
+    try {
+      const config = parseKubeconfig(readFileSync(platformKubeconfigPath, 'utf8'));
+      const context = resolveKubeContext(config);
+      const client = new KubeClient(context);
+      new PlatformSource(pluginRegistry, client).start();
+      console.info(`[plugins] platform source watching ${context.server}`);
+    } catch (err) {
+      console.error(`[plugins] failed to start platform source: ${String(err)}`);
     }
   }
 }

--- a/app/modules/plugins/server/platform-source.test.ts
+++ b/app/modules/plugins/server/platform-source.test.ts
@@ -1,0 +1,290 @@
+/// <reference types="bun-types/test" />
+import { KubeClient, resolveKubeContext, parseKubeconfig } from './kubeconfig';
+import { PlatformSource, specFromConsumerPortalPlugin } from './platform-source';
+import { PluginRegistry } from './registry';
+import { describe, expect, mock, test } from 'bun:test';
+
+const VALID_MANIFEST = {
+  name: 'compute.miloapis.com',
+  version: '1.4.0',
+  sdk: { name: '@datum-cloud/portal-plugin-sdk', range: '^1.0.0' },
+  remoteEntry: 'remote-entry.js',
+  exposedModules: { InstanceList: './src/pages/instance-list.tsx' },
+  extensions: [
+    {
+      type: 'portal.page/project',
+      properties: { path: 'instances', component: { $codeRef: 'InstanceList' } },
+    },
+  ],
+};
+
+const NO_AUTH_KUBECONFIG = `
+apiVersion: v1
+kind: Config
+current-context: milo
+clusters:
+- name: c
+  cluster:
+    server: http://127.0.0.1:8080
+contexts:
+- name: milo
+  context: { cluster: c, user: u }
+users:
+- name: u
+  user: {}
+`;
+
+function consumerPortalPluginResource(
+  spec: Record<string, unknown> = {},
+  meta: { generation?: number; resourceVersion?: string } = {},
+
+  status?: { conditions?: any[] }
+) {
+  return {
+    metadata: {
+      name: 'compute-datumapis-com',
+      generation: meta.generation ?? 1,
+      resourceVersion: meta.resourceVersion ?? '100',
+    },
+    spec: {
+      slug: 'compute',
+      displayName: 'Compute',
+      deprecated: false,
+      suspend: false,
+      assets: { baseURL: 'http://plugin.example.com' },
+      visibility: { entitlement: 'Required' },
+      ...spec,
+    },
+    ...(status ? { status } : {}),
+  };
+}
+
+/** The status.conditions block the source writes for the valid fixture (Ready). */
+function readyConditions(patchBody: string): any[] {
+  return JSON.parse(patchBody).status.conditions;
+}
+
+/** A registry whose manifest pipeline always resolves the valid fixture. */
+function makeRegistry() {
+  const fetchImpl = mock(async () => new Response(JSON.stringify(VALID_MANIFEST), { status: 200 }));
+  const registry = new PluginRegistry({ fetchImpl: fetchImpl as unknown as typeof fetch });
+  return { registry, fetchImpl };
+}
+
+/** A KubeClient whose requests (status patches) succeed. */
+function makeClient() {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const fetchImpl = mock(async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return new Response('{}', { status: 200 });
+  });
+  const client = new KubeClient(resolveKubeContext(parseKubeconfig(NO_AUTH_KUBECONFIG)), {
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+  return { client, calls };
+}
+
+const silentLogger = { warn: mock(() => {}), info: mock(() => {}), error: mock(() => {}) };
+
+describe('specFromConsumerPortalPlugin', () => {
+  test('maps a resource spec with defaults applied', () => {
+    const spec = specFromConsumerPortalPlugin(consumerPortalPluginResource(), silentLogger);
+    expect(spec).not.toBeNull();
+    expect(spec!.slug).toBe('compute');
+    expect(spec!.assets.manifestPath).toBe('/plugin-manifest.json');
+    expect(spec!.visibility.entitlement).toBe('Required');
+  });
+
+  test('returns null when slug or assets.baseURL is missing', () => {
+    expect(specFromConsumerPortalPlugin({ spec: { slug: 'x' } }, silentLogger)).toBeNull();
+    expect(
+      specFromConsumerPortalPlugin({ spec: { assets: { baseURL: 'http://x' } } }, silentLogger)
+    ).toBeNull();
+  });
+
+  test('reads assets.caBundle as a flat string (no live ref resolution)', () => {
+    const spec = specFromConsumerPortalPlugin(
+      consumerPortalPluginResource({
+        assets: {
+          baseURL: 'https://plugin.example.com',
+          caBundle: '-----BEGIN CERTIFICATE-----\nfake\n',
+        },
+      }),
+      silentLogger
+    );
+    expect(spec?.assets.caBundle).toBe('-----BEGIN CERTIFICATE-----\nfake\n');
+  });
+});
+
+describe('PlatformSource.applyWatchEvent', () => {
+  test('ADDED reduces into a servable registry entry', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: consumerPortalPluginResource() });
+
+    const plugin = registry.getPlugin('compute');
+    expect(plugin).toBeDefined();
+    expect(plugin?.source).toBe('platform');
+    expect(plugin?.devMode).toBe(false);
+    expect(plugin?.manifest?.version).toBe('1.4.0');
+  });
+
+  test('best-effort PATCHes the status subresource', async () => {
+    const { registry } = makeRegistry();
+    const { client, calls } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: consumerPortalPluginResource() });
+
+    const patch = calls.find((c) =>
+      c.url.endsWith('/consumerportalplugins/compute-datumapis-com/status')
+    );
+    expect(patch).toBeDefined();
+    expect(patch?.init.method).toBe('PATCH');
+    const body = JSON.parse(patch!.init.body as string);
+    expect(
+      body.status.conditions.some((cond: any) => cond.type === 'Ready' && cond.status === 'True')
+    ).toBe(true);
+  });
+
+  test('spec-only MODIFIED hot-applies the new spec (entitlement flip)', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: consumerPortalPluginResource() });
+    expect(registry.getPlugin('compute')?.spec.visibility.entitlement).toBe('Required');
+
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: consumerPortalPluginResource(
+        { visibility: { entitlement: 'None' } },
+        { generation: 2, resourceVersion: '200' }
+      ),
+    });
+
+    expect(registry.getPlugin('compute')?.spec.visibility.entitlement).toBe('None');
+  });
+
+  test('suspend kill switch takes effect within one watch event, and un-suspend restores', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: consumerPortalPluginResource() });
+    expect(registry.getPlugin('compute')).toBeDefined();
+
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: consumerPortalPluginResource(
+        { suspend: true },
+        { generation: 2, resourceVersion: '200' }
+      ),
+    });
+    expect(registry.getPlugin('compute')).toBeUndefined();
+
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: consumerPortalPluginResource(
+        { suspend: false },
+        { generation: 3, resourceVersion: '300' }
+      ),
+    });
+    expect(registry.getPlugin('compute')).toBeDefined();
+  });
+
+  test('ignores a status-only MODIFIED (spec unchanged) — breaks the reconcile feedback loop', async () => {
+    const { registry, fetchImpl } = makeRegistry();
+    const { client, calls } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: consumerPortalPluginResource() });
+    const fetchesAfterAdd = fetchImpl.mock.calls.length;
+    const patchesAfterAdd = calls.filter((c) => c.init.method === 'PATCH').length;
+    expect(patchesAfterAdd).toBe(1);
+
+    const writtenConditions = readyConditions(
+      calls.find((c) => c.init.method === 'PATCH')!.init.body as string
+    );
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: consumerPortalPluginResource(
+        {},
+        { generation: 1, resourceVersion: '101' },
+        { conditions: writtenConditions }
+      ),
+    });
+
+    expect(fetchImpl.mock.calls.length).toBe(fetchesAfterAdd);
+    expect(calls.filter((c) => c.init.method === 'PATCH').length).toBe(patchesAfterAdd);
+  });
+
+  test('applies a spec change even when metadata.generation does NOT bump', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: consumerPortalPluginResource() });
+    expect(registry.getPlugin('compute')?.spec.suspend).toBe(false);
+
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: consumerPortalPluginResource(
+        { suspend: true },
+        { generation: 1, resourceVersion: '150' }
+      ),
+    });
+    expect(registry.getPlugin('compute')).toBeUndefined();
+  });
+
+  test('a spec change that does not alter conditions reconciles but skips a redundant status patch', async () => {
+    const { registry } = makeRegistry();
+    const { client, calls } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: consumerPortalPluginResource() });
+    const writtenConditions = readyConditions(
+      calls.find((c) => c.init.method === 'PATCH')!.init.body as string
+    );
+    const patchesAfterAdd = calls.filter((c) => c.init.method === 'PATCH').length;
+
+    await source.applyWatchEvent({
+      type: 'MODIFIED',
+      object: consumerPortalPluginResource(
+        { deprecated: true },
+        { generation: 2, resourceVersion: '200' },
+        { conditions: writtenConditions }
+      ),
+    });
+
+    expect(registry.getPlugin('compute')?.spec.deprecated).toBe(true);
+    expect(calls.filter((c) => c.init.method === 'PATCH').length).toBe(patchesAfterAdd);
+  });
+
+  test('DELETED removes the plugin from the registry', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await source.applyWatchEvent({ type: 'ADDED', object: consumerPortalPluginResource() });
+    expect(registry.getPlugin('compute')).toBeDefined();
+
+    await source.applyWatchEvent({
+      type: 'DELETED',
+      object: { metadata: { name: 'compute-datumapis-com' }, spec: { slug: 'compute' } },
+    });
+    expect(registry.getPlugin('compute')).toBeUndefined();
+  });
+
+  test('ERROR event throws to trigger a re-list', async () => {
+    const { registry } = makeRegistry();
+    const { client } = makeClient();
+    const source = new PlatformSource(registry, client, { logger: silentLogger });
+
+    await expect(
+      source.applyWatchEvent({ type: 'ERROR', object: { code: 410, message: 'too old' } })
+    ).rejects.toThrow();
+  });
+});

--- a/app/modules/plugins/server/platform-source.ts
+++ b/app/modules/plugins/server/platform-source.ts
@@ -1,0 +1,387 @@
+/**
+ * Platform registry source (production).
+ *
+ * Lists and watches the cluster-scoped `ConsumerPortalPlugin` CRD
+ * (portal.miloapis.com/v1alpha1) on milo's control plane via fetch
+ * streaming, reducing ADDED/MODIFIED/DELETED events into the registry, and
+ * best-effort PATCHing each resource's status subresource with
+ * Discovered / Compatible / Ready conditions. Structurally identical to
+ * `KubeconfigSource` (same list/watch/backoff/reconcile shape) — the
+ * difference is entirely in what credential/endpoint the `KubeClient` it's
+ * given points at, and the CRD it targets. One real simplification versus
+ * `KubeconfigSource`: `ConsumerPortalPlugin.spec.assets.caBundle` is a flat
+ * PEM string, not a `caBundleRef` pointing at a Secret/ConfigMap, so there's
+ * no live ref-resolution step here.
+ */
+import {
+  CONSUMER_PORTAL_PLUGIN_GROUP,
+  CONSUMER_PORTAL_PLUGIN_PLURAL,
+  CONSUMER_PORTAL_PLUGIN_VERSION,
+  DEFAULT_MANIFEST_PATH,
+  type PluginEntryStatus,
+  type PortalPluginSpec,
+} from '../types';
+import type { KubeClient } from './kubeconfig';
+import type { PluginRegistry } from './registry';
+
+interface ConsumerPortalPluginConditionResource {
+  type?: string;
+  status?: string;
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+}
+
+/** A cluster-scoped ConsumerPortalPlugin resource as returned by the API server. */
+interface ConsumerPortalPluginResource {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: { name?: string; generation?: number; resourceVersion?: string };
+  spec?: Record<string, any>;
+  status?: { conditions?: ConsumerPortalPluginConditionResource[] };
+}
+
+interface WatchEvent {
+  type: 'ADDED' | 'MODIFIED' | 'DELETED' | 'BOOKMARK' | 'ERROR';
+  object: ConsumerPortalPluginResource & { code?: number; message?: string };
+}
+
+const RESOURCE_PATH = `/apis/${CONSUMER_PORTAL_PLUGIN_GROUP}/${CONSUMER_PORTAL_PLUGIN_VERSION}/${CONSUMER_PORTAL_PLUGIN_PLURAL}`;
+
+const INITIAL_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+
+export interface PlatformSourceOptions {
+  /** Best-effort status writes; disable if the client lacks status permission. */
+  patchStatus?: boolean;
+  logger?: Pick<Console, 'warn' | 'info' | 'error'>;
+  /** Injectable delay for tests. */
+  delay?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Normalizes a ConsumerPortalPlugin resource's spec into the internal spec
+ * shape. Returns null for a malformed resource — missing slug or
+ * assets.baseURL — rather than serving a broken entry.
+ */
+export function specFromConsumerPortalPlugin(
+  resource: ConsumerPortalPluginResource,
+  logger: Pick<Console, 'warn'> = console
+): PortalPluginSpec | null {
+  const s = resource.spec ?? {};
+  const slug = typeof s.slug === 'string' ? s.slug : undefined;
+  if (!slug) return null;
+  if (!s.assets?.baseURL) {
+    logger.warn(`[plugins] ConsumerPortalPlugin "${slug}" is missing assets.baseURL`);
+    return null;
+  }
+
+  return {
+    slug,
+    displayName: typeof s.displayName === 'string' && s.displayName ? s.displayName : slug,
+    deprecated: s.deprecated === true,
+    suspend: s.suspend === true,
+    assets: {
+      baseURL: s.assets.baseURL,
+      manifestPath: s.assets.manifestPath || DEFAULT_MANIFEST_PATH,
+      caBundle: typeof s.assets.caBundle === 'string' ? s.assets.caBundle : undefined,
+    },
+    visibility: {
+      entitlement: s.visibility?.entitlement === 'None' ? 'None' : 'Required',
+      featureFlag: s.visibility?.featureFlag || undefined,
+    },
+    contentSecurityPolicy: Array.isArray(s.contentSecurityPolicy)
+      ? s.contentSecurityPolicy
+      : undefined,
+  };
+}
+
+/**
+ * Whether the desired conditions already match the resource's current ones,
+ * comparing type/status/reason/message but IGNORING `lastTransitionTime` — so a
+ * status write is only issued when something meaningful actually changed.
+ */
+function conditionsMatch(
+  desired: PluginEntryStatus['conditions'],
+  current: ConsumerPortalPluginConditionResource[] | undefined
+): boolean {
+  if (!current || current.length !== desired.length) return false;
+  return desired.every((d) => {
+    const c = current.find((e) => e.type === d.type);
+    return (
+      c !== undefined &&
+      c.status === d.status &&
+      (c.reason ?? '') === (d.reason ?? '') &&
+      (c.message ?? '') === (d.message ?? '')
+    );
+  });
+}
+
+export class PlatformSource {
+  private readonly registry: PluginRegistry;
+  private readonly client: KubeClient;
+  private readonly patchStatusEnabled: boolean;
+  private readonly logger: Pick<Console, 'warn' | 'info' | 'error'>;
+  private readonly delay: (ms: number) => Promise<void>;
+
+  private readonly abort = new AbortController();
+  private resourceVersion: string | undefined;
+  /** Resource name → slug, so DELETED and status patches resolve correctly. */
+  private readonly nameToSlug = new Map<string, string>();
+  /**
+   * Resource name → a stable key of the last reconciled (normalized) spec. Watch
+   * MODIFIED events that carry only our own status patch back have an unchanged
+   * spec, so they're ignored here — preventing an endless reconcile →
+   * status-patch → MODIFIED → reconcile feedback loop. Keying on spec CONTENT
+   * (rather than `metadata.generation`) means a real spec change always applies,
+   * without depending on the apiserver's generation-bump semantics.
+   */
+  private readonly lastSpecKey = new Map<string, string>();
+  private stopped = false;
+
+  constructor(registry: PluginRegistry, client: KubeClient, options: PlatformSourceOptions = {}) {
+    this.registry = registry;
+    this.client = client;
+    this.patchStatusEnabled = options.patchStatus ?? true;
+    this.logger = options.logger ?? console;
+    this.delay = options.delay ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  }
+
+  /** Starts the list+watch loop in the background (does not block boot). */
+  start(): void {
+    void this.listAndWatchLoop();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.abort.abort();
+  }
+
+  private async listAndWatchLoop(): Promise<void> {
+    let backoff = INITIAL_BACKOFF_MS;
+    while (!this.stopped) {
+      try {
+        await this.list();
+        backoff = INITIAL_BACKOFF_MS; // a clean list resets backoff
+        await this.watch();
+      } catch (err) {
+        if (this.stopped) return;
+        this.logger.warn(
+          `[plugins] platform watch error, retrying in ${backoff}ms: ${String(err)}`
+        );
+        await this.delay(backoff);
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+      }
+    }
+  }
+
+  /** Seeds the registry from a full list and prunes entries that disappeared. */
+  private async list(): Promise<void> {
+    const response = await this.client.request(RESOURCE_PATH, {
+      headers: { Accept: 'application/json' },
+      signal: this.abort.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`list ConsumerPortalPlugins failed: HTTP ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      items?: ConsumerPortalPluginResource[];
+      metadata?: { resourceVersion?: string };
+    };
+    this.resourceVersion = body.metadata?.resourceVersion;
+
+    const seenSlugs = new Set<string>();
+    for (const item of body.items ?? []) {
+      // Force a full reconcile on (re)list so a resync always refreshes.
+      const slug = await this.reconcile(item, true);
+      if (slug) seenSlugs.add(slug);
+    }
+
+    // Prune slugs that are no longer present in the cluster.
+    for (const [name, slug] of [...this.nameToSlug]) {
+      if (!seenSlugs.has(slug)) {
+        this.registry.remove('platform', slug);
+        this.nameToSlug.delete(name);
+        this.lastSpecKey.delete(name);
+      }
+    }
+
+    this.logger.info(`[plugins] platform source listed ${seenSlugs.size} ConsumerPortalPlugin(s)`);
+  }
+
+  /** Streams watch events from the current resourceVersion until the stream ends. */
+  private async watch(): Promise<void> {
+    const query = new URLSearchParams({ watch: 'true', allowWatchBookmarks: 'true' });
+    if (this.resourceVersion) query.set('resourceVersion', this.resourceVersion);
+
+    const response = await this.client.request(`${RESOURCE_PATH}?${query.toString()}`, {
+      headers: { Accept: 'application/json' },
+      signal: this.abort.signal,
+    });
+    if (!response.ok) {
+      // 410 Gone: our resourceVersion is too old — drop it and re-list.
+      if (response.status === 410) this.resourceVersion = undefined;
+      throw new Error(`watch ConsumerPortalPlugins failed: HTTP ${response.status}`);
+    }
+    if (!response.body) throw new Error('watch ConsumerPortalPlugins returned no body');
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (!this.stopped) {
+      const { done, value } = await reader.read();
+      if (done) return; // stream closed; caller re-lists + re-watches
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
+        if (line === '') continue;
+
+        let event: WatchEvent;
+        try {
+          event = JSON.parse(line) as WatchEvent;
+        } catch {
+          this.logger.warn('[plugins] skipping unparseable watch line');
+          continue;
+        }
+        await this.applyWatchEvent(event);
+      }
+    }
+  }
+
+  /**
+   * Reduces a single watch event into the registry. Exposed for unit testing
+   * the watch-event → registry-map mapping.
+   */
+  async applyWatchEvent(event: WatchEvent): Promise<void> {
+    const rv = event.object?.metadata?.resourceVersion;
+    if (rv) this.resourceVersion = rv;
+
+    switch (event.type) {
+      case 'ADDED':
+      case 'MODIFIED':
+        await this.reconcile(event.object);
+        return;
+      case 'DELETED': {
+        const name = event.object?.metadata?.name;
+        const slug = event.object?.spec?.slug ?? (name ? this.nameToSlug.get(name) : undefined);
+        if (slug) this.registry.remove('platform', slug);
+        if (name) {
+          this.nameToSlug.delete(name);
+          this.lastSpecKey.delete(name);
+        }
+        return;
+      }
+      case 'BOOKMARK':
+        return; // resourceVersion already advanced above
+      case 'ERROR':
+        // A 410 Gone status arrives as an ERROR event; force a re-list.
+        if (event.object?.code === 410) this.resourceVersion = undefined;
+        throw new Error(`watch ERROR event: ${event.object?.message ?? 'unknown'}`);
+    }
+  }
+
+  /**
+   * Upserts one resource and writes its resolved status back. Returns the slug.
+   *
+   * Reconciles only when the normalized spec has actually changed since we last
+   * processed it — status-only MODIFIED events (including the ones our own status
+   * patch produces, which leave the spec untouched) are no-ops, which is what
+   * breaks the feedback loop. `force` bypasses the gate for a full re-list resync.
+   */
+  private async reconcile(
+    resource: ConsumerPortalPluginResource,
+    force = false
+  ): Promise<string | undefined> {
+    const spec = specFromConsumerPortalPlugin(resource, this.logger);
+    const name = resource.metadata?.name;
+    if (!spec) {
+      this.logger.warn(
+        `[plugins] skipping ConsumerPortalPlugin "${name ?? '<unnamed>'}": missing slug or assets.baseURL`
+      );
+      return undefined;
+    }
+
+    if (name) this.nameToSlug.set(name, spec.slug);
+
+    // Skip when the spec is byte-identical to the last one we applied.
+    const specKey = JSON.stringify(spec);
+    if (!force && name !== undefined && this.lastSpecKey.get(name) === specKey) {
+      return spec.slug;
+    }
+
+    const entry = await this.registry.upsert('platform', spec, false);
+    if (name !== undefined) this.lastSpecKey.set(name, specKey);
+
+    if (this.patchStatusEnabled && name) {
+      await this.patchStatus(
+        name,
+        resource.metadata?.generation,
+        entry.status,
+        resource.status?.conditions
+      );
+    }
+    return spec.slug;
+  }
+
+  /**
+   * Best-effort status patch. Registry health never depends on this succeeding.
+   *
+   * Idempotent: skips the write entirely when the desired conditions already
+   * match what's on the resource (comparing everything except timestamps), and
+   * preserves each condition's `lastTransitionTime` when its status didn't
+   * change. Without this, a fresh `lastTransitionTime` on every write would make
+   * each patch a real mutation and re-trigger the watch.
+   */
+  private async patchStatus(
+    name: string,
+    generation: number | undefined,
+    status: PluginEntryStatus,
+    current: ConsumerPortalPluginConditionResource[] | undefined
+  ): Promise<void> {
+    if (conditionsMatch(status.conditions, current)) {
+      return; // nothing changed — don't churn the resourceVersion
+    }
+
+    const now = new Date().toISOString();
+    const body = {
+      status: {
+        observedGeneration: generation,
+        conditions: status.conditions.map((c) => {
+          const existing = current?.find((e) => e.type === c.type);
+          // lastTransitionTime only advances when the condition's status flips.
+          const lastTransitionTime =
+            existing && existing.status === c.status ? (existing.lastTransitionTime ?? now) : now;
+          return {
+            type: c.type,
+            status: c.status,
+            reason: c.reason,
+            message: c.message ?? '',
+            lastTransitionTime,
+            ...(generation !== undefined ? { observedGeneration: generation } : {}),
+          };
+        }),
+        ...(status.manifest ? { manifest: status.manifest } : {}),
+      },
+    };
+
+    try {
+      const response = await this.client.request(`${RESOURCE_PATH}/${name}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/merge-patch+json' },
+        body: JSON.stringify(body),
+        signal: this.abort.signal,
+      });
+      if (!response.ok) {
+        this.logger.warn(`[plugins] status patch for "${name}" rejected: HTTP ${response.status}`);
+      }
+    } catch (err) {
+      if (this.stopped) return;
+      this.logger.warn(`[plugins] status patch for "${name}" failed: ${String(err)}`);
+    }
+  }
+}

--- a/app/modules/plugins/types.ts
+++ b/app/modules/plugins/types.ts
@@ -20,6 +20,16 @@ export const PORTAL_PLUGIN_VERSION = 'v1alpha1';
 /** Plural resource name used in the Kubernetes REST path. */
 export const PORTAL_PLUGIN_PLURAL = 'portalplugins';
 
+/**
+ * The real, shipped CRD (cloud-portal repo, config/crd/consumerportalplugin.yaml)
+ * that the `platform` registry source watches. Distinct from `PORTAL_PLUGIN_*`
+ * above, which is the generic `PortalPlugin` Kind the dev-only `kubeconfig`
+ * source still targets (pre-dates the Consumer/Provider split).
+ */
+export const CONSUMER_PORTAL_PLUGIN_GROUP = 'portal.miloapis.com';
+export const CONSUMER_PORTAL_PLUGIN_VERSION = 'v1alpha1';
+export const CONSUMER_PORTAL_PLUGIN_PLURAL = 'consumerportalplugins';
+
 /** Default manifest path appended to `assets.baseURL` when none is declared. */
 export const DEFAULT_MANIFEST_PATH = '/plugin-manifest.json';
 

--- a/app/utils/env/env.server.ts
+++ b/app/utils/env/env.server.ts
@@ -190,6 +190,16 @@ const serverSchema = z.object({
   PORTAL_PLUGINS_JSON: z.string().optional(),
   PLUGIN_REGISTRY_KUBECONFIG: z.string().optional(),
   AUTH_DEV_TOKEN_EXCHANGE: z.string().optional(),
+
+  // ─────────────────────────────────────────────────────────
+  // Optional: Portal Plugin System (platform registry source)
+  //
+  // PLATFORM_REGISTRY_KUBECONFIG: path to the mounted
+  // consumer-portal-plugin-reader kubeconfig used to watch
+  // ConsumerPortalPlugin on milo's control plane at boot. Meant for real
+  // deployments — no NODE_ENV gating, unlike the dev-only vars above.
+  // ─────────────────────────────────────────────────────────
+  PLATFORM_REGISTRY_KUBECONFIG: z.string().optional(),
 });
 
 // ═══════════════════════════════════════════════════════════
@@ -275,6 +285,7 @@ export const env: Env = {
     portalPluginsJson: data.PORTAL_PLUGINS_JSON,
     pluginRegistryKubeconfig: data.PLUGIN_REGISTRY_KUBECONFIG,
     authDevTokenExchange: data.AUTH_DEV_TOKEN_EXCHANGE,
+    platformRegistryKubeconfig: data.PLATFORM_REGISTRY_KUBECONFIG,
   },
   isProd: data.NODE_ENV === 'production',
   isDev: data.NODE_ENV === 'development',

--- a/app/utils/env/types.ts
+++ b/app/utils/env/types.ts
@@ -111,6 +111,13 @@ export interface ServerEnv {
   portalPluginsJson?: string;
   pluginRegistryKubeconfig?: string;
   authDevTokenExchange?: string;
+
+  // Optional: Portal Plugin System (platform registry source)
+  // platformRegistryKubeconfig: path to the mounted consumer-portal-plugin-reader
+  //   kubeconfig used to watch ConsumerPortalPlugin on milo's control plane at
+  //   boot. Unlike the dev-only vars above, this one is meant to be set in
+  //   real deployments and carries no NODE_ENV gating.
+  platformRegistryKubeconfig?: string;
 }
 
 /**

--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -50,15 +50,9 @@ spec:
               value: http://vmsingle-datum-resource-metrics.datum-system.svc.cluster.local:8429
             - name: SENTRY_DSN
               value: https://5577e0a8a54d023d2c51092ee68041b3@sentry.prod.env.datum.net/5
-            - name: PLATFORM_REGISTRY_KUBECONFIG
-              value: /etc/milo/plugin-reader/kubeconfig
           envFrom:
             - secretRef:
                 name: cloud-portal
-          volumeMounts:
-            - name: milo-plugin-reader-kubeconfig
-              mountPath: /etc/milo/plugin-reader
-              readOnly: true
           resources:
             # TODO: Specify resource requests
             limits:
@@ -85,7 +79,3 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
-      volumes:
-        - name: milo-plugin-reader-kubeconfig
-          secret:
-            secretName: consumer-portal-plugin-reader-kubeconfig

--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -50,9 +50,15 @@ spec:
               value: http://vmsingle-datum-resource-metrics.datum-system.svc.cluster.local:8429
             - name: SENTRY_DSN
               value: https://5577e0a8a54d023d2c51092ee68041b3@sentry.prod.env.datum.net/5
+            - name: PLATFORM_REGISTRY_KUBECONFIG
+              value: /etc/milo/plugin-reader/kubeconfig
           envFrom:
             - secretRef:
                 name: cloud-portal
+          volumeMounts:
+            - name: milo-plugin-reader-kubeconfig
+              mountPath: /etc/milo/plugin-reader
+              readOnly: true
           resources:
             # TODO: Specify resource requests
             limits:
@@ -79,3 +85,7 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
+      volumes:
+        - name: milo-plugin-reader-kubeconfig
+          secret:
+            secretName: consumer-portal-plugin-reader-kubeconfig

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - consumerportalplugin.yaml
+  - plugin-reader-rbac.yaml

--- a/config/crd/plugin-reader-rbac.yaml
+++ b/config/crd/plugin-reader-rbac.yaml
@@ -1,0 +1,40 @@
+# Grants the consumer-portal-plugin-reader credential (see
+# infra/apps/cloud-portal/base/milo-plugin-reader-certificate.yaml) read-only
+# access to ConsumerPortalPlugin on milo's control plane. Bound to a
+# dedicated group rather than system:masters/system:datum-cloud — this
+# credential is mounted into the live, internet-facing cloud-portal app
+# pod, not just wielded by Flux, so it carries the least privilege that
+# platform-source.ts actually needs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: consumer-portal-plugin-reader
+rules:
+  - apiGroups:
+      - portal.miloapis.com
+    resources:
+      - consumerportalplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - portal.miloapis.com
+    resources:
+      - consumerportalplugins/status
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: consumer-portal-plugin-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: consumer-portal-plugin-reader
+subjects:
+  - kind: Group
+    name: datum:consumer-portal-plugin-reader
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary
- Implements `PlatformSource` — the `platform` registry-source slot, previously reserved but unbuilt. Adapted from the dev-only `KubeconfigSource`: same list/watch/backoff/reconcile/status-patch shape, but targets the real, shipped `ConsumerPortalPlugin` CRD (not the legacy generic `PortalPlugin`), and reads `assets.caBundle` as a flat string (the shipped schema has no `caBundleRef` live-lookup case).
- Wired unconditionally in `initPluginRegistry()` — independent of `planDevSources()`'s `NODE_ENV=development` gate, since this source is meant for real deployments, not a dev shortcut.
- New `PLATFORM_REGISTRY_KUBECONFIG` env var (server-only, no dev gating) points at a kubeconfig mounted into the app pod from a new, narrowly-scoped credential (`consumer-portal-plugin-reader`) — deliberately *not* the existing `system:masters` `milo-configuration` cert that Flux alone wields, so a compromised web pod only ever gets read access to one CRD.
- `config/crd/plugin-reader-rbac.yaml`: `ClusterRole`/`ClusterRoleBinding` granting that credential's group `get/list/watch` on `consumerportalplugins` (+ `get/patch` on `/status`).
- `config/base/deployment.yaml`: mounts the corresponding Secret (`consumer-portal-plugin-reader-kubeconfig`) as a volume.

Deployment wiring that lands the CRD+RBAC on milo's control plane and issues that credential lives in datum-cloud/infra#(companion PR).

## Test plan
- [x] `bun test app/modules/plugins/` — 142 pass (12 new for `PlatformSource`), no regressions
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `kustomize build config/crd` and `kustomize build config/base` render cleanly, including the new volume/env
- [ ] Once the companion infra PR merges and the CRD/RBAC/cert land in staging, verify pod logs show `[plugins] platform source watching ...` and a real `ConsumerPortalPlugin` shows up via `getPlugins()`