### PR TITLE
fix: resolve client-certificate/client-key given as file paths

### DIFF
--- a/app/modules/plugins/server/kubeconfig.test.ts
+++ b/app/modules/plugins/server/kubeconfig.test.ts
@@ -7,6 +7,9 @@ import {
   type ExecAuth,
 } from './kubeconfig';
 import { describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const INSECURE_LOOPBACK = `
 apiVersion: v1
@@ -104,6 +107,49 @@ describe('resolveKubeContext', () => {
 
   test('parseKubeconfig throws on non-mapping YAML', () => {
     expect(() => parseKubeconfig('- just\n- a\n- list')).toThrow();
+  });
+
+  // Regression: a cert-manager CSI-mounted client cert is referenced by file
+  // path (client-certificate/client-key/certificate-authority), not inline
+  // base64 (client-certificate-data/client-key-data). Silently dropping the
+  // file-path form means the client connects with no client cert at all —
+  // TLS still completes (if the server allows optional client certs), but
+  // every request authenticates as anonymous instead of the intended
+  // identity, surfacing as a confusing 403 rather than a connection error.
+  test('resolves client-certificate/client-key/certificate-authority given as file paths', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'kubeconfig-test-'));
+    const caPath = join(dir, 'ca.crt');
+    const certPath = join(dir, 'tls.crt');
+    const keyPath = join(dir, 'tls.key');
+    writeFileSync(caPath, 'fake-ca-pem');
+    writeFileSync(certPath, 'fake-cert-pem');
+    writeFileSync(keyPath, 'fake-key-pem');
+
+    const kubeconfig = `
+apiVersion: v1
+kind: Config
+current-context: milo
+clusters:
+- name: milo-cluster
+  cluster:
+    server: https://milo-apiserver.datum-system.svc.cluster.local:6443
+    certificate-authority: ${caPath}
+contexts:
+- name: milo
+  context:
+    cluster: milo-cluster
+    user: plugin-reader
+users:
+- name: plugin-reader
+  user:
+    client-certificate: ${certPath}
+    client-key: ${keyPath}
+`;
+
+    const ctx = resolveKubeContext(parseKubeconfig(kubeconfig));
+    expect(ctx.tls.caPem).toBe('fake-ca-pem');
+    expect(ctx.tls.clientCertPem).toBe('fake-cert-pem');
+    expect(ctx.tls.clientKeyPem).toBe('fake-key-pem');
   });
 });
 

--- a/app/modules/plugins/server/kubeconfig.ts
+++ b/app/modules/plugins/server/kubeconfig.ts
@@ -31,6 +31,8 @@ interface RawUser {
   exec?: RawExec;
   'client-certificate-data'?: string;
   'client-key-data'?: string;
+  'client-certificate'?: string;
+  'client-key'?: string;
 }
 
 interface RawCluster {
@@ -120,9 +122,13 @@ export function resolveKubeContext(
   }
   if (user['client-certificate-data']) {
     tls.clientCertPem = decodeBase64(user['client-certificate-data']);
+  } else if (user['client-certificate']) {
+    tls.clientCertPem = readFileSync(user['client-certificate'], 'utf8');
   }
   if (user['client-key-data']) {
     tls.clientKeyPem = decodeBase64(user['client-key-data']);
+  } else if (user['client-key']) {
+    tls.clientKeyPem = readFileSync(user['client-key'], 'utf8');
   }
 
   return {


### PR DESCRIPTION
## Summary
Confirmed live in staging: `PlatformSource` connected to milo's control plane, but every request got `HTTP 403`. Root-caused via `kubectl auth can-i --as=<CN> --as-group=<O>` impersonation (RBAC checked out fine) and inspecting the CSI-mounted cert's actual Subject inside the pod (`openssl x509 -noout -subject` — matched exactly, right CN/O, right issuer).

The actual bug: `kubeconfig.ts` only read `client-certificate-data`/`client-key-data` (inline base64) — never `client-certificate`/`client-key` (file paths). A cert-manager CSI ephemeral volume is referenced by file path, not inline data (that's the whole point — nothing lands in a Secret), so the client cert/key were silently never loaded. The client connected with no client cert at all; milo's apiserver authenticated the request as anonymous and RBAC correctly denied it — hence a real `403`, not a connection error, which is what made this one tricky to spot.

`certificate-authority` already supported both forms (see the existing `readFileSync` fallback next to `certificate-authority-data`) — `client-certificate`/`client-key` just needed the same treatment.

## Test plan
- [x] `bun test app/modules/plugins/` — 143 pass (1 new regression test using real temp files for the file-path form), no regressions
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [ ] After merge + staging redeploy, confirm pod logs show `[plugins] platform source watching ...` with no more 403s