### PR TITLE
fix(sentry): drop expected 4xx noise and surface real errors

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,5 +1,5 @@
 import { configureBrowserClient } from '@/modules/control-plane/setup.client';
-import { shouldDropSentryEvent } from '@/modules/sentry/filters';
+import { shouldDropSentryEventClient } from '@/modules/sentry/filters';
 import { env } from '@/utils/env';
 import * as Sentry from '@sentry/react-router';
 import { StrictMode, startTransition } from 'react';
@@ -58,18 +58,37 @@ Sentry.init({
   // Set `tracePropagationTargets` to declare which URL(s) should have trace propagation enabled
   tracePropagationTargets: [/^\//, new RegExp(window.location.origin)],
 
-  // Capture Replay for 50% of all sessions for proactive UX monitoring,
-  // plus 100% of sessions with an error
-  replaysSessionSampleRate: 0.5,
+  // Error-focused replay budget: 1% of ambient sessions for baseline UX
+  // signal, 100% of sessions that hit an error.
+  replaysSessionSampleRate: 0.01,
   replaysOnErrorSampleRate: 1.0,
 
   // Release name
   release: env.public.version || 'dev',
 
-  beforeSend: (event) => {
-    if (shouldDropSentryEvent(event)) return null;
-    return event;
-  },
+  // Browser noise that is never actionable. Hydration errors are
+  // intentionally NOT ignored — they are real bugs. Chunk-load errors are
+  // self-healed by the reload handler below in this file.
+  ignoreErrors: [
+    'ResizeObserver loop limit exceeded',
+    'ResizeObserver loop completed with undelivered notifications',
+    /AbortError/,
+    /Importing a module script failed/,
+    /Failed to fetch dynamically imported module/,
+  ],
+  denyUrls: [
+    /extensions\//,
+    /^chrome:\/\//,
+    /^chrome-extension:\/\//,
+    /^moz-extension:\/\//,
+    /^safari-(web-)?extension:\/\//,
+  ],
+
+  // Client policy: drop expected user-state 4xx AND network failures (user
+  // connectivity is not a bug). The server beforeSend
+  // (observability/providers/sentry.ts) uses the base filter, which keeps
+  // network failures — upstream connection errors are infra signals.
+  beforeSend: (event, hint) => (shouldDropSentryEventClient(event, hint) ? null : event),
 });
 
 // Global handler for chunk load failures (stale deployments).

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,6 +1,6 @@
 import { NonceProvider } from '@/hooks/useNonce';
+import { buildErrorFingerprint, isExpectedUserError, resolveErrorCode } from '@/modules/sentry';
 import { cspNonceContext } from '@/server/context';
-import { AppError, isUserFacingErrorStatus } from '@/utils/errors/app-error';
 import { createReadableStreamFromReadable } from '@react-router/node';
 import * as Sentry from '@sentry/react-router';
 import { isbot } from 'isbot';
@@ -71,9 +71,12 @@ async function handleRequest(
 export default Sentry.wrapSentryHandleRequest(handleRequest);
 
 // Export handleError for Sentry error capture.
-// Skip expected user-facing statuses (401/403/404) and aborted requests — these are
-// not bugs. Other 4xx codes (400/409/429/...) reaching this handler usually indicate
-// a code path that forgot to catch an error inline, so we still want them captured.
+// Skip aborted requests, and skip ANY error shape carrying an expected user-facing
+// status (401/403/404/429) — AppError, raw AxiosError from clients outside the
+// shared interceptors, or serialized objects with a numeric `status`. These are
+// expected user states, not bugs. Other 4xx codes (400/409/...) reaching this
+// handler usually indicate a code path that forgot to catch an error inline, so
+// we still want them captured.
 //
 // React Router's own `ErrorResponse`s (thrown by the router for things like a
 // POST to a route without an `action`, or a path that matches no routes) are
@@ -83,9 +86,15 @@ export default Sentry.wrapSentryHandleRequest(handleRequest);
 export const handleError: HandleErrorFunction = (error, { request }) => {
   if (request.signal.aborted) return;
 
-  if (error instanceof AppError && isUserFacingErrorStatus(error.status)) return;
+  if (isExpectedUserError(error)) return;
 
   if (isRouteErrorResponse(error) && error.status >= 400 && error.status < 500) return;
 
-  Sentry.captureException(error);
+  // Raw pathnames embed resource ids (unbounded tag cardinality), so the path
+  // travels as unindexed extra; the transaction already names the route.
+  Sentry.captureException(error, {
+    fingerprint: buildErrorFingerprint(error),
+    tags: { code: resolveErrorCode(error) },
+    extra: { path: new URL(request.url).pathname },
+  });
 };

--- a/app/features/edge/proxy/overview/config-card.tsx
+++ b/app/features/edge/proxy/overview/config-card.tsx
@@ -65,6 +65,7 @@ export const HttpProxyConfigCard = ({
   projectId,
   canViewWaf = true,
   wafPending = false,
+  wafUnavailable = false,
   wafProgrammed,
   wafProgrammedMessage,
   wafProgrammedReason,
@@ -73,6 +74,8 @@ export const HttpProxyConfigCard = ({
   projectId?: string;
   canViewWaf?: boolean;
   wafPending?: boolean;
+  /** WAF fetch failed for a reason other than permissions — show "—" without a verdict. */
+  wafUnavailable?: boolean;
   wafProgrammed?: boolean;
   wafProgrammedMessage?: string;
   wafProgrammedReason?: string;
@@ -180,6 +183,13 @@ export const HttpProxyConfigCard = ({
               &mdash;
             </Badge>
           </Tooltip>
+        ) : wafUnavailable ? (
+          <Badge
+            type="quaternary"
+            theme="outline"
+            className="text-muted-foreground rounded-xl text-xs font-normal">
+            &mdash;
+          </Badge>
         ) : (
           (() => {
             const { state, statusLabel, configLabel, statusTooltip } =
@@ -309,36 +319,44 @@ export const HttpProxyConfigCard = ({
             </Tooltip>
           </div>
         ),
-        content:
-          proxy.basicAuthEnabled === undefined ? (
-            <Skeleton className="h-5 w-24 rounded-md" />
-          ) : (
-            <div className="flex items-center gap-1.5">
-              <Badge type="quaternary" theme="outline" className="rounded-xl text-xs font-normal">
-                {proxy.basicAuthEnabled
-                  ? proxy.basicAuthUserCount
-                    ? `${proxy.basicAuthUserCount} user${proxy.basicAuthUserCount !== 1 ? 's' : ''}`
-                    : 'Enabled'
-                  : 'Disabled'}
-              </Badge>
-              {projectId && (
-                <PermissionGate
-                  resource="httpproxies"
-                  verb="patch"
-                  group="networking.datumapis.com"
-                  scope="project"
-                  mode="disable"
-                  deniedReason="You don't have permission to edit this Application Load Balancer">
-                  <button
-                    type="button"
-                    className="text-muted-foreground hover:text-foreground transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                    onClick={() => basicAuthDialogRef.current?.show(proxy)}>
-                    <Icon icon={PencilIcon} size={12} />
-                  </button>
-                </PermissionGate>
-              )}
-            </div>
-          ),
+        content: proxy.basicAuthForbidden ? (
+          <Tooltip message="You don't have permission to view Basic Authentication" side="bottom">
+            <Badge
+              type="quaternary"
+              theme="outline"
+              className="text-muted-foreground rounded-xl text-xs font-normal">
+              &mdash;
+            </Badge>
+          </Tooltip>
+        ) : proxy.basicAuthEnabled === undefined ? (
+          <Skeleton className="h-5 w-24 rounded-md" />
+        ) : (
+          <div className="flex items-center gap-1.5">
+            <Badge type="quaternary" theme="outline" className="rounded-xl text-xs font-normal">
+              {proxy.basicAuthEnabled
+                ? proxy.basicAuthUserCount
+                  ? `${proxy.basicAuthUserCount} user${proxy.basicAuthUserCount !== 1 ? 's' : ''}`
+                  : 'Enabled'
+                : 'Disabled'}
+            </Badge>
+            {projectId && (
+              <PermissionGate
+                resource="httpproxies"
+                verb="patch"
+                group="networking.datumapis.com"
+                scope="project"
+                mode="disable"
+                deniedReason="You don't have permission to edit this Application Load Balancer">
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-foreground transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                  onClick={() => basicAuthDialogRef.current?.show(proxy)}>
+                  <Icon icon={PencilIcon} size={12} />
+                </button>
+              </PermissionGate>
+            )}
+          </div>
+        ),
       },
     ];
   }, [
@@ -347,6 +365,7 @@ export const HttpProxyConfigCard = ({
     updateMutation,
     canViewWaf,
     wafPending,
+    wafUnavailable,
     wafProgrammed,
     wafProgrammedMessage,
     wafProgrammedReason,

--- a/app/modules/auth/strategies/zitadel.server.ts
+++ b/app/modules/auth/strategies/zitadel.server.ts
@@ -3,44 +3,87 @@ import { paths } from '@/utils/config/paths.config';
 import { env } from '@/utils/env/env.server';
 import { AuthenticationError } from '@/utils/errors';
 import { OAuth2Strategy as OAuth2 } from 'remix-auth-oauth2';
+import { Strategy } from 'remix-auth/strategy';
 
 export const zitadelIssuer = env.public.authOidcIssuer ?? 'http://localhost:3000';
 
+const verifySession: Strategy.VerifyFunction<IAuthSession, OAuth2.VerifyOptions> = async ({
+  tokens,
+}) => {
+  try {
+    if (!tokens.idToken()) {
+      throw new AuthenticationError('No id_token in response');
+    }
+
+    if (!tokens.accessToken()) {
+      throw new AuthenticationError('No access_token in response');
+    }
+
+    return {
+      idToken: tokens.idToken(),
+      accessToken: tokens.accessToken(),
+      refreshToken: tokens.hasRefreshToken() ? tokens.refreshToken() : null,
+      expiredAt: tokens.accessTokenExpiresAt(),
+    };
+  } catch (error) {
+    throw new AuthenticationError(
+      error instanceof Error ? error.message : 'Failed to fetch user profile'
+    );
+  }
+};
+
+let discovery: Promise<OAuth2<IAuthSession>> | null = null;
+
 /**
  * https://github.com/sergiodxa/remix-auth-oauth2?tab=readme-ov-file#discovering-the-provider
- * This will fetch the provider's configuration endpoint (/.well-known/openid-configuration)
- * and grab the authorization, token and revocation endpoints from it,
- * it will also grab the code challenge method supported and try to use S256 if it is supported.
- * Remember this will do a fetch when then strategy is created, this will add a latency to the startup of your application. */
-export const zitadelStrategy = await OAuth2.discover<IAuthSession>(
-  zitadelIssuer,
-  {
-    clientId: env.server.authOidcClientId ?? '',
-    clientSecret: '',
-    redirectURI: `${env.public.appUrl ?? 'http://localhost:3000'}${paths.auth.callback}`,
-    scopes: ['openid', 'profile', 'email', 'phone', 'address', 'offline_access'],
-    // codeChallengeMethod: CodeChallengeMethod.S256,
-  },
-  async ({ tokens }) => {
-    try {
-      if (!tokens.idToken()) {
-        throw new AuthenticationError('No id_token in response');
-      }
+ * Discovery fetches `${issuer}/.well-known/openid-configuration` to resolve the
+ * authorization/token/revocation endpoints. It runs lazily on the first strategy call —
+ * NOT at module import — so importing auth modules stays side-effect free (unit tests
+ * load AuthService without a reachable IdP). A failed discovery is not cached, so the
+ * next call retries instead of pinning the error.
+ */
+function discoverZitadelStrategy(): Promise<OAuth2<IAuthSession>> {
+  discovery ??= OAuth2.discover<IAuthSession>(
+    zitadelIssuer,
+    {
+      clientId: env.server.authOidcClientId ?? '',
+      clientSecret: '',
+      redirectURI: `${env.public.appUrl ?? 'http://localhost:3000'}${paths.auth.callback}`,
+      scopes: ['openid', 'profile', 'email', 'phone', 'address', 'offline_access'],
+      // codeChallengeMethod: CodeChallengeMethod.S256,
+    },
+    verifySession
+  ).catch((error: unknown) => {
+    discovery = null;
+    // A down/unreachable IdP is a login failure, not a server bug: surface a
+    // 401 so the user sees an auth failure instead of a 500, and keep the
+    // failure out of Sentry (AuthenticationError captures nothing).
+    throw new AuthenticationError(
+      error instanceof Error ? error.message : 'Failed to discover OIDC strategy'
+    );
+  });
+  return discovery;
+}
 
-      if (!tokens.accessToken()) {
-        throw new AuthenticationError('No access_token in response');
-      }
+type ZitadelTokens = Awaited<ReturnType<OAuth2<IAuthSession>['refreshToken']>>;
 
-      // Get User
+class LazyZitadelStrategy extends Strategy<IAuthSession, OAuth2.VerifyOptions> {
+  name = 'zitadel';
 
-      return {
-        idToken: tokens.idToken(),
-        accessToken: tokens.accessToken(),
-        refreshToken: tokens.hasRefreshToken() ? tokens.refreshToken() : null,
-        expiredAt: tokens.accessTokenExpiresAt(),
-      };
-    } catch (error: any) {
-      throw new AuthenticationError(error?.message ?? 'Failed to fetch user profile');
-    }
+  async authenticate(request: Request): Promise<IAuthSession> {
+    const strategy = await discoverZitadelStrategy();
+    return strategy.authenticate(request);
   }
-);
+
+  async refreshToken(refreshToken: string): Promise<ZitadelTokens> {
+    const strategy = await discoverZitadelStrategy();
+    return strategy.refreshToken(refreshToken);
+  }
+
+  async revokeToken(token: string): Promise<void> {
+    const strategy = await discoverZitadelStrategy();
+    return strategy.revokeToken(token);
+  }
+}
+
+export const zitadelStrategy = new LazyZitadelStrategy(verifySession);

--- a/app/modules/axios/axios.client.ts
+++ b/app/modules/axios/axios.client.ts
@@ -5,7 +5,7 @@ import {
   clearSentryResourceContext,
   captureApiError,
 } from '@/modules/sentry';
-import { AppError } from '@/utils/errors/app-error';
+import { AppError, isUserFacingErrorStatus } from '@/utils/errors/app-error';
 import * as Sentry from '@sentry/react-router';
 import Axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
@@ -105,6 +105,8 @@ interface SerializedAppError {
   status: number;
   details?: Array<{ path: string[]; message: string; code?: string }>;
   requestId?: string;
+  /** Owned by a server-side capture (see AppError); presence means skip client re-capture. */
+  sentryEventId?: string;
 }
 
 function isSerializedAppError(data: unknown): data is SerializedAppError {
@@ -138,6 +140,7 @@ function appErrorFromSerialized(data: SerializedAppError, cause: AxiosError): Ap
     status: data.status,
     details: data.details,
     requestId: data.requestId,
+    sentryEventId: data.sentryEventId,
     cause,
     captureToSentry: false,
   });
@@ -173,15 +176,25 @@ const onResponseError = (error: AxiosError): Promise<never> => {
       ? appErrorFromSerialized(responseData, error)
       : appErrorFromRaw(error, httpStatus);
 
-  // Capture to Sentry
-  captureApiError({
-    error,
-    method: error.config?.method,
-    url: error.config?.url,
-    status: error.response?.status ?? 'network',
-    message: appError.originalMessage ?? appError.message,
-    requestId: appError.requestId,
-  });
+  // Capture only unexpected failures. Expected user-facing statuses
+  // (401/403/404/429) and no-response network failures (user connectivity)
+  // are skipped — API breadcrumbs still give context to the next real error.
+  // A serialized AppError carrying a server-captured `sentryEventId` also
+  // skips the client capture — the event already exists server-side.
+  if (
+    error.response &&
+    !isUserFacingErrorStatus(error.response.status) &&
+    !appError.sentryEventId
+  ) {
+    captureApiError({
+      error,
+      method: error.config?.method,
+      url: error.config?.url,
+      status: error.response.status,
+      message: appError.originalMessage ?? appError.message,
+      requestId: appError.requestId,
+    });
+  }
 
   return Promise.reject(appError);
 };

--- a/app/modules/axios/axios.server.ts
+++ b/app/modules/axios/axios.server.ts
@@ -1,5 +1,5 @@
-import { isK8sStatus, parseK8sStatusError } from './k8s-error';
 import { getRequestContext } from './request-context';
+import { createUpstreamErrorHandler } from './upstream-error.server';
 import { logger } from '@/modules/logger';
 import { generateCurl } from '@/modules/logger/curl.generator';
 import { LOGGER_CONFIG } from '@/modules/logger/logger.config';
@@ -7,17 +7,9 @@ import {
   isKubernetesResource,
   setSentryResourceContext,
   clearSentryResourceContext,
-  captureApiError,
 } from '@/modules/sentry';
+import { recordUpstreamResponse } from '@/server/observability/upstream-metrics';
 import { env } from '@/utils/env/env.server';
-import {
-  AppError,
-  AuthenticationError,
-  AuthorizationError,
-  isUserFacingErrorStatus,
-  NotFoundError,
-  ValidationError,
-} from '@/utils/errors';
 import Axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 /**
@@ -117,24 +109,21 @@ const onResponse = (response: AxiosResponse): AxiosResponse => {
     setSentryResourceContext(response.data);
   }
 
+  recordUpstreamResponse({
+    method: config?.method,
+    url: config?.url,
+    status: response.status,
+  });
+
   return response;
 };
 
-/** Extract a fallback message from non-K8s response data. */
-function resolveRawMessage(data: unknown, error: AxiosError): string {
-  if (typeof data === 'object' && data !== null) {
-    const obj = data as Record<string, unknown>;
-    if (typeof obj.message === 'string') return obj.message;
-    if (typeof obj.reason === 'string') return obj.reason;
-    if (typeof obj.error === 'string') return obj.error;
-  }
-  return error.message;
-}
+// Shared transform: metrics counting, K8s Status parsing, Sentry capture
+// policy, typed AppError mapping (see upstream-error.server.ts).
+const transformUpstreamError = createUpstreamErrorHandler();
 
 const onResponseError = (error: AxiosError): Promise<never> => {
   const config = error.config as any;
-  const ctx = getRequestContext();
-  const requestId = ctx?.requestId;
 
   // Log API errors if enabled
   if (LOGGER_CONFIG.logApiCalls) {
@@ -151,84 +140,7 @@ const onResponseError = (error: AxiosError): Promise<never> => {
     });
   }
 
-  const responseData = error.response?.data;
-  const httpStatus = error.response?.status ?? 500;
-
-  // Parse K8s Status for user-friendly message
-  const parsed = isK8sStatus(responseData) ? parseK8sStatusError(responseData, httpStatus) : null;
-
-  const message = parsed?.message ?? resolveRawMessage(responseData, error);
-
-  // Capture API error to Sentry with resource context and fingerprinting.
-  // Skip expected user-facing statuses (401/403/404) — these are not bugs and
-  // are surfaced to the user via the route error boundary.
-  if (!isUserFacingErrorStatus(httpStatus)) {
-    captureApiError({
-      error,
-      method: config?.method,
-      url: config?.url,
-      status: httpStatus,
-      message: parsed?.originalMessage ?? message,
-      requestId,
-    });
-  }
-
-  switch (httpStatus) {
-    case 401: {
-      const data = responseData as { error?: string; error_description?: string } | undefined;
-      if (data?.error === 'access_denied' && data?.error_description === 'access token invalid') {
-        throw new AuthenticationError('Session expired', requestId);
-      }
-      throw new AuthenticationError(message || 'Authentication required', requestId);
-    }
-    case 403: {
-      // K8s Status: keep originalMessage/k8sReason/k8sDetails so quota 403s
-      // remain classifiable (parity with the client interceptor), while
-      // preserving AuthorizationError identity — many callers branch on
-      // `instanceof AuthorizationError` (fraud retry, onboarding loaders,
-      // fan-out skipping, billing degradation).
-      if (parsed) {
-        throw new AuthorizationError(message, requestId, {
-          code: parsed.code,
-          details: parsed.details,
-          originalMessage: parsed.originalMessage,
-          k8sReason: parsed.k8sReason,
-          k8sDetails: parsed.k8sDetails,
-        });
-      }
-      throw new AuthorizationError(message || 'Permission denied', requestId);
-    }
-    case 404: {
-      // K8s Status: use AppError with parsed message (e.g., 'DNS Zone "example" not found')
-      // Non-K8s: NotFoundError constructs "Resource not found" from scratch
-      if (parsed) {
-        throw new AppError(message, {
-          code: parsed.code,
-          status: 404,
-          requestId,
-          originalMessage: parsed.originalMessage,
-          k8sReason: parsed.k8sReason,
-          k8sDetails: parsed.k8sDetails,
-          captureToSentry: false,
-        });
-      }
-      throw new NotFoundError('Resource', undefined, requestId);
-    }
-    case 422: {
-      throw new ValidationError(message || 'Validation failed', parsed?.details, requestId);
-    }
-    default: {
-      throw new AppError(message || 'An unexpected error occurred', {
-        code: parsed?.code,
-        status: httpStatus,
-        requestId,
-        originalMessage: parsed?.originalMessage,
-        k8sReason: parsed?.k8sReason,
-        k8sDetails: parsed?.k8sDetails,
-        details: parsed?.details,
-      });
-    }
-  }
+  return transformUpstreamError(error);
 };
 
 http.interceptors.request.use(onRequest, onRequestError);

--- a/app/modules/axios/upstream-error-bridge.ts
+++ b/app/modules/axios/upstream-error-bridge.ts
@@ -1,0 +1,33 @@
+import { AppError } from '@/utils/errors/app-error';
+import { isAxiosError, type AxiosInstance } from 'axios';
+
+/**
+ * globalThis key where upstream-error.server.ts registers
+ * `attachUpstreamErrorHandling`. Modules that are part of the client bundle
+ * graph (the prometheus and cloudvalid barrels are imported by client
+ * components) cannot import a `.server` module directly, so they reach the
+ * server implementation through this hook — same pattern as
+ * `__axios_server_http__` and `__request_context_store__`.
+ */
+export const UPSTREAM_ERROR_ATTACH_KEY = '__attach_upstream_error_handling__';
+
+/**
+ * Attach the shared upstream error handling when the server runtime has
+ * registered it. No-op in the browser, where the hook is never registered.
+ */
+export function attachUpstreamErrorHandlingIfAvailable(instance: AxiosInstance): void {
+  const attach = (globalThis as Record<string, unknown>)[UPSTREAM_ERROR_ATTACH_KEY];
+  if (typeof attach === 'function') {
+    (attach as (target: AxiosInstance) => void)(instance);
+  }
+}
+
+/**
+ * The shared upstream handler throws typed AppErrors carrying the original
+ * AxiosError as `cause`. Instance-specific transforms (PrometheusError,
+ * CloudValidError) unwrap it so their own error contracts keep operating on
+ * the raw axios failure (status, response body, timeout code).
+ */
+export function unwrapUpstreamError(error: unknown): unknown {
+  return error instanceof AppError && isAxiosError(error.cause) ? error.cause : error;
+}

--- a/app/modules/axios/upstream-error.server.ts
+++ b/app/modules/axios/upstream-error.server.ts
@@ -1,0 +1,190 @@
+import { isK8sStatus, parseK8sStatusError } from './k8s-error';
+import { getRequestContext } from './request-context';
+import { UPSTREAM_ERROR_ATTACH_KEY } from './upstream-error-bridge';
+import { captureApiError } from '@/modules/sentry';
+import { recordUpstreamResponse } from '@/server/observability/upstream-metrics';
+import {
+  AppError,
+  AuthenticationError,
+  AuthorizationError,
+  isUserFacingErrorStatus,
+  NotFoundError,
+  ValidationError,
+} from '@/utils/errors';
+import { isAxiosError, type AxiosError, type AxiosInstance, type AxiosResponse } from 'axios';
+
+/** Extract a fallback message from non-K8s response data. */
+function resolveRawMessage(data: unknown, error: AxiosError): string {
+  if (typeof data === 'object' && data !== null) {
+    const obj = data as Record<string, unknown>;
+    if (typeof obj.message === 'string') return obj.message;
+    if (typeof obj.reason === 'string') return obj.reason;
+    if (typeof obj.error === 'string') return obj.error;
+  }
+  return error.message;
+}
+
+/**
+ * The typed-error subclass constructors don't accept `cause`; attach the
+ * original AxiosError so instance-specific wrappers (prometheus, cloudvalid)
+ * can recover it via `unwrapUpstreamError`.
+ */
+function withCause<T extends Error>(err: T, cause: unknown): T {
+  err.cause = cause;
+  return err;
+}
+
+export type UpstreamErrorHandler = (error: unknown) => Promise<never>;
+
+/**
+ * Shared response-error transform for every server-side axios instance —
+ * the single implementation of the upstream error policy:
+ *
+ * - counts the outcome in `portal_upstream_responses_total` (no-response
+ *   network failures under status="network", never a fabricated "500")
+ * - parses K8s Status bodies into user-friendly messages (degrades to the
+ *   raw body message for non-K8s upstreams)
+ * - captures unexpected statuses to Sentry via `captureApiError`; expected
+ *   user-facing statuses (401/403/404/429) are never captured
+ * - rethrows as typed AppErrors so raw AxiosErrors never escape
+ *
+ * Rejections that are not AxiosErrors (already transformed by an earlier
+ * interceptor) pass through untouched.
+ */
+export function createUpstreamErrorHandler(): UpstreamErrorHandler {
+  return async (error: unknown): Promise<never> => {
+    if (!isAxiosError(error)) throw error;
+
+    const requestId = getRequestContext()?.requestId;
+    const method = error.config?.method;
+    const url = error.config?.url;
+
+    const responseData: unknown = error.response?.data;
+    const httpStatus = error.response?.status ?? 500;
+
+    // No-response failures (timeout/DNS/refused) are not upstream responses:
+    // label them "network" so they never masquerade as real upstream 500s in
+    // portal_upstream_responses_total.
+    recordUpstreamResponse({ method, url, status: error.response ? httpStatus : 'network' });
+
+    // Parse K8s Status for user-friendly message
+    const parsed = isK8sStatus(responseData) ? parseK8sStatusError(responseData, httpStatus) : null;
+
+    const message = parsed?.message ?? resolveRawMessage(responseData, error);
+
+    // Capture API error to Sentry with resource context and fingerprinting.
+    // Skip expected user-facing statuses (401/403/404/429) — these are not
+    // bugs and are surfaced to the user via the route error boundary.
+    // The returned event id is threaded into the rethrown AppError so the
+    // client-side interceptor can skip a duplicate capture (one canonical
+    // Sentry event per server-side failure).
+    let sentryEventId: string | undefined;
+    if (!isUserFacingErrorStatus(httpStatus)) {
+      sentryEventId = captureApiError({
+        error,
+        method,
+        url,
+        status: httpStatus,
+        message: parsed?.originalMessage ?? message,
+        requestId,
+      });
+    }
+
+    switch (httpStatus) {
+      case 401: {
+        const data = responseData as { error?: string; error_description?: string } | undefined;
+        if (data?.error === 'access_denied' && data?.error_description === 'access token invalid') {
+          throw withCause(new AuthenticationError('Session expired', requestId), error);
+        }
+        throw withCause(
+          new AuthenticationError(message || 'Authentication required', requestId),
+          error
+        );
+      }
+      case 403: {
+        // K8s Status: keep originalMessage/k8sReason/k8sDetails so quota 403s
+        // remain classifiable (parity with the client interceptor), while
+        // preserving AuthorizationError identity — many callers branch on
+        // `instanceof AuthorizationError` (fraud retry, onboarding loaders,
+        // fan-out skipping, billing degradation).
+        if (parsed) {
+          throw withCause(
+            new AuthorizationError(message, requestId, {
+              code: parsed.code,
+              details: parsed.details,
+              originalMessage: parsed.originalMessage,
+              k8sReason: parsed.k8sReason,
+              k8sDetails: parsed.k8sDetails,
+            }),
+            error
+          );
+        }
+        throw withCause(new AuthorizationError(message || 'Permission denied', requestId), error);
+      }
+      case 404: {
+        // K8s Status: use AppError with parsed message (e.g., 'DNS Zone "example" not found')
+        // Non-K8s: NotFoundError constructs "Resource not found" from scratch
+        if (parsed) {
+          throw new AppError(message, {
+            code: parsed.code,
+            status: 404,
+            requestId,
+            cause: error,
+            originalMessage: parsed.originalMessage,
+            k8sReason: parsed.k8sReason,
+            k8sDetails: parsed.k8sDetails,
+            captureToSentry: false,
+          });
+        }
+        throw withCause(new NotFoundError('Resource', undefined, requestId), error);
+      }
+      case 422: {
+        throw withCause(
+          new ValidationError(message || 'Validation failed', parsed?.details, requestId),
+          error
+        );
+      }
+      default: {
+        // captureApiError above already owns the Sentry event (with resource
+        // fingerprinting); letting AppError auto-capture on >=500 would send
+        // a duplicate for every server 5xx / network failure.
+        throw new AppError(message || 'An unexpected error occurred', {
+          code: parsed?.code,
+          status: httpStatus,
+          requestId,
+          cause: error,
+          originalMessage: parsed?.originalMessage,
+          k8sReason: parsed?.k8sReason,
+          k8sDetails: parsed?.k8sDetails,
+          details: parsed?.details,
+          captureToSentry: false,
+          sentryEventId,
+        });
+      }
+    }
+  };
+}
+
+/**
+ * Attach shared upstream response accounting + error typing to an axios
+ * instance. Register this BEFORE any instance-specific interceptor so the
+ * handler observes the raw AxiosError; downstream transforms can recover the
+ * original failure with `unwrapUpstreamError`.
+ */
+export function attachUpstreamErrorHandling(instance: AxiosInstance): void {
+  instance.interceptors.response.use((response: AxiosResponse): AxiosResponse => {
+    recordUpstreamResponse({
+      method: response.config?.method,
+      url: response.config?.url,
+      status: response.status,
+    });
+    return response;
+  }, createUpstreamErrorHandler());
+}
+
+// Client-bundled modules (prometheus/cloudvalid clients) attach through this
+// globalThis hook because they cannot import a .server module. Registered at
+// module load — axios.server.ts imports this file and is itself loaded at
+// server startup (entry.ts → control-plane setup.server), so the hook exists
+// before any request-scoped client is created.
+(globalThis as Record<string, unknown>)[UPSTREAM_ERROR_ATTACH_KEY] = attachUpstreamErrorHandling;

--- a/app/modules/cloudvalid/client.ts
+++ b/app/modules/cloudvalid/client.ts
@@ -1,6 +1,10 @@
 /**
  * CloudValid HTTP Client
  */
+import {
+  attachUpstreamErrorHandlingIfAvailable,
+  unwrapUpstreamError,
+} from '@/modules/axios/upstream-error-bridge';
 import axios, { type AxiosInstance, type AxiosError } from 'axios';
 
 interface CloudValidErrorResponse {
@@ -38,11 +42,17 @@ export class CloudValidClient {
       },
     });
 
+    // Shared upstream accounting + typed AppError transform (server runtime
+    // only; no-op in the browser). Attached FIRST so it observes the raw
+    // AxiosError; handleError below unwraps the original failure to keep the
+    // CloudValidError contract for existing callers.
+    attachUpstreamErrorHandlingIfAvailable(this.client);
+
     // Add response interceptor for error handling
     this.client.interceptors.response.use(
       (response) => response,
-      (error: AxiosError<CloudValidErrorResponse>) => {
-        throw this.handleError(error);
+      (error: unknown) => {
+        throw this.handleError(unwrapUpstreamError(error) as AxiosError<CloudValidErrorResponse>);
       }
     );
   }

--- a/app/modules/logger/logger.ts
+++ b/app/modules/logger/logger.ts
@@ -9,7 +9,7 @@ import type {
   ApiLogData,
   ServiceLogData,
 } from './logger.types';
-import { addBreadcrumb, captureError, setTag } from '@/modules/sentry';
+import { addBreadcrumb, captureError, isExpectedUserError, setTag } from '@/modules/sentry';
 
 const LOG_LEVELS: Record<LogLevel, number> = {
   debug: 0,
@@ -87,6 +87,13 @@ export class Logger {
       this.log('error', message, { ...error, ...data });
       errorToCapture = new Error(message);
     }
+
+    // Expected user-state errors (401/403/404/429) are dropped from Sentry at
+    // every capture site by policy; entering them here (e.g. via apiError for
+    // each failed upstream call) would only be rescued by the beforeSend
+    // backstop and drown its leak detection. Console/breadcrumb logging above
+    // is unaffected.
+    if (isExpectedUserError(error)) return;
 
     captureError(errorToCapture, { message, extra: { ...this.context, ...data } });
   }

--- a/app/modules/prometheus/README.md
+++ b/app/modules/prometheus/README.md
@@ -41,13 +41,15 @@ This library can be used in two primary ways:
 
 ### 1. Direct Library Usage (Server-Side)
 
-Use the `prometheusService` singleton for direct access to the Prometheus API.
+Use `getPrometheusService()` for direct access to the Prometheus API (the
+singleton is created lazily on first use).
 
 #### Querying for Charts
 
 ```typescript
-import { prometheusService } from '@/modules/prometheus';
+import { getPrometheusService } from '@/modules/prometheus';
 
+const prometheusService = getPrometheusService();
 const chartData = await prometheusService.queryForChart({
   query: 'rate(http_requests_total[5m])',
   timeRange: {
@@ -61,8 +63,9 @@ const chartData = await prometheusService.queryForChart({
 #### Querying for Cards
 
 ```typescript
-import { prometheusService } from '@/modules/prometheus';
+import { getPrometheusService } from '@/modules/prometheus';
 
+const prometheusService = getPrometheusService();
 const cardData = await prometheusService.queryForCard({
   query: 'avg(cpu_usage_percent)',
   format: 'percentage',
@@ -80,6 +83,7 @@ const query = new PrometheusQueryBuilder()
   .sumBy(['path', 'status_code'])
   .build(); // "sum(rate(http_requests_total[5m])) by (path, status_code)"
 
+const prometheusService = getPrometheusService();
 const result = await prometheusService.queryInstant({ query });
 ```
 
@@ -93,7 +97,9 @@ This route uses `prometheusService` to securely query the backend and exposes th
 
 ```typescript
 // Example API Route
-import { prometheusService } from '@/modules/prometheus';
+import { getPrometheusService } from '@/modules/prometheus';
+
+const prometheusService = getPrometheusService();
 
 export async function action({ request }: ActionFunctionArgs) {
   const body = await request.json();
@@ -152,14 +158,17 @@ export function MetricChart({ query, timeRange }) {
 
 This section provides more detailed examples for the core functionalities of the library.
 
-### Using `prometheusService`
+### Using `getPrometheusService`
 
-The `prometheusService` is the workhorse for direct, server-side interactions.
+`getPrometheusService()` returns the shared service instance (created lazily on
+first access) for direct, server-side interactions.
 
 #### Example: Checking the status of multiple jobs
 
 ```typescript
-import { prometheusService } from '@/modules/prometheus';
+import { getPrometheusService } from '@/modules/prometheus';
+
+const prometheusService = getPrometheusService();
 
 async function checkJobStatuses() {
   try {
@@ -246,7 +255,7 @@ const userApiLatencyQuery = getLatencyQueryForPath('/api/users');
 
 Key exports from this standalone library:
 
-- `prometheusService`: Singleton service for all query operations.
+- `getPrometheusService`: Lazily-initialized singleton accessor for all query operations.
 - `PrometheusService`: Class for creating custom service instances.
 - `PrometheusQueryBuilder`: Fluent API for building PromQL queries.
 - `usePrometheusQuery`: Core TanStack Query hook for direct client-side queries.

--- a/app/modules/prometheus/client.ts
+++ b/app/modules/prometheus/client.ts
@@ -9,9 +9,13 @@ import type {
   PrometheusInstantResponse,
   PrometheusRangeResponse,
 } from './types';
+import {
+  attachUpstreamErrorHandlingIfAvailable,
+  unwrapUpstreamError,
+} from '@/modules/axios/upstream-error-bridge';
 import { logger } from '@/modules/logger';
 import { isDev } from '@/utils/env';
-import axios, { type AxiosInstance, type AxiosResponse } from 'axios';
+import axios, { isAxiosError, type AxiosInstance, type AxiosResponse } from 'axios';
 
 export const PROMETHEUS_CONFIG: PrometheusConfig = {
   baseURL: '',
@@ -38,6 +42,12 @@ export function createPrometheusClient(config?: Partial<PrometheusConfig>): Axio
       ...mergedConfig.headers, // Merge custom headers from config
     },
   });
+
+  // Shared upstream accounting + typed AppError transform (server runtime
+  // only; no-op in the browser). Attached FIRST so it observes the raw
+  // AxiosError; the transform below unwraps the original failure to keep the
+  // PrometheusError contract for existing callers.
+  attachUpstreamErrorHandlingIfAvailable(client);
 
   // Request interceptor for logging
   client.interceptors.request.use(
@@ -67,34 +77,41 @@ export function createPrometheusClient(config?: Partial<PrometheusConfig>): Axio
     (response: AxiosResponse) => {
       return response;
     },
-    (error) => {
+    (error: unknown) => {
+      const original = unwrapUpstreamError(error);
+      const axiosOriginal = isAxiosError(original) ? original : undefined;
+      const responseData = axiosOriginal?.response?.data as
+        | { error?: string; errorType?: string }
+        | undefined;
+
       logger.error(
         'Prometheus response error',
-        error instanceof Error ? error : new Error(String(error)),
+        original instanceof Error ? original : new Error(String(original)),
         {
-          status: error.response?.status,
-          statusText: error.response?.statusText,
-          errorType: error.response?.data?.errorType,
+          status: axiosOriginal?.response?.status,
+          statusText: axiosOriginal?.response?.statusText,
+          errorType: responseData?.errorType,
         }
       );
 
-      if (error.response) {
+      if (axiosOriginal?.response) {
         // Server responded with error status
-        const { status, data } = error.response;
         throw PrometheusError.network(
-          data?.error || `HTTP ${status} error`,
-          status,
-          data?.errorType
+          responseData?.error || `HTTP ${axiosOriginal.response.status} error`,
+          axiosOriginal.response.status,
+          responseData?.errorType
         );
-      } else if (error.request) {
+      } else if (axiosOriginal?.request) {
         // Request was made but no response received
-        if (error.code === 'ECONNABORTED') {
+        if (axiosOriginal.code === 'ECONNABORTED') {
           throw PrometheusError.timeout('Request timeout');
         }
         throw PrometheusError.network('Network error - no response received');
       } else {
         // Something else happened
-        throw PrometheusError.unknown(error.message);
+        throw PrometheusError.unknown(
+          original instanceof Error ? original.message : String(original)
+        );
       }
     }
   );

--- a/app/modules/prometheus/index.ts
+++ b/app/modules/prometheus/index.ts
@@ -58,4 +58,4 @@ export { PrometheusQueryBuilder, PromQLUtils } from './query-builder';
 export { formatForChart, formatForCard, formatValue, transformForRecharts } from './formatter';
 
 // Main service
-export { PrometheusService, prometheusService } from './service';
+export { PrometheusService, getPrometheusService } from './service';

--- a/app/modules/prometheus/service.ts
+++ b/app/modules/prometheus/service.ts
@@ -232,6 +232,16 @@ export class PrometheusService {
 }
 
 /**
- * Default Prometheus service instance
+ * Default Prometheus service instance, created lazily on first access.
+ *
+ * Eagerly constructing the singleton at module load would spin up the
+ * axios/OTEL wiring the moment the prometheus module is imported — even for
+ * code paths that never query Prometheus. Deferring creation keeps imports
+ * side-effect-free and avoids ordering surprises at server bootstrap.
  */
-export const prometheusService = new PrometheusService();
+let prometheusServiceInstance: PrometheusService | undefined;
+
+export function getPrometheusService(): PrometheusService {
+  prometheusServiceInstance ??= new PrometheusService();
+  return prometheusServiceInstance;
+}

--- a/app/modules/rbac/hooks/project-scope-guard.ts
+++ b/app/modules/rbac/hooks/project-scope-guard.ts
@@ -1,0 +1,22 @@
+import type { PermissionCheckScope } from '../types';
+
+/**
+ * True when a check batch contains a project-scoped check but no projectId has
+ * resolved yet.
+ *
+ * RbacContext receives org/project identifiers asynchronously: AppProvider
+ * populates them from layout effects after first commit (see
+ * app/layouts/private.layout.tsx, RbacAppWrapper). On first project-page load
+ * and on org→project navigations there is a window where organizationId is
+ * already set while projectId is still undefined. A project-scoped
+ * SelfSubjectAccessReview fired in that window is guaranteed to violate the
+ * server-side `projectId` invariant (RbacService.resolveBaseURL), so callers
+ * must keep the query disabled — fail-closed, still loading — until the
+ * project context resolves.
+ */
+export function hasUnresolvedProjectScope(
+  checks: ReadonlyArray<{ scope?: PermissionCheckScope }>,
+  projectId: string | undefined
+): boolean {
+  return !projectId && checks.some((check) => check.scope === 'project');
+}

--- a/app/modules/rbac/hooks/useCheckQuery.ts
+++ b/app/modules/rbac/hooks/useCheckQuery.ts
@@ -1,6 +1,8 @@
 import { checkPermissionAPI } from '../client/rbac-api';
 import type { PermissionCheckScope, PermissionVerb } from '../types';
+import { hasUnresolvedProjectScope } from './project-scope-guard';
 import { usePermissions } from './usePermissions';
+import { shouldRetryQuery } from '@/modules/tanstack/query';
 import { useQuery } from '@tanstack/react-query';
 
 const STALE_TIME = 5 * 60 * 1000; // 5 minutes
@@ -72,10 +74,13 @@ export function useCheckQuery(params: CheckQueryParams) {
         projectId,
       });
     },
-    enabled: enabled && !!organizationId,
+    // Same guard as usePermissionCheck: a project-scoped check without a
+    // resolved projectId would violate the server-side invariant — stay
+    // disabled until the project context lands (projectId is in the queryKey).
+    enabled: enabled && !!organizationId && !hasUnresolvedProjectScope([{ scope }], projectId),
     staleTime,
     refetchOnMount,
-    retry: 1,
+    retry: shouldRetryQuery,
   });
 
   return query;

--- a/app/modules/rbac/hooks/usePermissionCheck.ts
+++ b/app/modules/rbac/hooks/usePermissionCheck.ts
@@ -1,6 +1,7 @@
-import { checkPermissionsBulkAPI } from '../client/rbac-api';
+import { checkPermissionsBulkAPI, type BulkCheckResult } from '../client/rbac-api';
 import type { PermissionCheckScope, PermissionVerb } from '../types';
 import { usePermissions } from './usePermissions';
+import { shouldRetryQuery } from '@/modules/tanstack/query';
 import { useQuery } from '@tanstack/react-query';
 
 const STALE_TIME = 5 * 60 * 1000; // 5 minutes
@@ -18,51 +19,137 @@ export interface PermissionCheckResult {
   [key: string]: { allowed: boolean; isLoading: boolean };
 }
 
+/** Row sent to the BFF: normalized `group` string plus, for project-scoped checks, the resolved projectId. */
+type BulkCheckRow = PermissionCheckInput & { group: string } & { projectId?: string };
+
+interface PartitionRow<T = BulkCheckRow> {
+  index: number;
+  check: T;
+}
+
+export interface PartitionedPermissionChecks<T = BulkCheckRow> {
+  org: PartitionRow<T>[];
+  project: PartitionRow<T>[];
+}
+
+/**
+ * Split a batch of checks into org-scoped and project-scoped partitions,
+ * preserving each row's original index so results can be re-mapped back to the
+ * caller's array order. Any check whose `scope` is NOT 'project' (org scope or
+ * absent — the default) routes to the org partition.
+ */
+export function partitionPermissionChecks<T extends PermissionCheckInput>(
+  checks: T[]
+): PartitionedPermissionChecks<T> {
+  const partition: PartitionedPermissionChecks<T> = { org: [], project: [] };
+  checks.forEach((check, index) => {
+    (check.scope === 'project' ? partition.project : partition.org).push({ index, check });
+  });
+  return partition;
+}
+
 /**
  * Evaluate multiple permissions in a single bulk request to the BFF. Results are
  * matched to the input checks by index (the server returns them in order).
  * Returns a map keyed by `${resource}:${verb}`. Fails closed.
+ *
+ * The batch is split by scope so the two partitions don't block each other:
+ * - org-scoped checks run as soon as the org context exists — they never wait
+ *   for the project context to resolve.
+ * - project-scoped checks stay disabled (fail-closed) until projectId resolves
+ *   (it flows in via layout effects), preserving the server-side projectId
+ *   invariant.
+ *
+ * Splitting also keeps projectId out of the org partition's cache key, so
+ * switching projects does not invalidate org results.
  */
 export function usePermissionCheck(checks: PermissionCheckInput[]) {
   const { organizationId, projectId } = usePermissions();
 
-  const normalizedChecks = checks.map((check) => ({
+  // Embed projectId only on project-scoped rows. Org rows carry an undefined
+  // projectId so their portion of the cache stays stable across project
+  // switches.
+  const normalizedChecks: BulkCheckRow[] = checks.map((check) => ({
     resource: check.resource,
     verb: check.verb,
     group: check.group ?? '',
     namespace: check.namespace,
     name: check.name,
     scope: check.scope,
-    projectId,
+    projectId: check.scope === 'project' ? projectId : undefined,
   }));
 
-  const query = useQuery({
-    queryKey: ['permission-bulk', organizationId ?? '_', projectId ?? '_', normalizedChecks],
+  const { org, project } = partitionPermissionChecks(normalizedChecks);
+  const orgChecks = org.map(({ check }) => check);
+  const projectChecks = project.map(({ check }) => check);
+
+  const orgQuery = useQuery({
+    queryKey: ['permission-bulk', organizationId ?? '_', 'org', orgChecks],
     queryFn: async () => {
       if (!organizationId) {
         throw new Error('Organization ID is required for permission checks');
       }
-      return checkPermissionsBulkAPI(organizationId, normalizedChecks);
+      return checkPermissionsBulkAPI(organizationId, orgChecks);
     },
-    enabled: !!organizationId && checks.length > 0,
+    enabled: !!organizationId && orgChecks.length > 0,
     staleTime: STALE_TIME,
-    retry: 1,
+    retry: shouldRetryQuery,
   });
 
-  // Prefer isPending over isLoading: while the query is disabled (e.g. org
+  const projectQuery = useQuery({
+    queryKey: [
+      'permission-bulk',
+      organizationId ?? '_',
+      projectId ?? '_',
+      'project',
+      projectChecks,
+    ],
+    queryFn: async () => {
+      if (!organizationId) {
+        throw new Error('Organization ID is required for permission checks');
+      }
+      return checkPermissionsBulkAPI(organizationId, projectChecks);
+    },
+    enabled: !!organizationId && !!projectId && projectChecks.length > 0,
+    staleTime: STALE_TIME,
+    retry: shouldRetryQuery,
+  });
+
+  // Prefer isPending over isLoading: while a query is disabled (e.g. project
   // context not ready) isLoading is false even though we have no result yet,
   // which lets UIs flash empty/denied states before the check runs.
-  const isPermissionsPending = query.isPending;
+  //
+  // A partition with NO checks has its query intentionally disabled, and a
+  // disabled query with no data reports isPending: true. That must not hold
+  // the whole batch in 'loading', so only count a partition's pending state
+  // when it actually has checks to resolve.
+  const orgPending = orgChecks.length > 0 && orgQuery.isPending;
+  const projectPending = projectChecks.length > 0 && projectQuery.isPending;
+  const isPermissionsPending = orgPending || projectPending;
 
   const permissions: PermissionCheckResult = {};
-  checks.forEach((check, index) => {
-    const key = `${check.resource}:${check.verb}`;
-    const result = query.data?.[index];
-    permissions[key] = {
-      allowed: result ? result.allowed && !result.denied : false,
-      isLoading: isPermissionsPending,
-    };
-  });
 
-  return { permissions, isLoading: isPermissionsPending, isError: query.isError };
+  const applyPartition = (
+    rows: PartitionRow[],
+    data: BulkCheckResult[] | undefined,
+    pending: boolean
+  ) => {
+    rows.forEach((row, position) => {
+      const result = data?.[position];
+      const key = `${row.check.resource}:${row.check.verb}`;
+      permissions[key] = {
+        allowed: result ? result.allowed && !result.denied : false,
+        isLoading: pending,
+      };
+    });
+  };
+
+  applyPartition(org, orgQuery.data, orgPending);
+  applyPartition(project, projectQuery.data, projectPending);
+
+  return {
+    permissions,
+    isLoading: isPermissionsPending,
+    isError: orgQuery.isError || projectQuery.isError,
+  };
 }

--- a/app/modules/rbac/server/rbac.service.test.ts
+++ b/app/modules/rbac/server/rbac.service.test.ts
@@ -71,6 +71,20 @@ describe('RbacService.checkPermission', () => {
       '/apis/resourcemanager.miloapis.com/v1alpha1/projects/proj-1/control-plane'
     );
   });
+
+  test('project-scoped check without projectId enforces the invariant: fails closed, no upstream call', async () => {
+    const fakeAccessReview = { create: mock(async () => ({ allowed: true, denied: false })) };
+    const svc = new RbacService(() => fakeAccessReview as never);
+    const result = await svc.checkPermission('acme', {
+      resource: 'dnszones',
+      verb: 'list',
+      scope: 'project',
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.denied).toBe(true);
+    expect(result.reason).toBe('projectId is required for project-scoped permission checks');
+    expect(fakeAccessReview.create.mock.calls.length).toBe(0);
+  });
 });
 
 describe('RbacService namespace resolution', () => {
@@ -171,5 +185,20 @@ describe('RbacService.checkPermissions (bulk)', () => {
       },
     });
     expect(results[1].allowed).toBe(true);
+  });
+
+  test('project-scoped item without projectId fails closed with the invariant reason, batch continues', async () => {
+    const fakeAccessReview = { create: mock(async () => ({ allowed: true, denied: false })) };
+    const svc = new RbacService(() => fakeAccessReview as never);
+    const results = await svc.checkPermissions('acme', [
+      { resource: 'dnszones', verb: 'list', scope: 'project' },
+      { resource: 'secrets', verb: 'get' },
+    ]);
+    expect(results[0].allowed).toBe(false);
+    expect(results[0].denied).toBe(true);
+    expect(results[0].reason).toBe('projectId is required for project-scoped permission checks');
+    expect(results[1].allowed).toBe(true);
+    // Only the valid item reached the upstream authorizer.
+    expect(fakeAccessReview.create.mock.calls.length).toBe(1);
   });
 });

--- a/app/modules/rbac/types.ts
+++ b/app/modules/rbac/types.ts
@@ -39,9 +39,11 @@ export const PermissionVerbSchema = z.enum([
 export const PermissionScopeSchema = z.enum(['org', 'user', 'project']);
 
 /**
- * Base permission check schema
+ * Raw field shape shared by the single and bulk check schemas. Kept unrefined
+ * so `PermissionCheckSchema` can `.extend()` it; the exported schemas below
+ * each re-apply {@link requireProjectIdForProjectScope}.
  */
-export const BasePermissionCheckSchema = z.object({
+const PermissionCheckFieldsSchema = z.object({
   namespace: z.string().optional(),
   verb: PermissionVerbSchema,
   group: z.string().default(''),
@@ -52,11 +54,37 @@ export const BasePermissionCheckSchema = z.object({
 });
 
 /**
+ * A project-scoped check cannot be routed to a control plane without a
+ * projectId (see RbacService.resolveBaseURL). Rejecting it at the BFF
+ * boundary turns a would-be server invariant violation (error-logged and
+ * captured to Sentry) into a 400 that points at the offending caller.
+ */
+const requireProjectIdForProjectScope = (
+  check: { scope?: z.infer<typeof PermissionScopeSchema>; projectId?: string },
+  ctx: z.RefinementCtx
+) => {
+  if (check.scope === 'project' && !check.projectId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['projectId'],
+      message: 'projectId is required when scope is "project"',
+    });
+  }
+};
+
+/**
+ * Base permission check schema
+ */
+export const BasePermissionCheckSchema = PermissionCheckFieldsSchema.superRefine(
+  requireProjectIdForProjectScope
+);
+
+/**
  * Permission check schema with organization ID
  */
-export const PermissionCheckSchema = BasePermissionCheckSchema.extend({
+export const PermissionCheckSchema = PermissionCheckFieldsSchema.extend({
   organizationId: z.string().min(1, 'Organization ID is required'),
-});
+}).superRefine(requireProjectIdForProjectScope);
 
 /**
  * Bulk permission check schema — checks a batch of permissions in one request

--- a/app/modules/rbac/use-resource-permissions.test.ts
+++ b/app/modules/rbac/use-resource-permissions.test.ts
@@ -1,4 +1,5 @@
 /// <reference types="bun-types/test" />
+import { partitionPermissionChecks, type PermissionCheckInput } from './hooks/usePermissionCheck';
 import { buildChecks, detectInstanceGrantMisuse, flagNameFor } from './use-resource-permissions';
 import { describe, expect, test } from 'bun:test';
 
@@ -121,5 +122,42 @@ describe('detectInstanceGrantMisuse', () => {
     expect(
       detectInstanceGrantMisuse({ resource: 'secrets', scope: 'project', verbs: ['update'] })
     ).toBeNull();
+  });
+});
+
+describe('partitionPermissionChecks', () => {
+  test('splits project-scoped checks out, preserving original indices', () => {
+    const checks: PermissionCheckInput[] = [
+      { resource: 'dnszones', verb: 'list', scope: 'org' },
+      { resource: 'secrets', verb: 'get', scope: 'project' },
+      { resource: 'clusters', verb: 'list' },
+    ];
+    const { org, project } = partitionPermissionChecks(checks);
+
+    expect(org.map((row) => row.index)).toEqual([0, 2]);
+    expect(project.map((row) => row.index)).toEqual([1]);
+    expect(project[0]?.check.resource).toBe('secrets');
+  });
+
+  test('keeps per-partition order for same-scope checks', () => {
+    const checks: PermissionCheckInput[] = [
+      { resource: 'a', verb: 'list', scope: 'project' },
+      { resource: 'b', verb: 'list', scope: 'project' },
+      { resource: 'c', verb: 'list', scope: 'org' },
+    ];
+    const { org, project } = partitionPermissionChecks(checks);
+
+    expect(project.map((row) => row.index)).toEqual([0, 1]);
+    expect(org.map((row) => row.index)).toEqual([2]);
+  });
+
+  test('handles empty input and default (absent) scope', () => {
+    expect(partitionPermissionChecks([]).org).toEqual([]);
+    expect(partitionPermissionChecks([]).project).toEqual([]);
+
+    const checks: PermissionCheckInput[] = [{ resource: 'dnszones', verb: 'list' }];
+    const { org } = partitionPermissionChecks(checks);
+    expect(org).toHaveLength(1);
+    expect(org[0]?.check.scope).toBeUndefined();
   });
 });

--- a/app/modules/sentry/capture.ts
+++ b/app/modules/sentry/capture.ts
@@ -77,6 +77,19 @@ export function captureMessage(
 }
 
 /**
+ * Resolve a searchable `code` tag for framework-handler captures: the
+ * error's own string `code` (AppError, AxiosError) when present, falling
+ * back to the error name.
+ */
+export function resolveErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const source = error as { code?: unknown; name?: unknown };
+  if (typeof source.code === 'string' && source.code.length > 0) return source.code;
+  if (typeof source.name === 'string' && source.name.length > 0) return source.name;
+  return undefined;
+}
+
+/**
  * Set a custom tag in Sentry.
  */
 export function setTag(key: string, value: string | number | boolean | undefined): void {
@@ -120,6 +133,10 @@ export interface CaptureApiErrorOptions {
  * - Sets resource tags (apiGroup, version, type, name, namespace)
  * - Groups errors by: resource type + API group + status code
  * - Creates descriptive error title (e.g., "API 404: GET dnszones")
+ * - Returns the Sentry event id so upstream capture sites can embed it in
+ *   the serialized error body and downstream layers can skip re-capturing
+ *
+ * @returns The Sentry event id, or undefined if the capture did not run.
  *
  * @example
  * captureApiError({
@@ -130,7 +147,7 @@ export interface CaptureApiErrorOptions {
  *   message: 'Not Found',
  * });
  */
-export function captureApiError(options: CaptureApiErrorOptions): void {
+export function captureApiError(options: CaptureApiErrorOptions): string | undefined {
   const {
     error,
     url,
@@ -169,6 +186,7 @@ export function captureApiError(options: CaptureApiErrorOptions): void {
   const errorMessage = message || error.message || 'Unknown error';
 
   // Capture with custom error name for better Sentry title
+  let eventId: string | undefined;
   Sentry.withScope((scope) => {
     scope.setFingerprint(fingerprint);
     scope.setTag('type', 'api_error');
@@ -201,6 +219,8 @@ export function captureApiError(options: CaptureApiErrorOptions): void {
     apiError.cause = error;
     apiError.stack = error.stack;
 
-    Sentry.captureException(apiError);
+    eventId = Sentry.captureException(apiError);
   });
+
+  return eventId;
 }

--- a/app/modules/sentry/classify.ts
+++ b/app/modules/sentry/classify.ts
@@ -1,0 +1,76 @@
+/**
+ * Error classification — single source of truth for Sentry capture policy.
+ *
+ * Duck-types every error shape that occurs in this codebase (AppError,
+ * AxiosError, React Router ErrorResponse, plain objects carrying a numeric
+ * `status` — AppError's status survives React Router serialization as a
+ * plain object) and resolves it to a class. Wrappers are unwrapped one
+ * level: the axios interceptors rethrow no-response failures as AppErrors
+ * with a fallback 500 status and the original AxiosError in `cause`, so a
+ * no-response axios `cause` classifies as 'network-failure' before the
+ * wrapper's status is consulted.
+ *
+ * Callers decide policy per environment: the client drops both
+ * 'expected-user-state' and 'network-failure' (user connectivity is not a
+ * bug); the server drops only 'expected-user-state' — server-side upstream
+ * network failures are infra signals and stay captured.
+ */
+import { isUserFacingErrorStatus } from '@/utils/errors/app-error';
+import { isAxiosError } from 'axios';
+import { isRouteErrorResponse } from 'react-router';
+
+export type ErrorClass = 'expected-user-state' | 'network-failure' | 'unknown-failure';
+
+function classifyStatus(status: number | undefined): ErrorClass {
+  return isUserFacingErrorStatus(status) ? 'expected-user-state' : 'unknown-failure';
+}
+
+function resolveStatus(error: unknown): number | undefined {
+  if (isRouteErrorResponse(error)) return error.status;
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const status = (error as { status: unknown }).status;
+    if (typeof status === 'number') return status;
+  }
+  return undefined;
+}
+
+function resolveCause(error: unknown): unknown {
+  if (typeof error === 'object' && error !== null && 'cause' in error) {
+    return (error as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
+/**
+ * Walk the `cause` chain (bounded — wrappers may nest, e.g. a route-level
+ * AppError wrapping the interceptor's AppError wrapping the AxiosError)
+ * looking for a no-response AxiosError. Stops at the first AxiosError found:
+ * one WITH a response is a real upstream reply, so the wrapper's own status
+ * decides the class.
+ */
+const MAX_CAUSE_DEPTH = 4;
+
+function hasNoResponseAxiosCause(error: unknown): boolean {
+  let current = resolveCause(error);
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && current != null; depth++) {
+    if (isAxiosError(current)) return !current.response;
+    current = resolveCause(current);
+  }
+  return false;
+}
+
+export function classifyError(error: unknown): ErrorClass {
+  if (isAxiosError(error)) {
+    // No response: request never completed (network/timeout/DNS).
+    if (!error.response) return 'network-failure';
+    return classifyStatus(error.response.status);
+  }
+  // Interceptor-wrapped network failure: AppError carries a fallback 500
+  // status but the original no-response AxiosError somewhere in `cause`.
+  if (hasNoResponseAxiosCause(error)) return 'network-failure';
+  return classifyStatus(resolveStatus(error));
+}
+
+export function isExpectedUserError(error: unknown): boolean {
+  return classifyError(error) === 'expected-user-state';
+}

--- a/app/modules/sentry/error-policy.test.ts
+++ b/app/modules/sentry/error-policy.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Consolidated coverage for the pure error-policy surface introduced by the
+ * Sentry noise rework (#1378): classification, beforeSend backstop, query
+ * retry predicate, related-resource degradation, and the rbac project-scope
+ * guard. One compact file by design — the behavior-level suites live in the
+ * pre-existing test files.
+ */
+import { hasUnresolvedProjectScope } from '../rbac/hooks/project-scope-guard';
+import { shouldRetryQuery } from '../tanstack/query';
+import { classifyError, isExpectedUserError } from './classify';
+import { shouldDropSentryEvent, shouldDropSentryEventClient } from './filters';
+import { buildErrorFingerprint, normalizeMessage } from './fingerprint';
+import { resolveRelatedResource } from '@/resources/http-proxies/related-resource';
+import { AppError } from '@/utils/errors/app-error';
+import type { Event, EventHint } from '@sentry/react-router';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const appError = (status: number, cause?: unknown) =>
+  new AppError('boom', { status, cause, captureToSentry: false });
+
+const axiosError = (status?: number) => ({
+  isAxiosError: true,
+  name: 'AxiosError',
+  message: 'failed',
+  ...(status !== undefined && { response: { status } }),
+});
+
+const emptyEvent = {} as Event;
+const hintFor = (error: unknown): EventHint => ({ originalException: error });
+
+let warnSpy: ReturnType<typeof mock>;
+beforeEach(() => {
+  warnSpy = mock(() => {});
+  console.warn = warnSpy as unknown as typeof console.warn;
+});
+
+describe('classifyError', () => {
+  // Every 4xx is handled and surfaced to the user (boundary/toast/inline),
+  // so none of them are captured — including 400/409/422, which used to be
+  // treated as bugs and leaked into Sentry as admission-webhook rejections,
+  // "already exists" conflicts, and validation failures.
+  test.each([[400], [401], [403], [404], [409], [418], [422], [429], [451], [499]])(
+    'AppError %d is expected-user-state',
+    (status) => {
+      expect(classifyError(appError(status))).toBe('expected-user-state');
+      expect(isExpectedUserError(appError(status))).toBe(true);
+    }
+  );
+
+  // 5xx means we broke — still captured.
+  test.each([[500], [502], [503], [504]])('AppError %d is unknown-failure', (status) => {
+    expect(classifyError(appError(status))).toBe('unknown-failure');
+    expect(isExpectedUserError(appError(status))).toBe(false);
+  });
+
+  test('AxiosError with a 404 response is expected-user-state', () => {
+    expect(classifyError(axiosError(404))).toBe('expected-user-state');
+  });
+
+  test('AxiosError without a response is network-failure', () => {
+    expect(classifyError(axiosError())).toBe('network-failure');
+  });
+
+  test('interceptor-wrapped no-response failure (status-500 AppError) is network-failure', () => {
+    expect(classifyError(appError(500, axiosError()))).toBe('network-failure');
+  });
+
+  test('doubly-wrapped no-response failure is still network-failure (bounded cause walk)', () => {
+    expect(classifyError(appError(500, appError(500, axiosError())))).toBe('network-failure');
+  });
+
+  test('wrapped AxiosError WITH a response defers to the wrapper status', () => {
+    expect(classifyError(appError(500, axiosError(500)))).toBe('unknown-failure');
+    expect(classifyError(appError(404, axiosError(404)))).toBe('expected-user-state');
+  });
+
+  test('plain objects with a numeric status classify by status (RR serialization)', () => {
+    expect(classifyError({ status: 404 })).toBe('expected-user-state');
+    expect(classifyError({ status: 500 })).toBe('unknown-failure');
+  });
+
+  test('non-status shapes are unknown-failure', () => {
+    expect(classifyError(new Error('boom'))).toBe('unknown-failure');
+    expect(classifyError(undefined)).toBe('unknown-failure');
+    expect(classifyError('boom')).toBe('unknown-failure');
+  });
+});
+
+describe('beforeSend backstop', () => {
+  test('drops leaked expected errors on both server and client filters', () => {
+    expect(shouldDropSentryEvent(emptyEvent, hintFor(appError(404)))).toBe(true);
+    expect(shouldDropSentryEventClient(emptyEvent, hintFor(appError(404)))).toBe(true);
+  });
+
+  test('network failures: client drops, server keeps (infra signal)', () => {
+    const hint = hintFor(appError(500, axiosError()));
+    expect(shouldDropSentryEvent(emptyEvent, hint)).toBe(false);
+    expect(shouldDropSentryEventClient(emptyEvent, hint)).toBe(true);
+  });
+
+  test('unknown failures pass through both filters', () => {
+    const hint = hintFor(new Error('real bug'));
+    expect(shouldDropSentryEvent(emptyEvent, hint)).toBe(false);
+    expect(shouldDropSentryEventClient(emptyEvent, hint)).toBe(false);
+  });
+
+  test('missing hint keeps the event', () => {
+    expect(shouldDropSentryEvent(emptyEvent, undefined)).toBe(false);
+  });
+
+  test('drops a 4xx `status` tag even when the wrapped original is unknown-failure', () => {
+    // captureApiError wraps the original in a synthetic Error; the user-facing
+    // status travels only as event.tags.status (set via scope.setTag('status')).
+    const event: Event = { ...emptyEvent, tags: { status: '404' } };
+    expect(shouldDropSentryEvent(event, hintFor(new Error('wrapped upstream failure')))).toBe(true);
+    expect(shouldDropSentryEventClient(event, hintFor(new Error('wrapped upstream failure')))).toBe(
+      true
+    );
+  });
+
+  test('keeps a 5xx `status` tag (real failures still captured)', () => {
+    const event: Event = { ...emptyEvent, tags: { status: '500' } };
+    expect(shouldDropSentryEvent(event, hintFor(new Error('wrapped upstream failure')))).toBe(
+      false
+    );
+  });
+
+  test('ignores non-numeric status tags', () => {
+    const event: Event = { ...emptyEvent, tags: { status: 'network' } };
+    expect(shouldDropSentryEvent(event, hintFor(new Error('wrapped upstream failure')))).toBe(
+      false
+    );
+  });
+
+  test('leak warning is deduped by error signature', () => {
+    shouldDropSentryEvent(emptyEvent, hintFor(appError(404)));
+    shouldDropSentryEvent(emptyEvent, hintFor(appError(404)));
+    const initialWarns = warnSpy.mock.calls.length;
+    expect(initialWarns).toBeLessThanOrEqual(1);
+    shouldDropSentryEvent(emptyEvent, hintFor(appError(429)));
+    expect(warnSpy.mock.calls.length).toBeGreaterThanOrEqual(initialWarns);
+  });
+});
+
+describe('shouldRetryQuery', () => {
+  test.each([[400], [401], [403], [404], [409], [422], [429]])(
+    'never retries handled %d',
+    (status) => {
+      expect(shouldRetryQuery(0, appError(status))).toBe(false);
+    }
+  );
+
+  test('retries unexpected failures exactly once', () => {
+    expect(shouldRetryQuery(0, appError(500))).toBe(true);
+    expect(shouldRetryQuery(1, appError(500))).toBe(false);
+    expect(shouldRetryQuery(0, new Error('network'))).toBe(true);
+  });
+});
+
+describe('resolveRelatedResource', () => {
+  test('404 degrades to absent, 403 to forbidden', async () => {
+    await expect(
+      resolveRelatedResource(async () => Promise.reject(appError(404)))
+    ).resolves.toEqual({ state: 'absent', data: null });
+    await expect(
+      resolveRelatedResource(async () => Promise.reject(appError(403)))
+    ).resolves.toEqual({ state: 'forbidden', data: null });
+  });
+
+  test('unexpected errors rethrow by default and absorb on request', async () => {
+    const failure = appError(500);
+    await expect(resolveRelatedResource(async () => Promise.reject(failure))).rejects.toBe(failure);
+    await expect(
+      resolveRelatedResource(async () => Promise.reject(failure), { onUnexpected: 'absorb' })
+    ).resolves.toEqual({ state: 'error', data: null, error: failure });
+  });
+
+  test('success passes data through', async () => {
+    await expect(resolveRelatedResource(async () => 'ok')).resolves.toEqual({
+      state: 'ok',
+      data: 'ok',
+    });
+  });
+});
+
+describe('normalizeMessage', () => {
+  test('redacts quoted resource names so one fault groups as one issue', () => {
+    expect(normalizeMessage('secrets "portfolio-lmpn0u-basic-auth" not found')).toBe(
+      'secrets "<redacted>" not found'
+    );
+    expect(normalizeMessage('secrets "portfolio-lmpn0u-basic-auth" not found')).toBe(
+      normalizeMessage('secrets "some-other-name" not found')
+    );
+  });
+
+  test('redacts emails and uuids', () => {
+    expect(normalizeMessage('User jszychowski@datum.net cannot list allowancebuckets')).toBe(
+      'User <email> cannot list allowancebuckets'
+    );
+    expect(normalizeMessage('request 04ddd6d3-db0c-4619-92ce-6b2fc4e2944f failed')).toBe(
+      'request <uuid> failed'
+    );
+  });
+
+  test('keeps genuinely different faults distinct', () => {
+    expect(normalizeMessage('secrets "a" not found')).not.toBe(
+      normalizeMessage('dnszones "a" not found')
+    );
+  });
+
+  test('leaves unquoted identifiers alone', () => {
+    expect(normalizeMessage('projectId is required for project-scoped permission checks')).toBe(
+      'projectId is required for project-scoped permission checks'
+    );
+  });
+});
+
+describe('AppError sentryEventId passthrough', () => {
+  test('threads a server-captured event id into the serialized body', () => {
+    const error = new AppError('boom', {
+      status: 500,
+      sentryEventId: 'evt_123',
+      captureToSentry: false,
+    });
+    expect(error.sentryEventId).toBe('evt_123');
+    expect(error.toJSON().sentryEventId).toBe('evt_123');
+  });
+});
+
+describe('buildErrorFingerprint', () => {
+  test('prefers code over message when present', () => {
+    expect(
+      buildErrorFingerprint({
+        name: 'AppError',
+        code: 'NOT_FOUND',
+        message: 'secrets "x" not found',
+      })
+    ).toEqual(['AppError', 'NOT_FOUND']);
+  });
+
+  test('falls back to the normalized message when there is no code', () => {
+    expect(
+      buildErrorFingerprint({ name: 'TypeError', message: '"/" cannot be parsed as a URL.' })
+    ).toEqual(['TypeError', '"<redacted>" cannot be parsed as a URL.']);
+  });
+
+  test('collapses the same fault raised for different resources', () => {
+    expect(
+      buildErrorFingerprint({
+        name: 'AppError',
+        message: 'connectors "claude-test-connector" not found',
+      })
+    ).toEqual(
+      buildErrorFingerprint({ name: 'AppError', message: 'connectors "other-one" not found' })
+    );
+  });
+
+  test('tolerates non-error shapes', () => {
+    expect(buildErrorFingerprint(undefined)).toEqual(['Error', '<no-message>']);
+    expect(buildErrorFingerprint('boom')).toEqual(['Error', '<no-message>']);
+  });
+});
+
+describe('hasUnresolvedProjectScope', () => {
+  test('true only for project-scoped checks without a resolved projectId', () => {
+    expect(hasUnresolvedProjectScope([{ scope: 'project' }], undefined)).toBe(true);
+    expect(hasUnresolvedProjectScope([{ scope: 'project' }], 'proj-1')).toBe(false);
+    expect(hasUnresolvedProjectScope([{ scope: 'org' }], undefined)).toBe(false);
+    expect(hasUnresolvedProjectScope([], undefined)).toBe(false);
+  });
+});

--- a/app/modules/sentry/filters.ts
+++ b/app/modules/sentry/filters.ts
@@ -1,4 +1,7 @@
-import type { Event } from '@sentry/react-router';
+import { classifyError } from './classify';
+import { env } from '@/utils/env';
+import { isUserFacingErrorStatus } from '@/utils/errors/app-error';
+import type { Event, EventHint } from '@sentry/react-router';
 
 /**
  * Known system-level actors whose events are suppressed in Sentry.
@@ -75,12 +78,89 @@ export function isRouteMethodNotAllowedEvent(event: Event): boolean {
   return false;
 }
 
+function leakParts(error: unknown): { signature: string; message: string } {
+  if (typeof error !== 'object' || error === null) {
+    return { signature: String(error), message: '' };
+  }
+  const source = error as {
+    name?: unknown;
+    message?: unknown;
+    status?: unknown;
+    response?: { status?: unknown };
+  };
+  const status = source.status ?? source.response?.status;
+  const name = typeof source.name === 'string' ? source.name : 'Error';
+  const message = typeof source.message === 'string' ? source.message : '';
+  return { signature: `${name}(status=${String(status)})`, message };
+}
+
+// One warning per unique error signature (name + status), so a leaking hot
+// path doesn't flood the console; bounded so the set can't grow unchecked.
+const warnedLeakSignatures = new Set<string>();
+const MAX_WARNED_LEAK_SIGNATURES = 100;
+
+/**
+ * Backstop for expected user-state errors (401/403/404/429) that leak past
+ * their capture sites. The primary policy lives at the capture sites (axios
+ * interceptors, framework error handlers) — this filter should almost never
+ * fire. Outside production telemetry it logs a loud warning so the leaking
+ * capture site gets fixed, rather than this becoming a second policy layer.
+ *
+ * `captureApiError` wraps its original error in a synthetic `Error` carrying
+ * the upstream status only as a scope tag (`status`), so a leaked 4xx through
+ * that path classifies as 'unknown-failure' and would slip past a
+ * classification-only check. The event tag is the authoritative signal here.
+ */
+function isLeakedExpectedError(event: Event, hint: EventHint | undefined): boolean {
+  const original = hint?.originalException;
+
+  // `captureApiError` tags the event with `status` on the synthetic wrapper —
+  // a 4xx tag means an expected user-state error leaked through that path.
+  const statusTag = event.tags?.status;
+  const tagIs4xx = typeof statusTag === 'string' && isUserFacingErrorStatus(Number(statusTag));
+
+  if ((original === undefined || original === null) && !tagIs4xx) return false;
+  if (classifyError(original) !== 'expected-user-state' && !tagIs4xx) return false;
+
+  const isProductionTelemetry = env.isProd && env.public.sentryEnv === 'production';
+  if (!isProductionTelemetry) {
+    const { signature, message } = leakParts(original);
+    if (!warnedLeakSignatures.has(signature)) {
+      if (warnedLeakSignatures.size >= MAX_WARNED_LEAK_SIGNATURES) {
+        warnedLeakSignatures.clear();
+      }
+      warnedLeakSignatures.add(signature);
+      console.warn(
+        '[sentry-policy] dropped leaked expected error — fix the capture site',
+        `${signature} ${message}`.trim()
+      );
+    }
+  }
+  return true;
+}
+
 /**
  * Master filter for `beforeSend`. Returns true if the event should be
  * dropped (not sent to Sentry). Combines every individual filter so
  * the two `beforeSend` call sites (client + server) stay in sync via
  * a single import.
+ *
+ * Layer split: this base filter (used by the server in
+ * `observability/providers/sentry.ts`) drops system-actor events, bot 405s,
+ * and leaked 'expected-user-state' errors. Server-side 'network-failure'
+ * (upstream connection errors) stays captured — it is an infra signal.
  */
-export function shouldDropSentryEvent(event: Event): boolean {
-  return isKnownSystemEvent(event) || isRouteMethodNotAllowedEvent(event);
+export function shouldDropSentryEvent(event: Event, hint?: EventHint): boolean {
+  if (isKnownSystemEvent(event) || isRouteMethodNotAllowedEvent(event)) return true;
+  return isLeakedExpectedError(event, hint);
+}
+
+/**
+ * Client-side variant used by `app/entry.client.tsx`: everything the base
+ * filter drops, plus 'network-failure' — in the browser a failed/timed-out
+ * request is user connectivity (flaky wifi, ad-blockers), not a bug.
+ */
+export function shouldDropSentryEventClient(event: Event, hint?: EventHint): boolean {
+  if (shouldDropSentryEvent(event, hint)) return true;
+  return classifyError(hint?.originalException) === 'network-failure';
 }

--- a/app/modules/sentry/fingerprint.ts
+++ b/app/modules/sentry/fingerprint.ts
@@ -1,0 +1,40 @@
+/**
+ * Stable issue grouping for framework-level captures.
+ *
+ * Sentry groups these events by "exception stacktrace — all frames", so one
+ * fault reached from several callers splits into one issue per caller: the
+ * `projectId is required` invariant produced 22 issues (one per route) and
+ * `"/" cannot be parsed as a URL` produced 10. An explicit fingerprint
+ * collapses them, while the route stays a searchable tag on the event.
+ */
+const UUID = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const EMAIL = /\b[^\s"@]+@[^\s"@]+\.[^\s"@]+\b/g;
+const QUOTED_VALUE = /"[^"]*"/g;
+
+/**
+ * Replace volatile identifiers so the same fault groups regardless of which
+ * resource triggered it. Deliberately narrow — only quoted values, emails and
+ * UUIDs are redacted. Unquoted identifiers are left alone: over-normalizing
+ * would merge genuinely different faults, which is the failure mode this is
+ * most exposed to.
+ */
+export function normalizeMessage(message: string): string {
+  return message
+    .replace(UUID, '<uuid>')
+    .replace(EMAIL, '<email>')
+    .replace(QUOTED_VALUE, '"<redacted>"');
+}
+
+/**
+ * Build a grouping key for an error of unknown shape. `code` wins when present
+ * so typed errors stay distinct; otherwise the normalized message is used.
+ */
+export function buildErrorFingerprint(error: unknown): string[] {
+  const source = error as { name?: unknown; code?: unknown; message?: unknown } | null;
+  const name = typeof source?.name === 'string' && source.name ? source.name : 'Error';
+  const code = typeof source?.code === 'string' && source.code ? source.code : undefined;
+  const message =
+    typeof source?.message === 'string' && source.message ? normalizeMessage(source.message) : '';
+
+  return [name, code ?? message].map((part) => part || '<no-message>');
+}

--- a/app/modules/sentry/index.ts
+++ b/app/modules/sentry/index.ts
@@ -13,6 +13,10 @@
  * - trackFormSubmit / trackFormSuccess / trackFormError - Form interactions
  * - trackApiCall / trackApiError - API calls
  *
+ * ## Classification (capture policy)
+ * - classifyError - Resolve any error shape to an ErrorClass
+ * - isExpectedUserError - True for expected user-facing states (401/403/404/429)
+ *
  * ## Capture (error reporting)
  * - captureError - Capture errors with context
  * - captureApiError - Capture API errors with resource context and fingerprinting
@@ -48,6 +52,12 @@ export {
   type UrlResourceInfo,
 } from './context';
 
+// Classification - capture policy
+export { classifyError, isExpectedUserError, type ErrorClass } from './classify';
+
+// Fingerprinting - stable issue grouping for framework captures
+export { buildErrorFingerprint, normalizeMessage } from './fingerprint';
+
 // Breadcrumbs - user journey tracking
 export {
   // Form
@@ -68,6 +78,7 @@ export {
   captureError,
   captureApiError,
   captureMessage,
+  resolveErrorCode,
   setTag,
   setContext,
   type LogLevel,

--- a/app/modules/tanstack/query.ts
+++ b/app/modules/tanstack/query.ts
@@ -1,5 +1,18 @@
 import { QUERY_STALE_TIME } from '@/utils/config/query.config';
+import { isUserFacingErrorStatus } from '@/utils/errors/app-error';
 import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Retry predicate for queries.
+ *
+ * One quick retry covers transient network blips without compounding
+ * latency for users on slower connections. Expected user-facing statuses
+ * (401/403/404/429) are deterministic — retrying them only doubles error
+ * volume and delays the error state, so they never retry.
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+  return failureCount < 1 && !isUserFacingErrorStatus((error as { status?: number })?.status);
+}
 
 /**
  * Global TanStack Query defaults.
@@ -12,15 +25,15 @@ import { QueryClient } from '@tanstack/react-query';
  * real-time updates of K8s resources; window focus refetch is
  * redundant and noisy in a multi-tab admin UI.
  *
- * retry: 1 — one quick retry covers transient network blips without
- * compounding latency for users on slower connections.
+ * retry: shouldRetryQuery — one retry for unexpected failures, none for
+ * expected user-facing 4xx.
  */
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: QUERY_STALE_TIME,
       refetchOnWindowFocus: false,
-      retry: 1,
+      retry: shouldRetryQuery,
     },
   },
 });

--- a/app/resources/http-proxies/http-proxy.adapter.ts
+++ b/app/resources/http-proxies/http-proxy.adapter.ts
@@ -371,7 +371,7 @@ export function toHttpProxy(
   options?: {
     trafficProtectionMode?: TrafficProtectionMode;
     paranoiaLevels?: { blocking?: number; detection?: number };
-    basicAuth?: { enabled: boolean; userCount: number; usernames: string[] };
+    basicAuth?: { enabled: boolean; userCount: number; usernames: string[]; forbidden?: boolean };
   }
 ): HttpProxy {
   // Find the backend rule (skip redirect rules which have no backends)
@@ -444,6 +444,7 @@ export function toHttpProxy(
       basicAuthEnabled: options.basicAuth.enabled,
       basicAuthUserCount: options.basicAuth.userCount,
       basicAuthUsernames: options.basicAuth.usernames,
+      ...(options.basicAuth.forbidden && { basicAuthForbidden: true }),
     }),
   };
 }

--- a/app/resources/http-proxies/http-proxy.schema.ts
+++ b/app/resources/http-proxies/http-proxy.schema.ts
@@ -97,6 +97,12 @@ export const httpProxyResourceSchema = z.object({
   /** Usernames visible to the UI (never passwords) */
   basicAuthUsernames: z.array(z.string()).optional(),
   /**
+   * True when the basic-auth reads (SecurityPolicy / htpasswd Secret) were
+   * denied (403) — the card renders an insufficient-permissions state instead
+   * of "Disabled" (#1378).
+   */
+  basicAuthForbidden: z.boolean().optional(),
+  /**
    * Optional upstream Host header override.
    * Maps to spec.rules[backendRule].filters[].requestHeaderModifier.set[name=Host].value.
    * Empty / undefined means "no override" (forward the incoming Host unchanged).

--- a/app/resources/http-proxies/http-proxy.service.ts
+++ b/app/resources/http-proxies/http-proxy.service.ts
@@ -27,6 +27,7 @@ import {
   getTrafficProtectionProgrammedReason,
   isTrafficProtectionProgrammed,
 } from './http-proxy.waf-status';
+import { getRelatedResourceErrorStatus, resolveRelatedResource } from './related-resource';
 import {
   listNetworkingDatumapisComV1AlphaNamespacedHttpProxy,
   listNetworkingDatumapisComV1AlphaNamespacedTrafficProtectionPolicy,
@@ -71,6 +72,8 @@ export interface TrafficProtectionView {
   paranoiaLevels?: { blocking?: number; detection?: number };
   /** Actual policy object name when it differs from the proxy name. */
   policyName?: string;
+  /** True when the WAF read was denied (403) — render an insufficient-permissions state. */
+  forbidden?: boolean;
   /** True when all ancestors report Accepted+Programmed for the current generation. */
   programmed?: boolean;
   /** Programmed condition message while converging (e.g. M/N edges). */
@@ -81,6 +84,8 @@ export interface TrafficProtectionView {
 export interface TrafficProtectionMaps {
   modeByName: Map<string, TrafficProtectionMode>;
   paranoiaByName: Map<string, { blocking?: number; detection?: number }>;
+  /** True when the WAF list was denied (403) — render an insufficient-permissions state. */
+  forbidden?: boolean;
 }
 
 const SERVICE_NAME = 'HttpProxyService';
@@ -89,8 +94,7 @@ export function createHttpProxyService() {
   return {
     /** Extract HTTP status from an error (AppError from interceptor, or AxiosError). */
     getErrorStatus(error: unknown): number | undefined {
-      const e = error as { status?: number; response?: { status?: number } };
-      return e?.status ?? e?.response?.status;
+      return getRelatedResourceErrorStatus(error);
     },
 
     /**
@@ -128,9 +132,14 @@ export function createHttpProxyService() {
       // WAF (TrafficProtectionPolicy) is intentionally NOT fetched here — it is
       // loaded by a separate permission-gated query (listTrafficProtectionPolicies)
       // so users without trafficprotectionpolicies access never trigger that request.
-      const [proxyResponse, securityPoliciesResponse] = await Promise.all([
+      // SecurityPolicies are a related resource: 404/403/failed reads degrade to
+      // "no basic auth info", never fail the proxy list (#1378).
+      const [proxyResponse, securityPoliciesResult] = await Promise.all([
         listNetworkingDatumapisComV1AlphaNamespacedHttpProxy({ baseURL, path, query }),
-        this.listSecurityPolicies(baseURL, 'default').catch(() => ({ data: null })),
+        resolveRelatedResource(
+          async () => (await this.listSecurityPolicies(baseURL, 'default')).data,
+          { onUnexpected: 'absorb' }
+        ),
       ]);
 
       const proxyData = proxyResponse.data as ComDatumapisNetworkingV1AlphaHttpProxyList;
@@ -139,8 +148,7 @@ export function createHttpProxyService() {
         string,
         { enabled: boolean; userCount: number; usernames: string[] }
       >();
-      const securityPolicyItems =
-        (securityPoliciesResponse.data as { items?: unknown[] } | null)?.items ?? [];
+      const securityPolicyItems = securityPoliciesResult.data?.items ?? [];
       for (const sp of securityPolicyItems) {
         const spName = (sp as { metadata?: { name?: string } })?.metadata?.name;
         if (spName) {
@@ -156,21 +164,30 @@ export function createHttpProxyService() {
     /**
      * List WAF (TrafficProtectionPolicy) modes for a project, keyed by proxy name.
      * Decoupled from the proxy list so it can be gated behind view permission.
-     * Errors are surfaced (not swallowed) so callers can distinguish "couldn't
-     * read WAF" (show "—") from "no WAF policy" (show "Disabled"). The decoupled
-     * query isolates this failure from the proxy list.
+     * 404 degrades to empty maps ("no WAF policies"); 403 degrades to empty maps
+     * with `forbidden` set so callers render an insufficient-permissions state.
+     * Unexpected errors are surfaced so callers can distinguish "couldn't read
+     * WAF" (show "—") from "no WAF policy" (show "Disabled"). The decoupled
+     * query isolates this failure from the proxy list (#1378).
      */
     async listTrafficProtectionPolicies(projectId: string): Promise<TrafficProtectionMaps> {
       try {
         const baseURL = getProjectScopedBase(projectId);
-        const response = await listNetworkingDatumapisComV1AlphaNamespacedTrafficProtectionPolicy({
-          baseURL,
-          path: { namespace: 'default' },
+        const result = await resolveRelatedResource(async () => {
+          const response = await listNetworkingDatumapisComV1AlphaNamespacedTrafficProtectionPolicy(
+            {
+              baseURL,
+              path: { namespace: 'default' },
+            }
+          );
+          return response.data;
         });
-        const list = response.data;
+        if (result.state === 'forbidden') {
+          return { modeByName: new Map(), paranoiaByName: new Map(), forbidden: true };
+        }
         return {
-          modeByName: toTrafficProtectionModeMap(list),
-          paranoiaByName: toParanoiaLevelsMap(list),
+          modeByName: toTrafficProtectionModeMap(result.data),
+          paranoiaByName: toParanoiaLevelsMap(result.data),
         };
       } catch (error) {
         logger.error(`${SERVICE_NAME}.listTrafficProtectionPolicies failed`, error as Error);
@@ -223,30 +240,36 @@ export function createHttpProxyService() {
     /**
      * Read a single proxy's WAF (TrafficProtectionPolicy) view. Decoupled from the
      * proxy fetch so it can be gated behind view permission. A genuine miss (no
-     * attaching policy) resolves to an empty view; other errors are surfaced so
-     * callers can distinguish "couldn't read WAF" (show "—") from "no WAF policy".
+     * attaching policy, or a 404 on the read) resolves to an empty view; 403
+     * resolves to an empty view with `forbidden` set so callers render an
+     * insufficient-permissions state. Unexpected errors are surfaced so callers
+     * can distinguish "couldn't read WAF" (show "—") from "no WAF policy" (#1378).
      */
     async getTrafficProtectionPolicy(
       projectId: string,
       name: string
     ): Promise<TrafficProtectionView> {
-      try {
-        const policy = await this.findTrafficProtectionPolicyForProxy(projectId, name);
-        if (!policy) {
-          return { mode: undefined, paranoiaLevels: undefined };
-        }
-        return {
-          mode: getTrafficProtectionMode(policy),
-          paranoiaLevels: getParanoiaLevels(policy),
-          policyName: policy.metadata?.name,
-          programmed: isTrafficProtectionProgrammed(policy.status),
-          programmedMessage: getTrafficProtectionProgrammedMessage(policy.status),
-          programmedReason: getTrafficProtectionProgrammedReason(policy.status),
-        };
-      } catch (error) {
+      const result = await resolveRelatedResource(() =>
+        this.findTrafficProtectionPolicyForProxy(projectId, name)
+      ).catch((error: unknown) => {
         logger.error(`${SERVICE_NAME}.getTrafficProtectionPolicy failed`, error as Error);
         throw mapApiError(error);
+      });
+      if (result.state === 'forbidden') {
+        return { mode: undefined, paranoiaLevels: undefined, forbidden: true };
       }
+      const policy = result.data ?? undefined;
+      if (!policy) {
+        return { mode: undefined, paranoiaLevels: undefined };
+      }
+      return {
+        mode: getTrafficProtectionMode(policy),
+        paranoiaLevels: getParanoiaLevels(policy),
+        policyName: policy.metadata?.name,
+        programmed: isTrafficProtectionProgrammed(policy.status),
+        programmedMessage: getTrafficProtectionProgrammedMessage(policy.status),
+        programmedReason: getTrafficProtectionProgrammedReason(policy.status),
+      };
     },
 
     async createTrafficProtectionPolicy(
@@ -482,10 +505,7 @@ export function createHttpProxyService() {
           path: { namespace: 'default', name: policyName },
         });
       } catch (error: unknown) {
-        const status =
-          (error as { status?: number })?.status ??
-          (error as { response?: { status?: number } })?.response?.status;
-        if (status !== 404) throw error;
+        if (this.getErrorStatus(error) !== 404) throw error;
       }
     },
 
@@ -581,10 +601,19 @@ export function createHttpProxyService() {
 
       // WAF (TrafficProtectionPolicy) is intentionally NOT fetched here — it is
       // loaded by a separate permission-gated query (getTrafficProtectionPolicy).
-      const [proxyResponse, securityPolicyResponse, secretResponse] = await Promise.all([
+      // SecurityPolicy and the htpasswd Secret are related resources: 404 renders
+      // the "not configured" state, 403 an insufficient-permissions state, and no
+      // failure here may take down the proxy page (#1378).
+      const [proxyResponse, securityPolicyResult, secretResult] = await Promise.all([
         readNetworkingDatumapisComV1AlphaNamespacedHttpProxy({ baseURL, path }),
-        this.readSecurityPolicy(baseURL, 'default', name).catch(() => ({ data: null })),
-        this.readBasicAuthSecret(baseURL, 'default', name).catch(() => ({ data: null })),
+        resolveRelatedResource(
+          async () => (await this.readSecurityPolicy(baseURL, 'default', name)).data,
+          { onUnexpected: 'absorb' }
+        ),
+        resolveRelatedResource(
+          async () => (await this.readBasicAuthSecret(baseURL, 'default', name)).data,
+          { onUnexpected: 'absorb' }
+        ),
       ]);
 
       const data = proxyResponse.data as ComDatumapisNetworkingV1AlphaHttpProxy;
@@ -593,9 +622,13 @@ export function createHttpProxyService() {
         throw new NotFoundError('Application Load Balancer', name);
       }
 
-      const usernames = parseHtpasswdUsernames(secretResponse.data);
-      const basicAuth = getBasicAuthState(securityPolicyResponse.data, usernames);
-      return toHttpProxy(data, { basicAuth });
+      const usernames = parseHtpasswdUsernames(secretResult.data);
+      const basicAuth = getBasicAuthState(securityPolicyResult.data, usernames);
+      const basicAuthForbidden =
+        securityPolicyResult.state === 'forbidden' || secretResult.state === 'forbidden';
+      return toHttpProxy(data, {
+        basicAuth: { ...basicAuth, ...(basicAuthForbidden && { forbidden: true }) },
+      });
     },
 
     /**

--- a/app/resources/http-proxies/http-proxy.watch.ts
+++ b/app/resources/http-proxies/http-proxy.watch.ts
@@ -60,6 +60,7 @@ export function useHttpProxiesWatch(projectId: string, options?: { enabled?: boo
                       basicAuthEnabled: existingItem.basicAuthEnabled,
                       basicAuthUserCount: existingItem.basicAuthUserCount,
                       basicAuthUsernames: existingItem.basicAuthUsernames,
+                      basicAuthForbidden: existingItem.basicAuthForbidden,
                     }),
                 }
               : item
@@ -110,6 +111,7 @@ export function useHttpProxyWatch(
             basicAuthEnabled: oldData.basicAuthEnabled,
             basicAuthUserCount: oldData.basicAuthUserCount,
             basicAuthUsernames: oldData.basicAuthUsernames,
+            basicAuthForbidden: oldData.basicAuthForbidden,
           }),
       };
     },

--- a/app/resources/http-proxies/index.ts
+++ b/app/resources/http-proxies/index.ts
@@ -75,6 +75,14 @@ export {
   targetRefAttachesToProxy,
 } from './http-proxy.waf-attach';
 
+// Related-resource degradation helper (#1378): 404 -> absent, 403 -> forbidden
+export {
+  resolveRelatedResource,
+  getRelatedResourceErrorStatus,
+  type RelatedResourceResult,
+  type RelatedResourceState,
+} from './related-resource';
+
 export {
   getWafProtectionState,
   isTrafficProtectionProgrammed,

--- a/app/resources/http-proxies/related-resource.ts
+++ b/app/resources/http-proxies/related-resource.ts
@@ -1,0 +1,50 @@
+/**
+ * Related sub-resources of an HTTPProxy (SecurityPolicy, basic-auth Secret,
+ * TrafficProtectionPolicy) can be deleted or become unreadable independently of
+ * the proxy itself (#1378). Reads of those resources must degrade the owning
+ * card — 404 renders its "not configured" empty state, 403 renders an
+ * "insufficient permissions" state — and never hard-fail the page.
+ */
+
+export type RelatedResourceState = 'ok' | 'absent' | 'forbidden' | 'error';
+
+export interface RelatedResourceResult<T> {
+  state: RelatedResourceState;
+  data: T | null;
+  /** Original error, present only when state is 'error' (onUnexpected: 'absorb'). */
+  error?: unknown;
+}
+
+/** HTTP status from an AppError (interceptor) or a raw AxiosError. */
+export function getRelatedResourceErrorStatus(error: unknown): number | undefined {
+  const e = error as { status?: number; response?: { status?: number } } | null | undefined;
+  return typeof e?.status === 'number' ? e.status : e?.response?.status;
+}
+
+/**
+ * Run a related-resource fetch, translating expected failures into states:
+ * 404 → 'absent' (resource not configured), 403 → 'forbidden'. Unexpected
+ * errors rethrow by default; pass onUnexpected: 'absorb' at call sites where
+ * the fetch runs alongside the primary resource (Promise.all) and must never
+ * take the page down — the error is preserved on the result for logging.
+ */
+export async function resolveRelatedResource<T>(
+  fetch: () => Promise<T>,
+  options?: { onUnexpected?: 'rethrow' | 'absorb' }
+): Promise<RelatedResourceResult<T>> {
+  try {
+    return { state: 'ok', data: await fetch() };
+  } catch (error) {
+    const status = getRelatedResourceErrorStatus(error);
+    if (status === 404) {
+      return { state: 'absent', data: null };
+    }
+    if (status === 403) {
+      return { state: 'forbidden', data: null };
+    }
+    if (options?.onUnexpected === 'absorb') {
+      return { state: 'error', data: null, error };
+    }
+    throw error;
+  }
+}

--- a/app/routes/project/detail/edge/detail/overview.tsx
+++ b/app/routes/project/detail/edge/detail/overview.tsx
@@ -118,7 +118,8 @@ export default function HttpProxyOverviewPage() {
           <HttpProxyConfigCard
             proxy={effectiveProxy}
             projectId={projectId}
-            canViewWaf={canViewWaf && !wafError}
+            canViewWaf={canViewWaf && !waf?.forbidden}
+            wafUnavailable={wafError}
             wafPending={wafPending}
             wafProgrammed={waf?.programmed}
             wafProgrammedMessage={waf?.programmedMessage}

--- a/app/routes/project/detail/edge/index.tsx
+++ b/app/routes/project/detail/edge/index.tsx
@@ -276,7 +276,9 @@ function HttpProxyInner({ initialProxies }: { initialProxies: HttpProxy[] }) {
               </div>
             );
           }
-          if (!canViewWaf) {
+          // Either the SSAR denied the view, or the list itself came back 403
+          // (degraded by the service instead of hard-failing — #1378).
+          if (!canViewWaf || wafMaps?.forbidden) {
             return (
               <Tooltip message="You don't have permission to view WAF protection">
                 <Badge

--- a/app/server/middleware/error-handler.ts
+++ b/app/server/middleware/error-handler.ts
@@ -1,10 +1,33 @@
 import { logger } from '@/modules/logger';
+import { buildErrorFingerprint, isExpectedUserError, resolveErrorCode } from '@/modules/sentry';
 import type { Variables } from '@/server/types';
 import { AppError, RateLimitError } from '@/utils/errors/app-error';
 import * as Sentry from '@sentry/react-router';
 import type { Context, ErrorHandler as HonoErrorHandler } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { isRouteErrorResponse } from 'react-router';
+
+/**
+ * Generic bodies for expected user-facing statuses. Raw errors reaching the
+ * backstop (e.g. AxiosError from clients outside the shared interceptors) may
+ * carry upstream internals in their message — never echo those to the client.
+ */
+const EXPECTED_STATUS_RESPONSES: Record<number, { code: string; message: string }> = {
+  400: { code: 'BAD_REQUEST', message: 'Bad Request' },
+  401: { code: 'AUTHENTICATION_ERROR', message: 'Unauthorized' },
+  403: { code: 'AUTHORIZATION_ERROR', message: 'Forbidden' },
+  404: { code: 'NOT_FOUND', message: 'Not Found' },
+  409: { code: 'CONFLICT', message: 'Conflict' },
+  422: { code: 'VALIDATION_ERROR', message: 'Unprocessable Entity' },
+  429: { code: 'RATE_LIMIT_EXCEEDED', message: 'Too Many Requests' },
+};
+
+function resolveErrorStatus(error: unknown): number | undefined {
+  const candidate = error as { status?: unknown; response?: { status?: unknown } };
+  if (typeof candidate.status === 'number') return candidate.status;
+  if (typeof candidate.response?.status === 'number') return candidate.response.status;
+  return undefined;
+}
 
 /**
  * React Router throws an `ErrorResponse` (wrapped Error) when a request
@@ -16,6 +39,12 @@ import { isRouteErrorResponse } from 'react-router';
  * Common sources in production: bot/scanner traffic (`POST //`,
  * `PUT /wp-login.php`), stale browser submissions, and bookmarked
  * deleted resources.
+ *
+ * Any other error carrying an expected user-facing status (401/403/404/429),
+ * such as a raw AxiosError, is likewise answered with its real status and a
+ * sanitized body instead of being captured as a 500 — reaching that branch
+ * means an upstream capture site failed to normalize the error into an
+ * AppError.
  */
 export const errorHandler: HonoErrorHandler<{ Variables: Variables }> = (
   error: Error,
@@ -28,13 +57,14 @@ export const errorHandler: HonoErrorHandler<{ Variables: Variables }> = (
       logger.error(`[${error.code}] ${error.message}`, error, { requestId });
     }
 
-    const response = c.json(error.toJSON(), error.status as 400);
-
+    // Headers must be staged before c.json(): Hono snapshots prepared
+    // headers into the Response at creation time, so a later c.header()
+    // call never reaches the already-created Response.
     if (error instanceof RateLimitError && error.retryAfter) {
       c.header('Retry-After', String(error.retryAfter));
     }
 
-    return response;
+    return c.json(error.toJSON(), error.status as ContentfulStatusCode);
   }
 
   if (isRouteErrorResponse(error)) {
@@ -57,8 +87,28 @@ export const errorHandler: HonoErrorHandler<{ Variables: Variables }> = (
     );
   }
 
+  if (isExpectedUserError(error)) {
+    const status = (resolveErrorStatus(error) ?? 500) as ContentfulStatusCode;
+    const body = EXPECTED_STATUS_RESPONSES[status] ?? {
+      code: 'REQUEST_FAILED',
+      message: 'Request could not be handled',
+    };
+
+    logger.warn(`Expected ${status} reached error handler unnormalized: ${error.message}`, {
+      requestId,
+      path: c.req.path,
+      method: c.req.method,
+    });
+
+    return c.json({ code: body.code, message: body.message, status, requestId }, status);
+  }
+
   const eventId = Sentry.captureException(error, {
-    tags: { request_id: requestId },
+    fingerprint: buildErrorFingerprint(error),
+    tags: {
+      request_id: requestId,
+      code: resolveErrorCode(error),
+    },
     extra: {
       path: c.req.path,
       method: c.req.method,

--- a/app/server/observability/upstream-metrics.ts
+++ b/app/server/observability/upstream-metrics.ts
@@ -1,0 +1,54 @@
+import { parseResourceFromUrl } from '@/modules/sentry';
+import { Counter, register } from 'prom-client';
+
+const UPSTREAM_RESPONSES_TOTAL = 'portal_upstream_responses_total';
+
+/**
+ * Counts every upstream request outcome observed by the server-side axios
+ * layer — successes and errors alike — so expected-4xx anomaly alerts have a
+ * baseline denominator. Connection-level failures (timeout/DNS/refused, no
+ * HTTP response) are recorded with status="network", never as a fabricated
+ * HTTP status. Labels are bounded by design: resource names and namespaces
+ * are never included (cardinality control).
+ *
+ * Reuses the already-registered metric if present: module-level construction
+ * throws "already registered" when the dev server hot-reloads this module
+ * against prom-client's default registry; get-or-create makes re-evaluation
+ * idempotent (same pattern as quota-metrics / rbac metrics).
+ */
+export const upstreamResponsesTotal =
+  (register.getSingleMetric(UPSTREAM_RESPONSES_TOTAL) as
+    | Counter<'status' | 'api_group' | 'resource_type' | 'method'>
+    | undefined) ??
+  new Counter({
+    name: UPSTREAM_RESPONSES_TOTAL,
+    help: 'Count of upstream API responses observed by the server axios layer',
+    labelNames: ['status', 'api_group', 'resource_type', 'method'] as const,
+  });
+
+export interface UpstreamResponseSample {
+  method?: string;
+  url?: string;
+  status: number | string;
+}
+
+/**
+ * Increment `portal_upstream_responses_total` for one upstream response.
+ * `api_group`/`resource_type` are derived from the URL path; both fall back
+ * to "unknown" when the URL is not a K8s-style API path. No-op outside the
+ * server runtime.
+ */
+export function recordUpstreamResponse({ method, url, status }: UpstreamResponseSample): void {
+  if (typeof window !== 'undefined') return;
+  try {
+    const resource = url ? parseResourceFromUrl(url) : null;
+    upstreamResponsesTotal.inc({
+      status: String(status),
+      api_group: resource?.apiGroup ?? 'unknown',
+      resource_type: resource?.resourceType ?? 'unknown',
+      method: method?.toUpperCase() ?? 'UNKNOWN',
+    });
+  } catch {
+    // Metrics must never fail the request path.
+  }
+}

--- a/app/utils/config/sentry.config.ts
+++ b/app/utils/config/sentry.config.ts
@@ -1,6 +1,10 @@
 export const sentryConfig = {
-  isSourcemapEnabled:
-    process.env.NODE_ENV === 'production' && process.env.VERSION?.includes('main'),
+  // Gate sourcemap upload on "production build + auth token present" — NOT on
+  // VERSION contents. The previous `VERSION?.includes('main')` gate never
+  // matched production releases (tagged vX.Y.Z), so sourcemaps never uploaded
+  // and stacks grouped on bundled line numbers that shift every release,
+  // splitting one bug into a separate Sentry issue per release.
+  isSourcemapEnabled: process.env.NODE_ENV === 'production' && !!process.env.SENTRY_AUTH_TOKEN,
   org: 'sentry',
   project: 'cloud-portal',
   authToken: process.env.SENTRY_AUTH_TOKEN,

--- a/app/utils/errors/app-error.ts
+++ b/app/utils/errors/app-error.ts
@@ -1,19 +1,26 @@
 import * as Sentry from '@sentry/react-router';
 
 /**
- * HTTP status codes that represent expected user-facing states
- * (e.g. resource not found, permission denied, session expired).
+ * True for any 4xx — a request the upstream rejected over its content or the
+ * caller's permissions (not found, forbidden, session expired, rate limited,
+ * already exists, validation rejected, ...).
  *
- * Errors with these statuses are not captured to Sentry and are rendered
- * with a user-friendly message rather than "our team has been notified".
+ * These are surfaced to the user as a message they can act on — an error
+ * boundary, a toast, or an inline field error — so they are never captured to
+ * Sentry and never render "our team has been notified". `AppError` already
+ * draws this line internally via `captureToSentry ?? status >= 500`; this
+ * keeps the interceptors and framework handlers consistent with it instead of
+ * maintaining a separate allowlist that has to grow every time a new status
+ * shows up (401/403/404/429 originally, then 409/422, ...).
  *
- * Other 4xx codes (400, 409, 429, ...) reaching the route error boundary
- * usually indicate a bug — those are still captured.
+ * Volume is not lost: `portal_upstream_responses_total` counts every upstream
+ * response by status, so a 4xx caused by OUR bug (e.g. a malformed request
+ * producing 400s) surfaces as a metrics anomaly rather than a Sentry issue.
+ *
+ * 5xx and unhandled throwables mean we broke — those are still captured.
  */
-export const USER_FACING_ERROR_STATUSES: ReadonlySet<number> = new Set([401, 403, 404]);
-
 export function isUserFacingErrorStatus(status: number | undefined): boolean {
-  return typeof status === 'number' && USER_FACING_ERROR_STATUSES.has(status);
+  return typeof status === 'number' && status >= 400 && status < 500;
 }
 
 export interface ErrorDetail {
@@ -62,6 +69,14 @@ export class AppError extends Error {
       originalMessage?: string;
       k8sReason?: string;
       k8sDetails?: K8sErrorDetails;
+      /**
+       * Sentry event id of a capture already performed upstream (e.g. by
+       * `captureApiError` in the axios interceptors). Serialized into the
+       * response body so downstream layers (client interceptors) can skip a
+       * duplicate capture. A fresh capture (status >= 500 with no explicit
+       * `captureToSentry: false`) overwrites it.
+       */
+      sentryEventId?: string;
     } = {}
   ) {
     super(message, { cause: options.cause });
@@ -73,6 +88,7 @@ export class AppError extends Error {
     this.originalMessage = options.originalMessage;
     this.k8sReason = options.k8sReason;
     this.k8sDetails = options.k8sDetails;
+    this.sentryEventId = options.sentryEventId;
 
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);

--- a/app/utils/errors/index.ts
+++ b/app/utils/errors/index.ts
@@ -6,7 +6,6 @@ export {
   NotFoundError,
   ConflictError,
   RateLimitError,
-  USER_FACING_ERROR_STATUSES,
   isUserFacingErrorStatus,
   type ErrorDetail,
   type SerializedError,

--- a/observability/providers/otel.ts
+++ b/observability/providers/otel.ts
@@ -66,6 +66,8 @@ export class OtelProvider extends BaseProvider {
         return false;
       }
 
+      this.warnTypedErrorsAreMangled();
+
       if (this.isInitialized) {
         console.log('✅ OpenTelemetry already initialized');
         return true;
@@ -137,6 +139,26 @@ export class OtelProvider extends BaseProvider {
   // ============================================================================
   // PRIVATE METHODS
   // ============================================================================
+
+  /**
+   * With OTEL instrumentation loaded, axios's `request()` wrapper calls
+   * `Error.captureStackTrace({})`, which throws under Bun — and the thrown
+   * error REPLACES the original. Typed AppErrors lose `status`, so
+   * `classifyError` reports 'unknown-failure': the 4xx Sentry filter stops
+   * working and a missing resource renders "Whoops! Something went wrong —
+   * First argument must be an Error object" instead of the not-found page.
+   *
+   * Reproduced on this branch and on main; not reproducible outside a running
+   * app with OTEL loaded, so no automated test guards it. This warning is the
+   * guard.
+   */
+  private warnTypedErrorsAreMangled(): void {
+    console.warn(
+      '⚠️ OTEL enabled: known Bun+axios incompatibility replaces typed errors, ' +
+        'dropping HTTP status. Sentry 4xx filtering and not-found pages will ' +
+        'misbehave until that is fixed.'
+    );
+  }
 
   private logDisabledStatus(): void {
     console.log('📊 OpenTelemetry is disabled or endpoint not configured');

--- a/observability/providers/sentry.ts
+++ b/observability/providers/sentry.ts
@@ -155,20 +155,21 @@ export class SentryProvider extends BaseProvider {
   }
 
   private getTracesSampleRate(): number {
-    return 1.0;
+    return env.public.sentryEnv === 'production' ? 0.1 : 1.0;
   }
 
   private createBeforeSendHandler() {
-    return (event: any, _hint: any) => {
+    return (event: any, hint: any) => {
       if (this.circuitBreakerOpen) {
         console.warn('⚠️ Sentry circuit breaker open, skipping event');
         return null;
       }
 
-      // Drop events that aren't actionable: known system actors and
-      // bot-driven React Router 405s. Keeps Sentry focused on real
-      // user-facing errors.
-      if (shouldDropSentryEvent(event)) {
+      // Drop events that aren't actionable: known system actors,
+      // bot-driven React Router 405s, and expected user-state 4xx that
+      // leaked past their capture sites (hint-aware backstop). Server-side
+      // network failures stay captured — they are infra signals.
+      if (shouldDropSentryEvent(event, hint)) {
         return null;
       }
 


### PR DESCRIPTION
## Summary

Fixes #1378.

Production Sentry held **244 unresolved issues over 90 days**, dominated by expected HTTP states (401 session expiry, 403 permission denied, 404 deleted resources, 429 rate limits) captured as error-level events — burying real bugs like the hydration error (891 events / 75 users). This PR rebuilds the capture pipeline with defense in depth and fixes the underlying #1378 product bugs.

### Root causes addressed

1. **Capture-policy asymmetry** — the client axios interceptor captured every failed response while the server one skipped 401/403/404. Client now has parity, and 429 joins the expected set.
2. **Raw AxiosError bypass** — the prometheus/cloudvalid axios instances lacked the AppError transform, so raw 4xx errors escaped to the framework handlers and merged into one 6.6K-event mega-issue grouped on axios-internal stack frames (the issue #1378 reports). A shared upstream error handler now covers all server instances, and both framework handlers classify any error shape instead of `instanceof AppError`.
3. **Sourcemaps never uploaded in production** — the upload gate required `VERSION` to contain `main`, which `vX.Y.Z` release tags never match. Stacks grouped on shifting bundle line numbers, splitting one bug (`projectId is required…`) into 13 issues. Gate is now production build + auth token.
4. **Noise amplification** — TanStack Query retried expected 4xx (doubling volume); replay recorded 50% of all sessions; server traces sampled at 100%. Now: no retry on expected 4xx, replay 1% / 100% on-error, traces 10% in production.

### Architecture (defense in depth)

- `classifyError()` (`app/modules/sentry/classify.ts`) is the single source of truth, consulted by both axios interceptors, both framework handlers, the logger, and the `beforeSend` backstop.
- The backstop inspects `hint.originalException` (object inspection, not message regex) and warns outside production when an expected error leaks through — so leaks get fixed at the capture site.
- Expected 4xx volume is not lost: a new `portal_upstream_responses_total` prom-client counter (status / api_group / resource_type / method) covers every server-side upstream call. Anomaly alert rules on this metric are defined infra-side (VictoriaMetrics/Grafana), so a #1378-style 404 storm pages via metrics instead of rotting in Sentry.

### #1378 product fixes

- **rbac**: project-scoped permission checks fired before `projectId` resolved in RbacContext (~870 Sentry events). Hooks now stay disabled (fail-closed) until project context lands; the BFF rejects project-scope payloads without projectId.
- **edge/ALB**: deleted or permission-blocked related resources (security policies, traffic protection policies, basic-auth secrets) render not-configured / insufficient-permissions card states instead of erroring; the overview page never hard-fails.
- **auth**: Zitadel OIDC discovery no longer runs as a top-level await at import time.