### PR TITLE
fix: Drop redundant Remove protection link in WAF dialog

### DIFF
--- a/app/features/edge/proxy/proxy-waf-dialog.tsx
+++ b/app/features/edge/proxy/proxy-waf-dialog.tsx
@@ -128,21 +128,6 @@ export const ProxyWafDialog = forwardRef<ProxyWafDialogRef, ProxyWafDialogProps>
       }
     };
 
-    const handleRemove = useCallback(async () => {
-      try {
-        await removeProtection();
-      } catch (error) {
-        showMutationErrorToast(error, {
-          fallbackTitle: 'Application Load Balancer',
-          fallbackDescription: (error as Error).message || 'Failed to remove protection',
-          scope: 'project',
-          projectId,
-        });
-        onError?.(error as Error);
-        setOpen(false);
-      }
-    }, [removeProtection, onError, projectId]);
-
     return (
       <Form.Dialog
         open={open}
@@ -211,17 +196,6 @@ export const ProxyWafDialog = forwardRef<ProxyWafDialogRef, ProxyWafDialogProps>
                 </Form.Select>
               </Form.Field>
             </>
-          )}
-
-          {hasActiveWaf && (
-            <div className="flex pt-2">
-              <button
-                type="button"
-                className="text-destructive hover:text-destructive/80 text-sm underline"
-                onClick={handleRemove}>
-                Remove protection
-              </button>
-            </div>
           )}
         </div>
       </Form.Dialog>


### PR DESCRIPTION
## Summary

The WAF edit dialog now uses an enable switch to turn protection on or off, and saving while disabled removes an active policy after confirmation. The separate Remove protection link duplicated that flow and added a second destructive path.

This removes the link so disable-and-save is the only way to turn protection off, matching Basic Authentication.

## Test plan

- [x] Open Edit Protection on a proxy with WAF enabled — no Remove protection link
- [x] Toggle Enable Protection off and Save — confirm dialog appears and protection is removed
- [x] `bun test app/features/edge/proxy/proxy-waf-dialog.test.ts` passes