### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+We take the security of Datum seriously and appreciate the community's help in
+reporting vulnerabilities responsibly.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+Instead, report a potential vulnerability privately to our Security Team at:
+
+**security@datum.net**
+
+Our Security Team reviews and responds to third-party reports of security
+issues sent to this address promptly. If you believe the issue is time-sensitive
+or actively exploited, mark it as urgent in the subject line so we can triage it
+immediately.
+
+Please include as much of the following as you reasonably can to help us
+remediate quickly:
+
+- The affected component and version
+- A description of the vulnerability
+- Steps to reproduce (or a proof of concept)
+- Any impact you were able to confirm
+- Your contact information (optional)
+
+## What to Expect
+
+We aim to remediate security vulnerabilities as soon as possible. For reference,
+our [patch management policy](https://www.datum.net/handbook/policy/patch-management)
+sets an expected remediation timeline of 90 days from when a patch is available
+to when it is applied, and we put mitigations in place where a patch is not yet
+available or cannot be applied.
+
+You can expect an acknowledgement that we received your report. We will keep you
+informed as we investigate and remediate.
+
+## Disclosure
+
+Confirmed vulnerabilities are disclosed publicly per our [incident disclosure
+policy](https://www.datum.net/handbook/policy/incident-disclosure): Datum
+publishes security bulletins publicly at [our blog](https://www.datum.net/blog),
+and may additionally notify affected users directly for actionable incidents.
+
+## Scope
+
+This applies to the software shipped from this repository. Note that
+security findings can also be reported against Datum's managed infrastructure
+(Datum Cloud); see our [incident response
+policy](https://www.datum.net/handbook/policy/incident-response) for more
+details.


### PR DESCRIPTION
Adds a SECURITY.md so external researchers and users know how to privately report security vulnerabilities, consistent with Datum's published handbook policies (@security@datum.net).