### PR TITLE
feat: Show deleting state on org project list

### DIFF
--- a/app/components/header/mobile-switcher-sheet.tsx
+++ b/app/components/header/mobile-switcher-sheet.tsx
@@ -3,6 +3,7 @@ import { useResourcePermissions } from '@/modules/rbac';
 import { useApp } from '@/providers/app.provider';
 import { type Organization, useOrganizationsGql } from '@/resources/organizations';
 import type { Project } from '@/resources/projects';
+import { filterActiveProjects } from '@/resources/projects';
 import { useProjects } from '@/resources/projects/project.queries';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
@@ -147,7 +148,7 @@ function ProjectSwitcherSheet({
   });
 
   const projects = useMemo(() => {
-    const items = data?.items ?? [];
+    const items = filterActiveProjects(data?.items ?? []);
     return [...items].sort((a, b) => {
       if (a.uid === currentProject?.uid) return -1;
       if (b.uid === currentProject?.uid) return 1;

--- a/app/components/header/project-switcher.tsx
+++ b/app/components/header/project-switcher.tsx
@@ -3,6 +3,7 @@ import { deriveSuspensionVerdict } from '@/features/project/suspension';
 import { useResourcePermissions } from '@/modules/rbac';
 import { useApp } from '@/providers/app.provider';
 import type { Project } from '@/resources/projects';
+import { filterActiveProjects } from '@/resources/projects';
 import { useProjects } from '@/resources/projects/project.queries';
 import { paths } from '@/utils/config/paths.config';
 import { getPathWithParams } from '@/utils/helpers/path.helper';
@@ -72,7 +73,7 @@ export const ProjectSwitcher = ({
   };
 
   const projects: Project[] = useMemo(() => {
-    const items = data?.items ?? [];
+    const items = filterActiveProjects(data?.items ?? []);
     return [...items].sort((a, b) => {
       if (a.uid === currentProject.uid) return -1;
       if (b.uid === currentProject.uid) return 1;

--- a/app/components/select-project/select-project.tsx
+++ b/app/components/select-project/select-project.tsx
@@ -1,3 +1,4 @@
+import { filterActiveProjects } from '@/resources/projects';
 import { useProjects } from '@/resources/projects/project.queries';
 import type { Project } from '@/resources/projects/project.schema';
 import { Autocomplete, type AutocompleteOption } from '@datum-cloud/datum-ui/autocomplete';
@@ -24,7 +25,7 @@ export const SelectProject = ({
   disabled?: boolean;
 }) => {
   const { data, isLoading, error } = useProjects(orgId);
-  const projects = data?.items ?? [];
+  const projects = filterActiveProjects(data?.items ?? []);
 
   useEffect(() => {
     if (error) {

--- a/app/features/project/settings/danger-card.tsx
+++ b/app/features/project/settings/danger-card.tsx
@@ -29,7 +29,8 @@ export const ProjectDangerCard = ({ project }: { project: Project }) => {
       navigate(
         getPathWithParams(paths.org.detail.projects.root, {
           orgId: project.organizationId,
-        })
+        }),
+        { state: { skipDeletingRedirect: true } }
       );
     },
     onError: (error) => {

--- a/app/features/project/status.tsx
+++ b/app/features/project/status.tsx
@@ -3,7 +3,7 @@ import { deriveSuspensionVerdict, reasonSummary } from '@/features/project/suspe
 import { useApp } from '@/providers/app.provider';
 import { ControlPlaneStatus, IControlPlaneStatus } from '@/resources/base';
 import type { Project } from '@/resources/projects';
-import { useProject } from '@/resources/projects';
+import { isProjectDeleting, useProject } from '@/resources/projects';
 import { transformControlPlaneStatus } from '@/utils/helpers/control-plane.helper';
 import { useMemo } from 'react';
 
@@ -41,7 +41,9 @@ export const ProjectStatus = ({
     refetchInterval: shouldWatch ? 10000 : false,
   });
 
-  const rawStatus = project?.status ?? fetchedProject?.status;
+  const resolvedProject = project ?? fetchedProject;
+  const rawStatus = resolvedProject?.status;
+  const deleting = resolvedProject != null && isProjectDeleting(resolvedProject);
 
   // Suspension wins over Ready-derived state (suspension never flips Ready,
   // so without this a suspended project reads as "Active").
@@ -61,6 +63,19 @@ export const ProjectStatus = ({
     }
     return undefined;
   }, [status]);
+
+  if (deleting) {
+    return (
+      <BadgeStatus
+        status="pending"
+        label={label ?? 'Deleting'}
+        showIcon
+        showTooltip={showTooltip}
+        tooltipText="This project is being deleted"
+        className={className}
+      />
+    );
+  }
 
   if (verdict.isSuspended) {
     return (

--- a/app/resources/projects/index.ts
+++ b/app/resources/projects/index.ts
@@ -35,10 +35,12 @@ export {
   useDeleteProject,
 } from './project.queries';
 
-// Watch hook exports (only list watch - single project watch not supported for cluster-scoped resources)
-export { useProjectsWatch, inspectProjectReady } from './project.watch';
+// Watch hook exports
+export { useProjectsWatch, useProjectWatch, inspectProjectReady } from './project.watch';
 
 export { createProjectWithBillingBind } from './create-project-with-billing';
+
+export { isProjectDeleting, filterActiveProjects, isSelfDeleteNavigation } from './project.helpers';
 
 export {
   waitForProjectAccessReady,

--- a/app/resources/projects/project.adapter.test.ts
+++ b/app/resources/projects/project.adapter.test.ts
@@ -40,10 +40,24 @@ describe('toProject', () => {
     expect(toProject(raw as never).displayName).toBe('no-desc');
     expect(toProject(raw as never).description).toBeUndefined();
   });
+
+  it('maps deletionTimestamp from metadata', () => {
+    const raw = {
+      metadata: rawMetadata({
+        name: 'deleting',
+        deletionTimestamp: '2024-02-02T00:00:00Z',
+      }),
+      spec: { ownerRef: { name: 'acme' } },
+      status: readyStatus(),
+    };
+    const project = toProject(raw as never);
+
+    expect(project.deletionTimestamp).toEqual(new Date('2024-02-02T00:00:00Z'));
+  });
 });
 
 describe('toProjectList', () => {
-  it('includes only ready projects and drops deleting / pending ones', () => {
+  it('includes ready projects and deleting ones, but drops pending ones', () => {
     const items = [
       {
         metadata: rawMetadata({ name: 'ready' }),
@@ -63,7 +77,10 @@ describe('toProjectList', () => {
     ];
     const list = toProjectList({ items, metadata: { continue: 'tok' } } as never);
 
-    expect(list.items.map((p) => p.name)).toEqual(['ready']);
+    expect(list.items.map((p) => p.name)).toEqual(['ready', 'deleting']);
+    expect(list.items.find((p) => p.name === 'deleting')?.deletionTimestamp).toEqual(
+      new Date('2024-02-02T00:00:00Z')
+    );
     expect(list.nextCursor).toBe('tok');
     expect(list.hasMore).toBe(true);
   });
@@ -77,6 +94,24 @@ describe('toProjectList', () => {
 });
 
 describe('toProjectListAll', () => {
+  it('excludes deleting projects for idempotent setup guards', () => {
+    const items = [
+      {
+        metadata: rawMetadata({ name: 'ready' }),
+        spec: { ownerRef: { name: 'acme' } },
+        status: readyStatus(),
+      },
+      {
+        metadata: rawMetadata({ name: 'deleting', deletionTimestamp: '2024-02-02T00:00:00Z' }),
+        spec: { ownerRef: { name: 'acme' } },
+        status: readyStatus(),
+      },
+    ];
+    const list = toProjectListAll({ items } as never);
+
+    expect(list.items.map((p) => p.name)).toEqual(['ready']);
+  });
+
   it('includes pending projects for idempotent setup guards', () => {
     const items = [
       {

--- a/app/resources/projects/project.adapter.ts
+++ b/app/resources/projects/project.adapter.ts
@@ -30,6 +30,7 @@ export function toProject(raw: ComMiloapisResourcemanagerV1Alpha1Project): Proje
     updatedAt: raw.metadata?.creationTimestamp,
     organizationId: raw.spec?.ownerRef?.name ?? '',
     status: raw.status ?? {},
+    deletionTimestamp: raw.metadata?.deletionTimestamp,
     labels: filterLabels(raw.metadata?.labels ?? {}, ['resourcemanager']),
     annotations: raw.metadata?.annotations ?? {},
   };
@@ -39,8 +40,6 @@ export function toProject(raw: ComMiloapisResourcemanagerV1Alpha1Project): Proje
 
 export function toProjectList(raw: ComMiloapisResourcemanagerV1Alpha1ProjectList): ProjectList {
   const items = (raw.items ?? [])
-    // Only include projects that are not being deleted
-    .filter((p) => !p.metadata?.deletionTimestamp)
     .filter((p) => {
       // Only include projects that are ready
       const status = transformControlPlaneStatus(p.status);

--- a/app/resources/projects/project.helpers.test.ts
+++ b/app/resources/projects/project.helpers.test.ts
@@ -1,0 +1,77 @@
+import {
+  filterActiveProjects,
+  isProjectDeleting,
+  isSelfDeleteNavigation,
+  markSelfDeleteNavigation,
+  patchProjectListDeleting,
+} from './project.helpers';
+import type { Project, ProjectList } from './project.schema';
+import { describe, expect, it } from 'bun:test';
+
+const deletedAt = new Date('2024-02-02T00:00:00Z');
+
+const activeProject = {
+  name: 'active',
+  deletionTimestamp: undefined,
+} as Project;
+
+const deletingProject = {
+  name: 'deleting',
+  deletionTimestamp: deletedAt,
+} as Project;
+
+describe('isProjectDeleting', () => {
+  it('returns true when deletionTimestamp is set', () => {
+    expect(isProjectDeleting(deletingProject)).toBe(true);
+  });
+
+  it('returns false when deletionTimestamp is absent', () => {
+    expect(isProjectDeleting(activeProject)).toBe(false);
+  });
+});
+
+describe('filterActiveProjects', () => {
+  it('removes deleting projects from the list', () => {
+    expect(filterActiveProjects([activeProject, deletingProject]).map((p) => p.name)).toEqual([
+      'active',
+    ]);
+  });
+});
+
+describe('selfDeleteNavigation', () => {
+  it('marks a project as self-delete navigation for a short window', () => {
+    markSelfDeleteNavigation('self-deleted');
+    expect(isSelfDeleteNavigation('self-deleted')).toBe(true);
+    expect(isSelfDeleteNavigation('other')).toBe(false);
+  });
+});
+
+describe('patchProjectListDeleting', () => {
+  const list: ProjectList = {
+    items: [activeProject, { ...activeProject, name: 'target', uid: 'target' } as Project],
+    hasMore: false,
+    nextCursor: null,
+  };
+
+  it('marks an existing project as deleting', () => {
+    const patched = patchProjectListDeleting(list, 'target', undefined, deletedAt);
+
+    expect(patched?.items.find((item) => item.name === 'target')?.deletionTimestamp).toEqual(
+      deletedAt
+    );
+  });
+
+  it('appends the project when it is missing from the cached list', () => {
+    const project = { ...activeProject, name: 'missing', uid: 'missing' } as Project;
+    const patched = patchProjectListDeleting(list, 'missing', project, deletedAt);
+
+    expect(patched?.items.map((item) => item.name)).toEqual(['active', 'target', 'missing']);
+    expect(patched?.items.find((item) => item.name === 'missing')?.deletionTimestamp).toEqual(
+      deletedAt
+    );
+  });
+
+  it('returns the original list when the project is missing and no seed project is provided', () => {
+    expect(patchProjectListDeleting(list, 'missing', undefined, deletedAt)).toBe(list);
+  });
+});

--- a/app/resources/projects/project.helpers.ts
+++ b/app/resources/projects/project.helpers.ts
@@ -1,0 +1,56 @@
+import type { Project, ProjectList } from './project.schema';
+
+/** Self-delete navigates away before the layout deleting-redirect should run. */
+const selfDeleteNavigationProjectNames = new Set<string>();
+
+const SELF_DELETE_NAVIGATION_WINDOW_MS = 3_000;
+
+export function markSelfDeleteNavigation(projectName: string): void {
+  selfDeleteNavigationProjectNames.add(projectName);
+  setTimeout(() => {
+    selfDeleteNavigationProjectNames.delete(projectName);
+  }, SELF_DELETE_NAVIGATION_WINDOW_MS);
+}
+
+export function isSelfDeleteNavigation(projectName: string): boolean {
+  return selfDeleteNavigationProjectNames.has(projectName);
+}
+
+export function isProjectDeleting(project: Pick<Project, 'deletionTimestamp'>): boolean {
+  return project.deletionTimestamp != null;
+}
+
+export function filterActiveProjects<T extends Pick<Project, 'deletionTimestamp'>>(
+  projects: T[]
+): T[] {
+  return projects.filter((project) => !isProjectDeleting(project));
+}
+
+/** Patch a project list so the named project reads as mid-deletion. */
+export function patchProjectListDeleting(
+  list: ProjectList | undefined,
+  name: string,
+  project: Project | undefined,
+  deletedAt: Date
+): ProjectList | undefined {
+  if (!list?.items) return list;
+
+  const markDeleting = (item: Project): Project => ({
+    ...item,
+    deletionTimestamp: deletedAt,
+  });
+
+  const hasProject = list.items.some((item) => item.name === name);
+  if (!hasProject) {
+    if (!project) return list;
+    return {
+      ...list,
+      items: [...list.items, markDeleting(project)],
+    };
+  }
+
+  return {
+    ...list,
+    items: list.items.map((item) => (item.name === name ? markDeleting(item) : item)),
+  };
+}

--- a/app/resources/projects/project.queries.ts
+++ b/app/resources/projects/project.queries.ts
@@ -1,3 +1,4 @@
+import { patchProjectListDeleting, markSelfDeleteNavigation } from './project.helpers';
 import type {
   Project,
   ProjectList,
@@ -105,14 +106,24 @@ export function useDeleteProject(options?: UseMutationOptions<void, Error, strin
     ...options,
     onSuccess: async (...args) => {
       const [, name] = args;
-      // Cancel in-flight queries - Watch handles list update
       await queryClient.cancelQueries({ queryKey: projectKeys.detail(name) });
 
+      const project = queryClient.getQueryData<Project>(projectKeys.detail(name));
+      const deletedAt = new Date();
+
+      // Navigate before list patch so the layout deleting-redirect does not race
+      // self-delete. Skip marking detail cache deleting — watch/refetch owns that.
+      markSelfDeleteNavigation(name);
       options?.onSuccess?.(...args);
+
+      queryClient.setQueriesData<ProjectList>({ queryKey: projectKeys.lists() }, (old) =>
+        patchProjectListDeleting(old, name, project, deletedAt)
+      );
+
+      void queryClient.invalidateQueries({ queryKey: projectKeys.lists() });
       void invalidateAllowanceBuckets(queryClient);
     },
     onSettled: (...args) => {
-      queryClient.invalidateQueries({ queryKey: projectKeys.lists() });
       options?.onSettled?.(...args);
     },
   });

--- a/app/resources/projects/project.schema.ts
+++ b/app/resources/projects/project.schema.ts
@@ -33,6 +33,7 @@ export type ProjectSuspensionInfo = z.infer<typeof projectSuspensionInfoSchema>;
 export const projectSchema = resourceMetadataSchema.extend({
   organizationId: z.string(),
   status: z.any(), // Raw status object from API
+  deletionTimestamp: z.coerce.date().optional(),
   labels: z.record(z.string(), z.string()).optional(),
   annotations: z.record(z.string(), z.string()).optional(),
 });

--- a/app/resources/projects/project.watch.ts
+++ b/app/resources/projects/project.watch.ts
@@ -1,6 +1,6 @@
 // app/resources/projects/project.watch.ts
 import { toProject } from './project.adapter';
-import type { Project } from './project.schema';
+import type { Project, ProjectList } from './project.schema';
 import { createProjectService, projectKeys } from './project.service';
 import type { ComMiloapisResourcemanagerV1Alpha1Project } from '@/modules/control-plane/resource-manager';
 import { useResourceWatch } from '@/modules/watch';
@@ -33,6 +33,37 @@ export function useProjectsWatch(orgId: string, options?: { enabled?: boolean })
     queryKey,
     transform: (item) => toProject(item as ComMiloapisResourcemanagerV1Alpha1Project),
     enabled: options?.enabled ?? true,
+    getItemKey: (project) => project.name,
+    updateListCache: (oldData, newItem) => {
+      const project = newItem as Project;
+      const name = project.name;
+      if (!name) return oldData;
+
+      if (Array.isArray(oldData)) {
+        const list = oldData as Project[];
+        const exists = list.some((item) => item.name === name);
+        return exists
+          ? list.map((item) => (item.name === name ? project : item))
+          : [...list, project];
+      }
+
+      if (
+        typeof oldData === 'object' &&
+        oldData !== null &&
+        Array.isArray((oldData as ProjectList).items)
+      ) {
+        const list = oldData as ProjectList;
+        const exists = list.items.some((item) => item.name === name);
+        return {
+          ...list,
+          items: exists
+            ? list.items.map((item) => (item.name === name ? project : item))
+            : [...list.items, project],
+        };
+      }
+
+      return oldData;
+    },
   });
 }
 

--- a/app/routes/org/detail/billing/index.tsx
+++ b/app/routes/org/detail/billing/index.tsx
@@ -30,7 +30,12 @@ import {
   useCreateBillingAccount,
 } from '@/resources/billing-accounts';
 import { newBindingName } from '@/resources/billing/_naming';
-import { useProjects, useProjectsWatch, type ProjectList } from '@/resources/projects';
+import {
+  filterActiveProjects,
+  useProjects,
+  useProjectsWatch,
+  type ProjectList,
+} from '@/resources/projects';
 import { createProjectService } from '@/resources/projects/project.service';
 import { buildOrganizationNamespace } from '@/utils/common';
 import { paths } from '@/utils/config/paths.config';
@@ -219,7 +224,7 @@ export default function OrgBillingSwitcherPage() {
 
   const rows: SwitcherRow[] = useMemo(
     () =>
-      projects.items.map((project) => {
+      filterActiveProjects(projects.items).map((project) => {
         const binding = activeBindingByProject.get(project.name);
         const establishedAt =
           binding?.status?.billingResponsibility?.establishedAt ??

--- a/app/routes/org/detail/projects/index.tsx
+++ b/app/routes/org/detail/projects/index.tsx
@@ -22,8 +22,10 @@ import {
   createProjectService,
   projectFormSchema,
   projectKeys,
+  isProjectDeleting,
   useCreateProject,
   useProjects,
+  useProjectsWatch,
   type Project,
   type ProjectList,
 } from '@/resources/projects';
@@ -111,6 +113,8 @@ function OrgProjectsInner({ loaderData }: { loaderData: LoaderData }) {
     }
   );
   const projects = queryData?.items ?? [];
+
+  useProjectsWatch(orgId);
 
   const navigate = useNavigate();
   const revalidator = useRevalidator();
@@ -330,9 +334,36 @@ function OrgProjectsInner({ loaderData }: { loaderData: LoaderData }) {
                   </div>
                 </div>
               )}
-              onSelect={(project) =>
-                navigate(getPathWithParams(paths.project.detail.root, { projectId: project.name }))
+              cardClassName={(project) =>
+                isProjectDeleting(project) ? 'cursor-default opacity-60 hover:bg-card' : undefined
               }
+              cardProps={(project) => {
+                if (isProjectDeleting(project)) {
+                  return {
+                    'aria-disabled': true,
+                    'aria-label': `${project.displayName} (deleting)`,
+                    tabIndex: -1,
+                  };
+                }
+
+                const projectDetailPath = getPathWithParams(paths.project.detail.root, {
+                  projectId: project.name,
+                });
+
+                return {
+                  role: 'button',
+                  tabIndex: 0,
+                  className:
+                    'cursor-pointer focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+                  onClick: () => navigate(projectDetailPath),
+                  onKeyDown: (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      navigate(projectDetailPath);
+                    }
+                  },
+                };
+              }}
             />
             <CardList.Empty
               title={canCreateProject ? "Let's create your first project!" : 'No projects yet'}

--- a/app/routes/org/detail/usage/index.tsx
+++ b/app/routes/org/detail/usage/index.tsx
@@ -7,7 +7,7 @@ import { toUsageView } from './usage.view';
 import { useOrgUsageDashboard } from '@/modules/billing/usage.queries';
 import { FeatureFlag } from '@/modules/feature-flags';
 import { isFeatureEnabled } from '@/modules/feature-flags/evaluate.server';
-import { useProjects } from '@/resources/projects';
+import { useProjects, filterActiveProjects } from '@/resources/projects';
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
 import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
 import { Card, CardContent } from '@datum-cloud/datum-ui/card';
@@ -113,7 +113,7 @@ export default function OrgUsagePage() {
 
   const projects: UsageProjectOption[] = useMemo(
     () =>
-      (projectsQuery.data?.items ?? []).map((project) => ({
+      filterActiveProjects(projectsQuery.data?.items ?? []).map((project) => ({
         name: project.name,
         displayName: project.displayName,
       })),

--- a/app/routes/project/detail/layout.tsx
+++ b/app/routes/project/detail/layout.tsx
@@ -23,7 +23,14 @@ import { createDomainService, domainKeys } from '@/resources/domains';
 import { createExportPolicyService, exportPolicyKeys } from '@/resources/export-policies';
 import { createHttpProxyService, httpProxyKeys } from '@/resources/http-proxies';
 import { useOrganization } from '@/resources/organizations';
-import { createProjectService, isProjectDeleting, isSelfDeleteNavigation, useProject, useProjectWatch, type Project } from '@/resources/projects';
+import {
+  createProjectService,
+  isProjectDeleting,
+  isSelfDeleteNavigation,
+  useProject,
+  useProjectWatch,
+  type Project,
+} from '@/resources/projects';
 import { createSecretService, secretKeys } from '@/resources/secrets';
 import { createServiceAccountService, serviceAccountKeys } from '@/resources/service-accounts';
 import { paths } from '@/utils/config/paths.config';

--- a/app/routes/project/detail/layout.tsx
+++ b/app/routes/project/detail/layout.tsx
@@ -23,7 +23,7 @@ import { createDomainService, domainKeys } from '@/resources/domains';
 import { createExportPolicyService, exportPolicyKeys } from '@/resources/export-policies';
 import { createHttpProxyService, httpProxyKeys } from '@/resources/http-proxies';
 import { useOrganization } from '@/resources/organizations';
-import { createProjectService, useProject, type Project } from '@/resources/projects';
+import { createProjectService, isProjectDeleting, isSelfDeleteNavigation, useProject, useProjectWatch, type Project } from '@/resources/projects';
 import { createSecretService, secretKeys } from '@/resources/secrets';
 import { createServiceAccountService, serviceAccountKeys } from '@/resources/service-accounts';
 import { paths } from '@/utils/config/paths.config';
@@ -297,6 +297,21 @@ export const loader = withMiddleware(
       paramName: 'projectId',
       notFoundLabel: 'Project',
       fetch: ({ id }) => createProjectService().get(id),
+      redirectIfDeleting: ({ data }) =>
+        data.deletionTimestamp
+          ? {
+              to: data.organizationId
+                ? getPathWithParams(paths.org.detail.projects.root, {
+                    orgId: data.organizationId,
+                  })
+                : paths.account.organizations.root,
+              toast: {
+                title: 'Project is being deleted',
+                description: 'This project is currently being deleted and is no longer accessible',
+                type: 'message',
+              },
+            }
+          : null,
       companions: {
         billingEnabled: {
           resource: 'projects',
@@ -420,6 +435,38 @@ function ProjectDetailLayoutContent({
     staleTime: QUERY_STALE_TIME,
     refetchOnMount: false,
   });
+
+  useProjectWatch(orgId, projectId ?? '', { enabled: !!orgId && !!projectId });
+
+  const deletingRedirectRef = useRef(false);
+
+  // Redirect when the project enters deletion while the user is still inside it
+  // (another tab/user deleted it; loader redirect only runs on entry).
+  useEffect(() => {
+    if (
+      !project ||
+      !projectId ||
+      !isProjectDeleting(project) ||
+      deletingRedirectRef.current ||
+      isSelfDeleteNavigation(projectId)
+    ) {
+      return;
+    }
+
+    deletingRedirectRef.current = true;
+
+    toast.message('Project is being deleted', {
+      description: 'This project is currently being deleted and is no longer accessible',
+    });
+
+    const redirectPath = project.organizationId
+      ? getPathWithParams(paths.org.detail.projects.root, { orgId: project.organizationId })
+      : appOrg?.name
+        ? getPathWithParams(paths.org.detail.projects.root, { orgId: appOrg.name })
+        : paths.account.organizations.root;
+
+    navigate(redirectPath);
+  }, [project, projectId, appOrg?.name, navigate]);
 
   // Redirect on error (invalid project, not found, etc.)
   useEffect(() => {


### PR DESCRIPTION
## Summary

Deleting a project is no longer instant. Milo keeps the project readable until child resources finish cleanup, but the portal hid those projects from the org list and gave no sign that deletion was in progress. 

This PR keeps deleting projects on the org list with a "Deleting" badge and spinner, disables navigation on those cards, and redirects anyone who opens a deleting project directly back to the org project list. Self-delete still navigates through the existing settings flow without an extra toast; the layout redirect covers deletes started elsewhere or in another tab.

Key behaviors:

- Deleting projects stay on the org list until the API removes them
- Cards show a spinner badge with a tooltip and cannot be clicked
- Deep links to a deleting project redirect to the org project list with a message
- List cache updates immediately after self-delete so the badge appears without a refresh
- Project switchers and pickers hide deleting projects

<img width="1624" height="1061" alt="Screenshot 2026-08-09 at 20 21 42" src="https://github.com/user-attachments/assets/591dfd8d-59c9-4a14-a3ea-2da9b82abddb" />

## Test plan

- [x] Unit tests pass for project adapter and helpers (`bun test app/resources/projects/project.adapter.test.ts app/resources/projects/project.helpers.test.ts`)
- [ ] Delete a project from settings and confirm redirect to org list with "Deleting" badge (no duplicate toast)
- [ ] Confirm deleting card is not clickable and disappears when cleanup finishes
- [ ] Open `/project/:id` for a deleting project and confirm redirect with toast
- [ ] Confirm deleting projects do not appear in project switcher or select-project

Closes #1419