### PR TITLE
feat(auth): gate platform access on email verification behind a default-off flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,25 @@ NODE_ENV=development
 # ANTHROPIC_MODEL=claude-sonnet-4-6
 
 # ───────────────────────────────────────────────────────────
+# Optional: Passkey Phase B — email verification hard gate
+# ───────────────────────────────────────────────────────────
+
+# Portal half of the two-switch hard gate. When 'true', any user whose
+# User.status.emailVerified is not true is redirected to /verify-email and
+# cannot reach any other page. DEFAULT OFF; only the exact string 'true'
+# enables it. Flipping requires a Deployment roll — the value is read from
+# the process environment.
+#
+# Enable order:  portal (this) FIRST, then milo's gate.
+# Disable order: milo's gate FIRST, then portal (this).
+#
+# DO NOT turn this on before the B3a backfill Job has run and its "how many
+# read false" count has been reviewed. Every pre-Phase-B User CR lacks the
+# field, and this gate reads absent as unverified — an early flip locks out
+# the entire existing user base.
+# EMAIL_VERIFICATION_GATE=true
+
+# ───────────────────────────────────────────────────────────
 # Optional: Usage Pipeline (Milo billing → Amberflo)
 #
 # When USAGE_GATEWAY_URL is unset, every chat completion is logged as

--- a/.env.example
+++ b/.env.example
@@ -154,7 +154,7 @@ NODE_ENV=development
 # ANTHROPIC_MODEL=claude-sonnet-4-6
 
 # ───────────────────────────────────────────────────────────
-# Optional: Passkey Phase B — email verification hard gate
+# Optional: email verification hard gate
 # ───────────────────────────────────────────────────────────
 
 # Portal half of the two-switch hard gate. When 'true', any user whose
@@ -166,10 +166,10 @@ NODE_ENV=development
 # Enable order:  portal (this) FIRST, then milo's gate.
 # Disable order: milo's gate FIRST, then portal (this).
 #
-# DO NOT turn this on before the B3a backfill Job has run and its "how many
-# read false" count has been reviewed. Every pre-Phase-B User CR lacks the
-# field, and this gate reads absent as unverified — an early flip locks out
-# the entire existing user base.
+# DO NOT turn this on before the milo backfill job has run and its "how many
+# read false" count has been reviewed. Every User record predating the gate
+# lacks the field, and this gate reads absent as unverified — an early flip
+# locks out the entire existing user base.
 # EMAIL_VERIFICATION_GATE=true
 
 # ───────────────────────────────────────────────────────────

--- a/app/features/account/email-verification/email-verification-error.test.ts
+++ b/app/features/account/email-verification/email-verification-error.test.ts
@@ -1,0 +1,45 @@
+import { EMAIL_NOT_VERIFIED_CAUSE, isEmailNotVerifiedDenial } from './email-verification-error';
+import { describe, expect, it } from 'bun:test';
+
+const denial = JSON.stringify({
+  kind: 'Status',
+  status: 'Failure',
+  code: 403,
+  message: 'email address for "a@b.com" is not verified',
+  details: { causes: [{ type: EMAIL_NOT_VERIFIED_CAUSE, message: 'not verified' }] },
+});
+
+describe('isEmailNotVerifiedDenial', () => {
+  it("matches milo's verification denial", () => {
+    expect(isEmailNotVerifiedDenial(denial)).toBe(true);
+  });
+
+  it('ignores a suspension denial', () => {
+    const suspended = JSON.stringify({
+      code: 403,
+      details: { causes: [{ type: 'ProjectSuspended' }] },
+    });
+    expect(isEmailNotVerifiedDenial(suspended)).toBe(false);
+  });
+
+  it('does not match on message text alone', () => {
+    // The whole point of the typed channel: a 403 that merely mentions
+    // verification must not trigger a refresh-and-retry.
+    const lookalike = JSON.stringify({
+      code: 403,
+      message: 'email address is not verified',
+      details: { causes: [] },
+    });
+    expect(isEmailNotVerifiedDenial(lookalike)).toBe(false);
+  });
+
+  it('returns false for a non-JSON body rather than throwing', () => {
+    // Upstream can return HTML from a gateway; the proxy must still forward
+    // the original 403 instead of 500ing on a parse error.
+    expect(isEmailNotVerifiedDenial('<html>502</html>')).toBe(false);
+  });
+
+  it('returns false when details are absent', () => {
+    expect(isEmailNotVerifiedDenial(JSON.stringify({ code: 403 }))).toBe(false);
+  });
+});

--- a/app/features/account/email-verification/email-verification-error.ts
+++ b/app/features/account/email-verification/email-verification-error.ts
@@ -1,0 +1,37 @@
+import { AppError } from '@/utils/errors/app-error';
+
+/**
+ * milo's EmailNotVerifiedCause, emitted by the EmailVerificationEnforcement
+ * admission plugin. A ValidatingAdmissionPolicy cannot set one — its `reason`
+ * is limited to the built-in enum — which is why enforcement is a plugin.
+ */
+export const EMAIL_NOT_VERIFIED_CAUSE = 'EmailNotVerified';
+
+/**
+ * Server-side: does this raw 403 body carry the verification cause?
+ *
+ * Reads the K8s Status directly because the proxy sees the response before the
+ * axios interceptor has parsed anything. Deliberately not a substring match on
+ * the body — `causes[].type` is the typed channel, and matching the message
+ * would break the moment the wording changes.
+ */
+export function isEmailNotVerifiedDenial(body: string): boolean {
+  try {
+    const status = JSON.parse(body) as {
+      details?: { causes?: Array<{ type?: string }> };
+    };
+    return (status.details?.causes ?? []).some((c) => c.type === EMAIL_NOT_VERIFIED_CAUSE);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Client-side: same denial, after the axios interceptor has mapped
+ * `cause.reason` onto `AppError.details[].code`
+ * (app/modules/axios/k8s-error.ts:78-97). Mirrors isProjectSuspendedError.
+ */
+export function isEmailNotVerifiedError(error: unknown): boolean {
+  if (!(error instanceof AppError) || error.status !== 403) return false;
+  return (error.details ?? []).some((d) => d.code === EMAIL_NOT_VERIFIED_CAUSE);
+}

--- a/app/modules/plugins/server/dev-session.ts
+++ b/app/modules/plugins/server/dev-session.ts
@@ -108,6 +108,9 @@ export function createDevSessionRoutes() {
       accessToken,
       expiredAt,
       sub: decoded.sub,
+      // Service-account principal — no email to verify. Matches
+      // buildDevStubUser, without which the e2e suite stops at the gate.
+      emailVerified: true,
     });
     sessionHeaders.forEach((value, key) => {
       if (key.toLowerCase() === 'set-cookie') {

--- a/app/modules/quota/quota-toast.tsx
+++ b/app/modules/quota/quota-toast.tsx
@@ -1,4 +1,5 @@
 import { classifyQuotaError, parseQuotaError } from './quota-error';
+import { isEmailNotVerifiedError } from '@/features/account/email-verification/email-verification-error';
 import { isProjectReadOnlyError } from '@/features/project/read-only/project-read-only-error';
 import { isProjectSuspendedError } from '@/features/project/suspension/classify-suspension-error';
 import { showProjectSuspendedToast } from '@/features/project/suspension/suspension-toast';
@@ -72,6 +73,21 @@ export function showMutationErrorToast(
   error: unknown,
   opts: QuotaToastContext & { fallbackTitle: string; fallbackDescription?: string }
 ): void {
+  // Verification outranks both, matching the server: milo runs
+  // EmailVerificationEnforcement ahead of ProjectSuspensionEnforcement, so when
+  // both apply the denial that comes back is EmailNotVerified. Checking
+  // suspension first would render a toast for a denial nobody issued.
+  //
+  // A redirect rather than a toast: an unverified account fails EVERY write, so
+  // a toast per attempt is noise, and unlike a suspension the user can fix this
+  // themselves. The proxy has already refreshed and retried once by this point,
+  // so reaching here means the account genuinely is unverified rather than the
+  // TokenReview being stale.
+  if (isEmailNotVerifiedError(error)) {
+    window.location.assign(paths.fraud.verifyEmail);
+    return;
+  }
+
   // Suspension outranks quota: a suspended project's writes 403 with
   // ProjectSuspended regardless of quota headroom. ProjectReadOnlyError is the
   // client-side equivalent from useGuardedMutation — it never reaches the

--- a/app/resources/users/user.adapter.test.ts
+++ b/app/resources/users/user.adapter.test.ts
@@ -63,9 +63,9 @@ describe('toUser', () => {
       status: { platformAccess: 'Approved', state: 'Active' },
     };
 
-    // Every pre-Phase-B User CR looks exactly like this. `undefined` here would
-    // make `emailVerified === false` in the cascade read as VERIFIED, which is
-    // the opposite of what the spec asks for.
+    // Every User record predating the gate looks exactly like this. Leaving it
+    // `undefined` would make an `emailVerified === false` check in the cascade
+    // read as VERIFIED — the opposite of the intended behaviour.
     expect(toUser(raw as never).emailVerified).toBe(false);
   });
 

--- a/app/resources/users/user.adapter.test.ts
+++ b/app/resources/users/user.adapter.test.ts
@@ -46,36 +46,28 @@ describe('toUser', () => {
     expect(user.country).toBe('US');
   });
 
-  it('maps status.emailVerified when milo reports it true', () => {
+  it('never reads emailVerified from the resource, even if milo sends one', () => {
     const raw = {
       metadata: { name: 'user-3', annotations: {} },
       spec: { email: 'a@b.com', givenName: 'A', familyName: 'B' },
       status: { platformAccess: 'Approved', state: 'Active', emailVerified: true },
     };
 
-    expect(toUser(raw as never).emailVerified).toBe(true);
+    // The signal is an id_token claim, overlaid by getUserWithAccessRetry.
+    // Trusting a resource field would let anything able to write User status
+    // grant itself the gate.
+    expect(toUser(raw as never).emailVerified).toBe(false);
   });
 
-  it('fails CLOSED when status.emailVerified is absent', () => {
+  it('fails CLOSED when nothing overlays a value', () => {
     const raw = {
       metadata: { name: 'user-4', annotations: {} },
       spec: { email: 'a@b.com', givenName: 'A', familyName: 'B' },
       status: { platformAccess: 'Approved', state: 'Active' },
     };
 
-    // Every User record predating the gate looks exactly like this. Leaving it
-    // `undefined` would make an `emailVerified === false` check in the cascade
-    // read as VERIFIED — the opposite of the intended behaviour.
-    expect(toUser(raw as never).emailVerified).toBe(false);
-  });
-
-  it('fails CLOSED on a non-boolean value from a future milo', () => {
-    const raw = {
-      metadata: { name: 'user-5', annotations: {} },
-      spec: { email: 'a@b.com', givenName: 'A', familyName: 'B' },
-      status: { platformAccess: 'Approved', state: 'Active', emailVerified: 'true' },
-    };
-
+    // Leaving it `undefined` would make an `emailVerified === false` check in
+    // the cascade read as VERIFIED — the opposite of the intended behaviour.
     expect(toUser(raw as never).emailVerified).toBe(false);
   });
 

--- a/app/resources/users/user.adapter.test.ts
+++ b/app/resources/users/user.adapter.test.ts
@@ -46,6 +46,39 @@ describe('toUser', () => {
     expect(user.country).toBe('US');
   });
 
+  it('maps status.emailVerified when milo reports it true', () => {
+    const raw = {
+      metadata: { name: 'user-3', annotations: {} },
+      spec: { email: 'a@b.com', givenName: 'A', familyName: 'B' },
+      status: { platformAccess: 'Approved', state: 'Active', emailVerified: true },
+    };
+
+    expect(toUser(raw as never).emailVerified).toBe(true);
+  });
+
+  it('fails CLOSED when status.emailVerified is absent', () => {
+    const raw = {
+      metadata: { name: 'user-4', annotations: {} },
+      spec: { email: 'a@b.com', givenName: 'A', familyName: 'B' },
+      status: { platformAccess: 'Approved', state: 'Active' },
+    };
+
+    // Every pre-Phase-B User CR looks exactly like this. `undefined` here would
+    // make `emailVerified === false` in the cascade read as VERIFIED, which is
+    // the opposite of what the spec asks for.
+    expect(toUser(raw as never).emailVerified).toBe(false);
+  });
+
+  it('fails CLOSED on a non-boolean value from a future milo', () => {
+    const raw = {
+      metadata: { name: 'user-5', annotations: {} },
+      spec: { email: 'a@b.com', givenName: 'A', familyName: 'B' },
+      status: { platformAccess: 'Approved', state: 'Active', emailVerified: 'true' },
+    };
+
+    expect(toUser(raw as never).emailVerified).toBe(false);
+  });
+
   it('applies preference defaults and leaves status-derived fields undefined', () => {
     const raw = {
       metadata: { name: 'user-2', annotations: {} },

--- a/app/resources/users/user.adapter.ts
+++ b/app/resources/users/user.adapter.ts
@@ -48,6 +48,7 @@ export interface ComMiloapisIamV1Alpha1User {
     state: string;
     avatarUrl?: string;
     lastLoginProvider?: 'google' | 'github';
+    emailVerified?: boolean;
   };
 }
 
@@ -85,6 +86,16 @@ export function toUser(raw: ComMiloapisIamV1Alpha1User): User {
         ? (status.lastLoginProvider as LastLoginProviderValue)
         : undefined,
     nameReviewRequired: metadata?.annotations?.[USER_NAME_REVIEW_REQUIRED_ANNOTATION] === 'true',
+    // Fails CLOSED: only a literal `true` counts as verified. Anything else —
+    // absent (every pre-Phase-B User CR), null, or a non-boolean a future milo
+    // might send — maps to false.
+    //
+    // This coercion is what lets the redirect cascade be written as the spec
+    // phrases it (`emailVerified === false`) while behaving as the spec
+    // intends ("absent reads as false → naturally fail-closed"). Without it
+    // those two sentences disagree, because `undefined === false` is false.
+    // Same shape and same reasoning as toPasskey's state mapping below.
+    emailVerified: status?.emailVerified === true,
     country: metadata?.annotations?.[USER_PROFILE_COUNTRY_ANNOTATION],
   };
 }

--- a/app/resources/users/user.adapter.ts
+++ b/app/resources/users/user.adapter.ts
@@ -48,7 +48,6 @@ export interface ComMiloapisIamV1Alpha1User {
     state: string;
     avatarUrl?: string;
     lastLoginProvider?: 'google' | 'github';
-    emailVerified?: boolean;
   };
 }
 
@@ -86,13 +85,10 @@ export function toUser(raw: ComMiloapisIamV1Alpha1User): User {
         ? (status.lastLoginProvider as LastLoginProviderValue)
         : undefined,
     nameReviewRequired: metadata?.annotations?.[USER_NAME_REVIEW_REQUIRED_ANNOTATION] === 'true',
-    // Fails CLOSED: only a literal `true` counts as verified. Anything else —
-    // absent (every User record predating the gate), null, or a non-boolean a
-    // future milo might send — maps to false. Without this coercion every call
-    // site would have to spell out the absent case itself, since
-    // `undefined === false` is false. Same shape and reasoning as toPasskey's
-    // state mapping below.
-    emailVerified: status?.emailVerified === true,
+    // milo carries no verification state — the signal is a token claim, and
+    // getUserWithAccessRetry overlays it from the session. False here so a
+    // caller reached without that overlay fails closed.
+    emailVerified: false,
     country: metadata?.annotations?.[USER_PROFILE_COUNTRY_ANNOTATION],
   };
 }

--- a/app/resources/users/user.adapter.ts
+++ b/app/resources/users/user.adapter.ts
@@ -87,14 +87,11 @@ export function toUser(raw: ComMiloapisIamV1Alpha1User): User {
         : undefined,
     nameReviewRequired: metadata?.annotations?.[USER_NAME_REVIEW_REQUIRED_ANNOTATION] === 'true',
     // Fails CLOSED: only a literal `true` counts as verified. Anything else —
-    // absent (every pre-Phase-B User CR), null, or a non-boolean a future milo
-    // might send — maps to false.
-    //
-    // This coercion is what lets the redirect cascade be written as the spec
-    // phrases it (`emailVerified === false`) while behaving as the spec
-    // intends ("absent reads as false → naturally fail-closed"). Without it
-    // those two sentences disagree, because `undefined === false` is false.
-    // Same shape and same reasoning as toPasskey's state mapping below.
+    // absent (every User record predating the gate), null, or a non-boolean a
+    // future milo might send — maps to false. Without this coercion every call
+    // site would have to spell out the absent case itself, since
+    // `undefined === false` is false. Same shape and reasoning as toPasskey's
+    // state mapping below.
     emailVerified: status?.emailVerified === true,
     country: metadata?.annotations?.[USER_PROFILE_COUNTRY_ANNOTATION],
   };

--- a/app/resources/users/user.schema.ts
+++ b/app/resources/users/user.schema.ts
@@ -39,8 +39,8 @@ export const userResourceSchema = z.object({
   avatarUrl: z.string().optional(),
   nameReviewRequired: z.boolean().optional(),
   /**
-   * Milo `User.status.emailVerified` — Phase B's hard-gate signal, written only
-   * by zitadel-provider on the write-restricted status subresource. Optional on
+   * Milo `User.status.emailVerified` — the email gate's signal, written only by
+   * zitadel-provider on the write-restricted status subresource. Optional on
    * the schema because `buildDevStubUser` and every test fixture construct a
    * User by hand; `toUser` itself always emits a boolean, and every consumer
    * treats absent as unverified.

--- a/app/resources/users/user.schema.ts
+++ b/app/resources/users/user.schema.ts
@@ -38,6 +38,14 @@ export const userResourceSchema = z.object({
   lastLoginProvider: z.enum(LAST_LOGIN_PROVIDER_VALUES).optional(),
   avatarUrl: z.string().optional(),
   nameReviewRequired: z.boolean().optional(),
+  /**
+   * Milo `User.status.emailVerified` — Phase B's hard-gate signal, written only
+   * by zitadel-provider on the write-restricted status subresource. Optional on
+   * the schema because `buildDevStubUser` and every test fixture construct a
+   * User by hand; `toUser` itself always emits a boolean, and every consumer
+   * treats absent as unverified.
+   */
+  emailVerified: z.boolean().optional(),
   /** ISO 3166-1 alpha-2 code from `metadata.annotations['profile/country']`. */
   country: z.string().optional(),
 });

--- a/app/resources/users/user.schema.ts
+++ b/app/resources/users/user.schema.ts
@@ -39,11 +39,10 @@ export const userResourceSchema = z.object({
   avatarUrl: z.string().optional(),
   nameReviewRequired: z.boolean().optional(),
   /**
-   * Milo `User.status.emailVerified` — the email gate's signal, written only by
-   * zitadel-provider on the write-restricted status subresource. Optional on
-   * the schema because `buildDevStubUser` and every test fixture construct a
-   * User by hand; `toUser` itself always emits a boolean, and every consumer
-   * treats absent as unverified.
+   * The email gate's signal. Not a milo field — it comes from the id_token's
+   * `email_verified` claim, overlaid onto the User by `getUserWithAccessRetry`.
+   * Optional because fixtures and `buildDevStubUser` construct a User by hand;
+   * every consumer treats absent as unverified.
    */
   emailVerified: z.boolean().optional(),
   /** ISO 3166-1 alpha-2 code from `metadata.annotations['profile/country']`. */

--- a/app/routes-layout-invariant.test.ts
+++ b/app/routes-layout-invariant.test.ts
@@ -1,0 +1,56 @@
+import routeConfig from './routes';
+import { paths } from '@/utils/config/paths.config';
+import { describe, expect, it } from 'bun:test';
+
+/**
+ * The blocking-page invariant, asserted once so three defensive guards
+ * elsewhere don't each have to be trusted on their own.
+ *
+ * Every page the redirect cascade can send a user TO must sit outside the
+ * private layout. Inside it, the layout would run the middleware that issued
+ * the redirect and bounce the user to the same page forever. The guards in
+ * resolveUserFraudRedirectPath, authMiddleware's skip list, and
+ * fraudStatusMiddleware are written to survive a break here — but nothing
+ * except this test tells you the break happened.
+ */
+
+type RouteEntry = { file?: string; path?: string; children?: RouteEntry[] };
+
+const BLOCKING_PAGES = [
+  paths.fraud.verifying,
+  paths.fraud.accountUnderReview,
+  paths.fraud.accountSuspended,
+  paths.fraud.verifyEmail,
+];
+
+/** `route('verify-email', ...)` declares path 'verify-email'; paths.config uses '/verify-email'. */
+const toRouteSegment = (path: string): string => path.replace(/^\//, '');
+
+const topLevelPaths = new Set(
+  (routeConfig as RouteEntry[]).map((entry) => entry.path).filter((path): path is string => !!path)
+);
+
+const collectNested = (entries: RouteEntry[]): string[] =>
+  entries.flatMap((entry) => [
+    ...(entry.children ?? []).map((child) => child.path).filter((p): p is string => !!p),
+    ...collectNested(entry.children ?? []),
+  ]);
+
+const nestedPaths = new Set(collectNested(routeConfig as RouteEntry[]));
+
+describe('blocking-page routing invariant', () => {
+  it.each(BLOCKING_PAGES)('%s is declared at the top level', (page) => {
+    expect(topLevelPaths.has(toRouteSegment(page))).toBe(true);
+  });
+
+  it.each(BLOCKING_PAGES)('%s is not nested inside any layout', (page) => {
+    expect(nestedPaths.has(toRouteSegment(page))).toBe(false);
+  });
+
+  it('has a route for every page the cascade can redirect to', () => {
+    // Guards the reverse direction: adding a fifth destination to
+    // resolveUserFraudRedirectPath without a route here would 404 the user
+    // into a dead end rather than blocking them.
+    expect(BLOCKING_PAGES.every((page) => topLevelPaths.has(toRouteSegment(page)))).toBe(true);
+  });
+});

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -264,14 +264,25 @@ export default [
     ]),
   ]),
 
-  // Fraud / gating routes — outside the private layout because the private layout loader fetches
-  // the user and would throw NotFoundError for brand-new users not yet in Milo.
-  // These pages use BlankLayout and handle their own auth checks.
-  // The /api/fraud-status polling endpoint is handled by the Hono server (app/server/routes/fraud-status.ts).
+  // BLOCKING-PAGE INVARIANT: every page the redirect cascade can send a user TO
+  // must be declared here, outside the private layout.
+  //
+  // Two reasons, and both bite. The private layout loader fetches the user and
+  // would throw NotFoundError for brand-new users not yet in Milo. And the
+  // layout runs the very middleware that redirects — so a blocking page mounted
+  // inside it would redirect to itself forever.
+  //
+  // resolveUserFraudRedirectPath has one branch per page below, and its
+  // self-exclusion guards are written to hold even if this invariant breaks.
+  // routes-layout-invariant.test.ts asserts the placement, so a fifth page
+  // cannot be added in the wrong place quietly.
+  //
+  // These pages use BlankLayout and handle their own auth checks. The
+  // /api/fraud-status polling endpoint is served by Hono
+  // (app/server/routes/fraud-status.ts).
   route('verifying', 'routes/fraud/verifying.tsx'),
   route('account-under-review', 'routes/fraud/account-under-review.tsx'),
   route('account-suspended', 'routes/fraud/account-suspended.tsx'),
-  // Phase B email-verification gate. Same placement rule as its three siblings.
   route('verify-email', 'routes/fraud/verify-email.tsx'),
   // Global Routes
   route('logout', 'routes/auth/logout.tsx', { id: 'logout' }),

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -271,6 +271,8 @@ export default [
   route('verifying', 'routes/fraud/verifying.tsx'),
   route('account-under-review', 'routes/fraud/account-under-review.tsx'),
   route('account-suspended', 'routes/fraud/account-suspended.tsx'),
+  // Phase B email-verification gate. Same placement rule as its three siblings.
+  route('verify-email', 'routes/fraud/verify-email.tsx'),
   // Global Routes
   route('logout', 'routes/auth/logout.tsx', { id: 'logout' }),
 

--- a/app/routes/auth/callback.tsx
+++ b/app/routes/auth/callback.tsx
@@ -1,6 +1,6 @@
 import { LogoIcon } from '@/components/logo/logo-icon';
 import { authenticator } from '@/modules/auth/auth.server';
-import { AUTH_CONFIG, AuthService } from '@/utils/auth';
+import { AUTH_CONFIG, AuthService, readEmailVerified } from '@/utils/auth';
 import type { IAuthSession } from '@/utils/auth';
 import { paths } from '@/utils/config/paths.config';
 import {
@@ -62,6 +62,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       accessToken: rest.accessToken,
       expiredAt: rest.expiredAt,
       sub: decoded.sub,
+      emailVerified: readEmailVerified(idToken),
     });
 
     // Handle refresh token (long-lived cookie) - SEPARATE from session

--- a/app/routes/fraud/verify-email.tsx
+++ b/app/routes/fraud/verify-email.tsx
@@ -1,0 +1,103 @@
+import BlankLayout from '@/layouts/blank.layout';
+import { createUserService } from '@/resources/users';
+import { paths } from '@/utils/config/paths.config';
+import { getSession } from '@/utils/cookies';
+import { mergeMeta, metaObject } from '@/utils/helpers/meta.helper';
+import {
+  isAwaitingEmailVerification,
+  resolveVerifyEmailPageRedirect,
+  type FraudPollResult,
+} from '@/utils/middlewares/fraud-redirect';
+import { Card, CardContent } from '@datum-cloud/datum-ui/card';
+import { useEffect } from 'react';
+import { Link, MetaFunction, LoaderFunctionArgs, redirect } from 'react-router';
+
+export const meta: MetaFunction = mergeMeta(() => {
+  return metaObject('Verify Your Email');
+});
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { session } = await getSession(request);
+
+  if (!session?.sub) {
+    return redirect(paths.auth.logOut);
+  }
+
+  // `null` means "could not read the user", which renders the page. Passing the
+  // caught error through as a user would be the bug: an outage must not open
+  // the gate. See resolveVerifyEmailPageRedirect.
+  let user: { emailVerified?: boolean } | null = null;
+  try {
+    user = await createUserService().get(session.sub);
+  } catch {
+    user = null;
+  }
+
+  const away = resolveVerifyEmailPageRedirect(user);
+  return away ? redirect(away) : null;
+};
+
+export default function VerifyEmailPage() {
+  useEffect(() => {
+    let stopped = false;
+
+    const poll = async () => {
+      if (stopped) return;
+
+      try {
+        const response = await fetch(paths.fraud.statusApi, { credentials: 'include' });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const result = (await response.json()) as FraudPollResult;
+
+        // Still waiting on the address — keep polling.
+        if (isAwaitingEmailVerification(result)) {
+          return;
+        }
+
+        // Anything else means the address is proven. Where to go next is
+        // deliberately NOT decided here. /verifying re-derives its destination
+        // client-side because its poll hands it a `redirectTo`; this page has no
+        // such target, and re-implementing the cascade in the browser is how the
+        // two copies drift. One hop through the server re-runs
+        // resolveUserFraudRedirectPath and lands the user wherever it says —
+        // /verifying if staff review is still pending, onboarding if approved.
+        window.location.replace(paths.home);
+      } catch {
+        // Fail silently — continue polling on network errors
+      }
+    };
+
+    poll(); // fire immediately — don't wait 4s if the link was already clicked
+    const intervalId = setInterval(poll, 4000);
+
+    return () => {
+      stopped = true;
+      clearInterval(intervalId);
+    };
+  }, []);
+
+  return (
+    <BlankLayout>
+      <Card className="bg-card text-foreground z-10 w-full max-w-full rounded-xl border p-3 sm:max-w-sm sm:p-4 md:p-6 lg:p-8 xl:p-11">
+        <CardContent className="p-0">
+          <h2 className="mb-3 text-center text-xl font-medium">Check your email</h2>
+          <p className="text-center text-[14px] leading-5 font-normal">
+            We sent a verification link to your email address. Open it to continue — this page
+            updates on its own once you have.
+          </p>
+          <div className="mt-6 text-center">
+            <Link
+              to={paths.auth.logOut}
+              className="dark:text-foreground dark:hover:text-foreground text-[14px] text-gray-600 underline hover:text-gray-900">
+              Log out
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </BlankLayout>
+  );
+}

--- a/app/routes/fraud/verify-email.tsx
+++ b/app/routes/fraud/verify-email.tsx
@@ -12,6 +12,30 @@ import { Card, CardContent } from '@datum-cloud/datum-ui/card';
 import { useEffect } from 'react';
 import { Link, MetaFunction, LoaderFunctionArgs, redirect } from 'react-router';
 
+const SUPPORT_EMAIL = 'support@datum.net';
+
+/**
+ * How often to re-check, by how long the page has been open.
+ *
+ * Fast while the user is plausibly clicking the link right now, then slower —
+ * unlike /verifying, which waits on a machine and promises "under 30 seconds",
+ * this page waits on a human finding an email. A flat 4s tick left open for an
+ * hour is ~900 requests that learn nothing.
+ */
+const POLL_SCHEDULE = [
+  { withinMs: 60_000, everyMs: 4_000 },
+  { withinMs: 300_000, everyMs: 15_000 },
+];
+const POLL_FALLBACK_MS = 60_000;
+
+const pollDelayFor = (elapsedMs: number): number =>
+  POLL_SCHEDULE.find((step) => elapsedMs < step.withinMs)?.everyMs ?? POLL_FALLBACK_MS;
+
+// `?refresh=0` — this page can poll for many minutes, and the endpoint's
+// proactive token refresh is meant for the short post-signup wait on
+// /verifying. See app/server/routes/fraud-status.ts.
+const STATUS_URL = `${paths.fraud.statusApi}?refresh=0`;
+
 export const meta: MetaFunction = mergeMeta(() => {
   return metaObject('Verify Your Email');
 });
@@ -40,43 +64,48 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 export default function VerifyEmailPage() {
   useEffect(() => {
     let stopped = false;
+    let timerId: ReturnType<typeof setTimeout> | undefined;
+    const startedAt = Date.now();
 
+    // Self-scheduling rather than setInterval: the next tick is only queued
+    // once the previous one has settled, so a slow response cannot stack
+    // requests on top of each other.
     const poll = async () => {
       if (stopped) return;
 
       try {
-        const response = await fetch(paths.fraud.statusApi, { credentials: 'include' });
+        const response = await fetch(STATUS_URL, { credentials: 'include' });
 
-        if (!response.ok) {
-          return;
+        if (response.ok) {
+          const result = (await response.json()) as FraudPollResult;
+
+          // Anything other than "still waiting on the address" means it is
+          // proven. Where to go next is deliberately NOT decided here:
+          // /verifying re-derives its destination client-side because its poll
+          // hands it a `redirectTo`; this page has no such target, and
+          // re-implementing the cascade in the browser is how the two copies
+          // drift. One hop through the server re-runs the redirect cascade and
+          // lands the user wherever it says — /verifying if staff review is
+          // still pending, onboarding if approved.
+          if (!isAwaitingEmailVerification(result)) {
+            window.location.replace(paths.home);
+            return; // navigating away — do not reschedule
+          }
         }
-
-        const result = (await response.json()) as FraudPollResult;
-
-        // Still waiting on the address — keep polling.
-        if (isAwaitingEmailVerification(result)) {
-          return;
-        }
-
-        // Anything else means the address is proven. Where to go next is
-        // deliberately NOT decided here. /verifying re-derives its destination
-        // client-side because its poll hands it a `redirectTo`; this page has no
-        // such target, and re-implementing the cascade in the browser is how the
-        // two copies drift. One hop through the server re-runs
-        // resolveUserFraudRedirectPath and lands the user wherever it says —
-        // /verifying if staff review is still pending, onboarding if approved.
-        window.location.replace(paths.home);
       } catch {
-        // Fail silently — continue polling on network errors
+        // Network error — say nothing and let the next tick retry.
+      }
+
+      if (!stopped) {
+        timerId = setTimeout(poll, pollDelayFor(Date.now() - startedAt));
       }
     };
 
-    poll(); // fire immediately — don't wait 4s if the link was already clicked
-    const intervalId = setInterval(poll, 4000);
+    poll(); // fire immediately — don't wait if the link was already clicked
 
     return () => {
       stopped = true;
-      clearInterval(intervalId);
+      clearTimeout(timerId);
     };
   }, []);
 
@@ -85,9 +114,16 @@ export default function VerifyEmailPage() {
       <Card className="bg-card text-foreground z-10 w-full max-w-full rounded-xl border p-3 sm:max-w-sm sm:p-4 md:p-6 lg:p-8 xl:p-11">
         <CardContent className="p-0">
           <h2 className="mb-3 text-center text-xl font-medium">Check your email</h2>
-          <p className="text-center text-[14px] leading-5 font-normal">
+          <p role="status" className="text-center text-[14px] leading-5 font-normal">
             We sent a verification link to your email address. Open it to continue — this page
             updates on its own once you have.
+          </p>
+          <p className="text-muted-foreground mt-4 text-center text-[13px] leading-5">
+            Didn&apos;t get it? Check your spam folder, or contact{' '}
+            <a href={`mailto:${SUPPORT_EMAIL}`} className="underline">
+              {SUPPORT_EMAIL}
+            </a>
+            .
           </p>
           <div className="mt-6 text-center">
             <Link

--- a/app/routes/fraud/verify-email.tsx
+++ b/app/routes/fraud/verify-email.tsx
@@ -22,19 +22,21 @@ const SUPPORT_EMAIL = 'support@datum.net';
  * this page waits on a human finding an email. A flat 4s tick left open for an
  * hour is ~900 requests that learn nothing.
  */
+// Wider than /verifying's intervals because each tick now costs a
+// refresh_token grant and a cookie rotation, not just a read.
 const POLL_SCHEDULE = [
-  { withinMs: 60_000, everyMs: 4_000 },
-  { withinMs: 300_000, everyMs: 15_000 },
+  { withinMs: 60_000, everyMs: 10_000 },
+  { withinMs: 300_000, everyMs: 20_000 },
 ];
 const POLL_FALLBACK_MS = 60_000;
 
 const pollDelayFor = (elapsedMs: number): number =>
   POLL_SCHEDULE.find((step) => elapsedMs < step.withinMs)?.everyMs ?? POLL_FALLBACK_MS;
 
-// `?refresh=0` — this page can poll for many minutes, and the endpoint's
-// proactive token refresh is meant for the short post-signup wait on
-// /verifying. See app/server/routes/fraud-status.ts.
-const STATUS_URL = `${paths.fraud.statusApi}?refresh=0`;
+// No `refresh=0` here, deliberately. Verification is an id_token claim, so it
+// only changes when a new token is issued — polling without the refresh
+// re-reads the same stale `false` forever.
+const STATUS_URL = paths.fraud.statusApi;
 
 export const meta: MetaFunction = mergeMeta(() => {
   return metaObject('Verify Your Email');

--- a/app/server/middleware/email-verification.test.ts
+++ b/app/server/middleware/email-verification.test.ts
@@ -1,0 +1,98 @@
+import { emailVerifiedGuardMiddleware } from './email-verification';
+import type { Variables } from '@/server/types';
+import type { UserAccessResult } from '@/utils/fraud/user-access';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Hono } from 'hono';
+
+// The user loader is the seam — injected rather than mock.module'd, which is
+// process-global in bun and would leak this stub into user-access.test.ts.
+let access: UserAccessResult = { user: { sub: 'u1', emailVerified: true } as never };
+
+const loadUser = async (): Promise<UserAccessResult> => access;
+
+const gateOn = () => {
+  process.env.EMAIL_VERIFICATION_GATE = 'true';
+};
+const gateOff = () => {
+  delete process.env.EMAIL_VERIFICATION_GATE;
+};
+
+/** Mirrors createApiApp: a session is already in context by the time this runs. */
+function appWithSession(session: { sub?: string } | null = { sub: 'u1' }) {
+  const app = new Hono<{ Variables: Variables }>();
+  app.use('*', async (c, next) => {
+    if (session) c.set('session', session as Variables['session']);
+    await next();
+  });
+  app.use('/assistant/*', emailVerifiedGuardMiddleware({ loadUser }));
+  app.post('/assistant', (c) => c.json({ reached: true }));
+  return app;
+}
+
+beforeEach(() => {
+  access = { user: { sub: 'u1', emailVerified: true } as never };
+});
+
+afterEach(() => {
+  gateOff();
+});
+
+describe('emailVerifiedGuardMiddleware', () => {
+  it('is inert while the flag is off — the shipping default', async () => {
+    gateOff();
+    access = { user: { sub: 'u1', emailVerified: false } as never };
+
+    const res = await appWithSession().request('/assistant', { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ reached: true });
+  });
+
+  it('lets a verified user through when the flag is on', async () => {
+    gateOn();
+
+    const res = await appWithSession().request('/assistant', { method: 'POST' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('blocks an unverified user with the flag on', async () => {
+    gateOn();
+    access = { user: { sub: 'u1', emailVerified: false } as never };
+
+    const res = await appWithSession().request('/assistant', { method: 'POST' });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).code).toBe('EMAIL_NOT_VERIFIED');
+  });
+
+  it('reads an ABSENT emailVerified as unverified (fail-closed)', async () => {
+    gateOn();
+    access = { user: { sub: 'u1' } as never };
+
+    const res = await appWithSession().request('/assistant', { method: 'POST' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('fails CLOSED when the user cannot be read', async () => {
+    // An upstream outage must not become a way past the gate — the same
+    // reading every other decision point in the cascade takes.
+    gateOn();
+    for (const error of ['not_found', 'forbidden', 'other'] as const) {
+      access = { error };
+      const res = await appWithSession().request('/assistant', { method: 'POST' });
+      expect(res.status).toBe(403);
+    }
+  });
+
+  it('defers the unauthenticated case to authGuardMiddleware', async () => {
+    // authGuard runs first in createApiApp and owns the 401. Returning 403
+    // here would mask it behind a misleading reason.
+    gateOn();
+
+    const res = await appWithSession(null).request('/assistant', { method: 'POST' });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/server/middleware/email-verification.ts
+++ b/app/server/middleware/email-verification.ts
@@ -1,0 +1,64 @@
+import type { Variables } from '@/server/types';
+import { isEmailVerificationGateEnabled } from '@/utils/config/email-verification-gate';
+import { getUserWithAccessRetry } from '@/utils/fraud/user-access';
+import { createMiddleware } from 'hono/factory';
+
+/**
+ * Blocks unverified accounts from API endpoints that spend Datum's own
+ * third-party credentials.
+ *
+ * The page-level gate lives in the React Router private layout, so it covers
+ * navigation and route actions but not this Hono API surface. Most routes here
+ * forward the caller's own access token (`/graphql`, `/proxy`, `/watch`,
+ * `/permissions`, `/user`, `/grafana`, `/prometheus`), which makes the upstream
+ * API the enforcement point — re-deriving the same answer here would cost a
+ * round trip per request to duplicate a check that already happens.
+ *
+ * The exceptions are the routes that authenticate with a key the portal holds
+ * (`/assistant` → Anthropic, `/cloudvalid` → CloudValid, `/usage` → Amberflo).
+ * Nothing downstream knows or cares who the caller is, so an unverified signup
+ * can spend real money through them. Those are the routes this guard covers.
+ *
+ * Fail-CLOSED on an unreadable user, matching every other decision point in the
+ * gate: an upstream outage must not become a way past it.
+ *
+ * Costs nothing while the flag is off — the shipping default — because that
+ * check runs before the user is fetched.
+ *
+ * `loadUser` is injectable so tests can drive every branch without
+ * `mock.module`, which is process-global in bun and would leak this module's
+ * stub into any suite that runs afterwards.
+ */
+export function emailVerifiedGuardMiddleware(
+  options: { loadUser?: typeof getUserWithAccessRetry } = {}
+) {
+  const loadUser = options.loadUser ?? getUserWithAccessRetry;
+
+  return createMiddleware<{ Variables: Variables }>(async (c, next) => {
+    if (!isEmailVerificationGateEnabled()) {
+      return next();
+    }
+
+    const session = c.get('session');
+    if (!session?.sub) {
+      // authGuardMiddleware owns the unauthenticated case and runs first.
+      return next();
+    }
+
+    const access = await loadUser(session.sub, c.req.header('Cookie') ?? null);
+    const isVerified = 'error' in access ? false : access.user.emailVerified === true;
+
+    if (!isVerified) {
+      return c.json(
+        {
+          code: 'EMAIL_NOT_VERIFIED',
+          message: 'Verify your email address to use this endpoint.',
+          status: 403,
+        },
+        403
+      );
+    }
+
+    return next();
+  });
+}

--- a/app/server/routes/api.ts
+++ b/app/server/routes/api.ts
@@ -10,6 +10,7 @@ import { usageRoutes } from './usage';
 import { userRoutes } from './user';
 import { watchRoutes } from './watch';
 import { authGuardMiddleware } from '@/server/middleware/auth';
+import { emailVerifiedGuardMiddleware } from '@/server/middleware/email-verification';
 import { rateLimiter, RateLimitPresets } from '@/server/middleware/rate-limit';
 import type { Variables } from '@/server/types';
 import { Hono } from 'hono';
@@ -38,6 +39,16 @@ export function createApiApp() {
         : RateLimitPresets.development
     )
   );
+
+  // Endpoints that authenticate with a key the PORTAL holds rather than the
+  // caller's token — nothing downstream can tell an unverified signup apart, so
+  // the email gate has to be applied here. Every other route below forwards the
+  // caller's own access token and is enforced upstream. See
+  // middleware/email-verification.ts. No-op while the flag is off.
+  const emailVerified = emailVerifiedGuardMiddleware();
+  api.use('/assistant/*', emailVerified);
+  api.use('/cloudvalid/*', emailVerified);
+  api.use('/usage/*', emailVerified);
 
   // Routes
   api.route('/fraud-status', fraudStatusRoutes);

--- a/app/server/routes/fraud-status.test.ts
+++ b/app/server/routes/fraud-status.test.ts
@@ -1,0 +1,55 @@
+import { createFraudStatusRoutes } from './fraud-status';
+import type { Variables } from '@/server/types';
+import type { UserAccessResult } from '@/utils/fraud/user-access';
+import { describe, expect, it } from 'bun:test';
+import { Hono } from 'hono';
+
+const verifiedUser = {
+  sub: 'u1',
+  platformAccess: 'Approved',
+  state: 'Active',
+  emailVerified: true,
+};
+
+function appWith(access: UserAccessResult) {
+  const app = new Hono<{ Variables: Variables }>();
+  app.use('*', async (c, next) => {
+    c.set('session', { sub: 'u1' } as Variables['session']);
+    await next();
+  });
+  app.route('/', createFraudStatusRoutes({ loadUser: async () => access }));
+  return app;
+}
+
+describe('fraud-status', () => {
+  // /verify-email polls this endpoint with the proactive refresh ON, so a
+  // rotation happens on every tick. Zitadel rotates refresh tokens, which makes
+  // dropping the Set-Cookie worse than a stale read: the next tick would present
+  // a token the IdP has already invalidated and log the user out mid-verification.
+  it('forwards rotated session cookies to the browser', async () => {
+    const rotated = new Headers();
+    rotated.append('Set-Cookie', '_session=new; Path=/');
+    rotated.append('Set-Cookie', '_refresh_token=rotated; Path=/');
+
+    const res = await appWith({
+      user: verifiedUser as never,
+      refreshedHeaders: rotated,
+    }).request('/');
+
+    const cookies = res.headers.getSetCookie();
+    expect(cookies).toContain('_session=new; Path=/');
+    expect(cookies).toContain('_refresh_token=rotated; Path=/');
+  });
+
+  it('sets no cookies when nothing was refreshed', async () => {
+    const res = await appWith({ user: verifiedUser as never }).request('/');
+    expect(res.headers.getSetCookie()).toHaveLength(0);
+  });
+
+  it('reports an unreadable user as fraud-review, not email-unverified', async () => {
+    // Holding someone on /verify-email for an upstream failure that has nothing
+    // to do with their address is the bug this guards.
+    const res = await appWith({ error: 'other' }).request('/');
+    expect(await res.json()).toEqual({ status: 'pending', reason: 'fraud-review' });
+  });
+});

--- a/app/server/routes/fraud-status.ts
+++ b/app/server/routes/fraud-status.ts
@@ -3,43 +3,57 @@ import { getUserWithAccessRetry } from '@/utils/fraud/user-access';
 import { resolveFraudPollResult } from '@/utils/middlewares/fraud-redirect';
 import { Hono } from 'hono';
 
-const fraudStatus = new Hono<{ Variables: Variables }>();
-
 /**
- * GET /api/fraud-status
- *
- * Lightweight polling endpoint used by the /verifying page to check whether
- * the fraud evaluation has completed and what decision was made.
+ * The user loader is injectable so the route can be tested without
+ * mock.module, which is process-global in bun and leaks across suites — the
+ * same seam emailVerifiedGuardMiddleware uses.
  */
-fraudStatus.get('/', async (c) => {
-  const session = c.get('session')!;
-  const cookieHeader = c.req.header('Cookie') ?? null;
+type FraudStatusDeps = { loadUser?: typeof getUserWithAccessRetry };
 
-  // The refresh is load-bearing for /verify-email rather than an optimisation:
-  // verification is an id_token claim, so it only changes when a new token is
-  // issued. `?refresh=0` remains for callers that only want a read — they will
-  // not observe a verification change while they use it.
-  const refreshBeforeRead = c.req.query('refresh') !== '0';
-  const access = await getUserWithAccessRetry(session.sub!, cookieHeader, { refreshBeforeRead });
+export function createFraudStatusRoutes({
+  loadUser = getUserWithAccessRetry,
+}: FraudStatusDeps = {}) {
+  const fraudStatus = new Hono<{ Variables: Variables }>();
 
-  if ('error' in access) {
-    // Unreadable user (404/403 during propagation, or an upstream failure).
-    // Deliberately NOT 'email-unverified': /verify-email would hold them here
-    // indefinitely on an error that has nothing to do with their address. As
-    // 'fraud-review' the page hands control back to the server, and
-    // fraudStatusMiddleware routes them to /verifying — which is what an
-    // unreadable user got before the email gate existed.
-    return c.json({ status: 'pending' as const, reason: 'fraud-review' as const });
-  }
+  /**
+   * GET /api/fraud-status
+   *
+   * Lightweight polling endpoint used by the /verifying and /verify-email pages
+   * to check whether the fraud evaluation has completed and what decision was
+   * made.
+   */
+  fraudStatus.get('/', async (c) => {
+    const session = c.get('session')!;
+    const cookieHeader = c.req.header('Cookie') ?? null;
 
-  const { user, refreshedHeaders } = access;
-  refreshedHeaders?.forEach((value, key) => {
-    if (key.toLowerCase() === 'set-cookie') {
-      c.header('Set-Cookie', value, { append: true });
+    // The refresh is load-bearing for /verify-email rather than an optimisation:
+    // verification is an id_token claim, so it only changes when a new token is
+    // issued. `?refresh=0` remains for callers that only want a read — they will
+    // not observe a verification change while they use it.
+    const refreshBeforeRead = c.req.query('refresh') !== '0';
+    const access = await loadUser(session.sub!, cookieHeader, { refreshBeforeRead });
+
+    if ('error' in access) {
+      // Unreadable user (404/403 during propagation, or an upstream failure).
+      // Deliberately NOT 'email-unverified': /verify-email would hold them here
+      // indefinitely on an error that has nothing to do with their address. As
+      // 'fraud-review' the page hands control back to the server, and
+      // fraudStatusMiddleware routes them to /verifying — which is what an
+      // unreadable user got before the email gate existed.
+      return c.json({ status: 'pending' as const, reason: 'fraud-review' as const });
     }
+
+    const { user, refreshedHeaders } = access;
+    refreshedHeaders?.forEach((value, key) => {
+      if (key.toLowerCase() === 'set-cookie') {
+        c.header('Set-Cookie', value, { append: true });
+      }
+    });
+
+    return c.json(resolveFraudPollResult(user));
   });
 
-  return c.json(resolveFraudPollResult(user));
-});
+  return fraudStatus;
+}
 
-export { fraudStatus as fraudStatusRoutes };
+export const fraudStatusRoutes = createFraudStatusRoutes();

--- a/app/server/routes/fraud-status.ts
+++ b/app/server/routes/fraud-status.ts
@@ -15,12 +15,10 @@ fraudStatus.get('/', async (c) => {
   const session = c.get('session')!;
   const cookieHeader = c.req.header('Cookie') ?? null;
 
-  // The proactive token refresh exists for /verifying, which polls for seconds
-  // immediately after signup while OpenFGA tuples propagate. /verify-email can
-  // poll for as long as it takes someone to open an email, where a refresh per
-  // tick is pure cost — a refresh_token grant and a session-cookie rotation
-  // every few seconds, for minutes. Long-lived callers pass `?refresh=0`; a 403
-  // mid-poll still triggers the reactive refresh inside getUserWithAccessRetry.
+  // The refresh is load-bearing for /verify-email rather than an optimisation:
+  // verification is an id_token claim, so it only changes when a new token is
+  // issued. `?refresh=0` remains for callers that only want a read — they will
+  // not observe a verification change while they use it.
   const refreshBeforeRead = c.req.query('refresh') !== '0';
   const access = await getUserWithAccessRetry(session.sub!, cookieHeader, { refreshBeforeRead });
 

--- a/app/server/routes/fraud-status.ts
+++ b/app/server/routes/fraud-status.ts
@@ -19,7 +19,13 @@ fraudStatus.get('/', async (c) => {
   });
 
   if ('error' in access) {
-    return c.json({ status: 'pending' as const });
+    // Unreadable user (404/403 during propagation, or an upstream failure).
+    // Deliberately NOT 'email-unverified': /verify-email would hold them here
+    // indefinitely on an error that has nothing to do with their address. As
+    // 'fraud-review' the page hands control back to the server, and
+    // fraudStatusMiddleware routes them to /verifying, which is exactly
+    // what an unreadable user got before Phase B.
+    return c.json({ status: 'pending' as const, reason: 'fraud-review' as const });
   }
 
   const { user, refreshedHeaders } = access;

--- a/app/server/routes/fraud-status.ts
+++ b/app/server/routes/fraud-status.ts
@@ -14,17 +14,23 @@ const fraudStatus = new Hono<{ Variables: Variables }>();
 fraudStatus.get('/', async (c) => {
   const session = c.get('session')!;
   const cookieHeader = c.req.header('Cookie') ?? null;
-  const access = await getUserWithAccessRetry(session.sub!, cookieHeader, {
-    refreshBeforeRead: true,
-  });
+
+  // The proactive token refresh exists for /verifying, which polls for seconds
+  // immediately after signup while OpenFGA tuples propagate. /verify-email can
+  // poll for as long as it takes someone to open an email, where a refresh per
+  // tick is pure cost — a refresh_token grant and a session-cookie rotation
+  // every few seconds, for minutes. Long-lived callers pass `?refresh=0`; a 403
+  // mid-poll still triggers the reactive refresh inside getUserWithAccessRetry.
+  const refreshBeforeRead = c.req.query('refresh') !== '0';
+  const access = await getUserWithAccessRetry(session.sub!, cookieHeader, { refreshBeforeRead });
 
   if ('error' in access) {
     // Unreadable user (404/403 during propagation, or an upstream failure).
     // Deliberately NOT 'email-unverified': /verify-email would hold them here
     // indefinitely on an error that has nothing to do with their address. As
     // 'fraud-review' the page hands control back to the server, and
-    // fraudStatusMiddleware routes them to /verifying, which is exactly
-    // what an unreadable user got before Phase B.
+    // fraudStatusMiddleware routes them to /verifying — which is what an
+    // unreadable user got before the email gate existed.
     return c.json({ status: 'pending' as const, reason: 'fraud-review' as const });
   }
 

--- a/app/server/routes/proxy.ts
+++ b/app/server/routes/proxy.ts
@@ -1,5 +1,7 @@
+import { isEmailNotVerifiedDenial } from '@/features/account/email-verification/email-verification-error';
 import { extractQuotaDenialLabels, quotaDeniedTotal } from '@/server/observability/quota-metrics';
 import type { Variables } from '@/server/types';
+import { AuthService } from '@/utils/auth';
 import { env } from '@/utils/env/env.server';
 import { Hono } from 'hono';
 
@@ -53,12 +55,20 @@ proxyRoutes.all('/*', async (c) => {
       upstreamHeaders['X-Forwarded-For'] = clientIP;
     }
 
-    const response = await fetch(`${env.public.apiUrl}${path}${queryString}`, {
-      method: c.req.method,
-      headers: upstreamHeaders,
-      body: c.req.method !== 'GET' ? await c.req.text() : undefined,
-      signal: controller.signal,
-    });
+    // Read once: a verification retry below re-sends the same body, and
+    // c.req.text() is not guaranteed to survive a second call.
+    const requestBody = c.req.method !== 'GET' ? await c.req.text() : undefined;
+
+    const callUpstream = (accessToken: string) =>
+      fetch(`${env.public.apiUrl}${path}${queryString}`, {
+        method: c.req.method,
+        headers: { ...upstreamHeaders, Authorization: `Bearer ${accessToken}` },
+        body: requestBody,
+        signal: controller.signal,
+      });
+
+    let response = await callUpstream(session.accessToken);
+    let rotatedCookies: Headers | undefined;
 
     // Remove encoding headers to prevent double-decoding
     const headers = new Headers(response.headers);
@@ -68,12 +78,34 @@ proxyRoutes.all('/*', async (c) => {
     // Count real quota rejections (the "advisory gate missed" signal). Non-watch
     // 403s only — watch streams must keep streaming untouched.
     if (response.status === 403 && !isWatch) {
-      const text = await response.text();
+      let text = await response.text();
       const labels = extractQuotaDenialLabels(text);
       if (labels) {
         quotaDeniedTotal.inc(labels);
       }
-      return new Response(text, { status: response.status, headers });
+
+      // A verification denial is more often a stale TokenReview than a genuinely
+      // unverified account: the apiserver caches reviews per token for ~2
+      // minutes, so milo can still be holding "unverified" after the user has
+      // verified. Refreshing mints a new token, which is a new cache key, so the
+      // next call re-introspects. Same shape as getUserWithAccessRetry's 403
+      // retry.
+      //
+      // Once only. If it survives a fresh introspection the account really is
+      // unverified, and the client redirects to /verify-email on the cause.
+      if (isEmailNotVerifiedDenial(text)) {
+        const retried = await retryAfterRefresh(c.req.header('Cookie') ?? null, callUpstream);
+        if (retried) {
+          response = retried.response;
+          rotatedCookies = retried.cookies;
+          text = await response.text();
+        }
+      }
+
+      const outHeaders = withRotatedCookies(new Headers(response.headers), rotatedCookies);
+      outHeaders.delete('content-encoding');
+      outHeaders.delete('transfer-encoding');
+      return new Response(text, { status: response.status, headers: outHeaders });
     }
 
     return new Response(response.body, {
@@ -89,3 +121,42 @@ proxyRoutes.all('/*', async (c) => {
     return c.json({ error: error instanceof Error ? error.message : 'Proxy error' }, 502);
   }
 });
+
+/**
+ * Refresh the session and re-issue the upstream call once. Returns null when
+ * there is nothing to refresh with, or the refresh itself fails — the caller
+ * then returns the original 403 rather than masking it.
+ */
+async function retryAfterRefresh(
+  cookieHeader: string | null,
+  callUpstream: (accessToken: string) => Promise<Response>
+): Promise<{ response: Response; cookies: Headers } | null> {
+  const { refreshToken, rawSession: refreshRaw } = await AuthService.getRefreshToken(cookieHeader);
+  if (!refreshToken) return null;
+
+  const { rawSession: sessionRaw } = await AuthService.getSession(cookieHeader);
+
+  try {
+    const { session, headers } = await AuthService.refreshTokens(
+      refreshToken,
+      sessionRaw,
+      refreshRaw
+    );
+    return { response: await callUpstream(session.accessToken), cookies: headers };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Zitadel rotates refresh tokens, so a rotation the browser never receives
+ * leaves the next request presenting one the IdP has already invalidated.
+ */
+function withRotatedCookies(target: Headers, rotated?: Headers): Headers {
+  rotated?.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie') {
+      target.append('Set-Cookie', value);
+    }
+  });
+  return target;
+}

--- a/app/utils/auth/auth.service.ts
+++ b/app/utils/auth/auth.service.ts
@@ -20,6 +20,25 @@ import { jwtDecode } from 'jwt-decode';
 import { createCookieSessionStorage, createCookie } from 'react-router';
 
 /**
+ * Reads `email_verified` off an id_token. Absent, unparseable, or non-boolean
+ * all read as false — an unverified account must never be admitted because a
+ * claim could not be read.
+ *
+ * UNVERIFIED ASSUMPTION: that Zitadel re-issues an id_token carrying this claim
+ * on the refresh_token grant. /verify-email polls by forcing a refresh, so if
+ * it does not, the poll never resolves and a verified user stays blocked.
+ * Confirm against staging before the gate is enabled.
+ */
+export function readEmailVerified(idToken: string | null | undefined): boolean {
+  if (!idToken) return false;
+  try {
+    return jwtDecode<{ email_verified?: unknown }>(idToken).email_verified === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Session cookie configuration
  */
 const sessionCookie = createCookie(AUTH_COOKIE_KEYS.SESSION, {
@@ -224,10 +243,18 @@ export class AuthService {
     // Decode new access token to get sub
     const decoded = jwtDecode<{ sub: string }>(refreshedTokens.accessToken());
 
+    let refreshedIdToken: string | undefined;
+    try {
+      refreshedIdToken = refreshedTokens.idToken();
+    } catch {
+      refreshedIdToken = undefined;
+    }
+
     const newSession: IAccessTokenSession = {
       accessToken: refreshedTokens.accessToken(),
       expiredAt: refreshedTokens.accessTokenExpiresAt(),
       sub: decoded.sub,
+      emailVerified: readEmailVerified(refreshedIdToken),
     };
 
     // Update session cookie

--- a/app/utils/auth/auth.types.ts
+++ b/app/utils/auth/auth.types.ts
@@ -21,6 +21,12 @@ export interface IAccessTokenSession {
   accessToken: string;
   expiredAt: Date;
   sub: string;
+  /**
+   * `email_verified` from the id_token, fixed at issue time. It only changes
+   * when a new token is issued, so a caller waiting on verification must force
+   * a refresh rather than re-read the session — see /verify-email.
+   */
+  emailVerified: boolean;
 }
 
 /**

--- a/app/utils/auth/index.ts
+++ b/app/utils/auth/index.ts
@@ -11,6 +11,7 @@ export {
   sessionStorage,
   refreshTokenStorage,
   clearUserPermissionCache,
+  readEmailVerified,
 } from './auth.service';
 export { destroyAllAuthCookies, destroyLocalSessions } from './auth.utils';
 export { sessionManager } from './session-manager';

--- a/app/utils/config/email-verification-gate.test.ts
+++ b/app/utils/config/email-verification-gate.test.ts
@@ -1,0 +1,42 @@
+import { isEmailVerificationGateEnabled } from './email-verification-gate';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+const original = process.env.EMAIL_VERIFICATION_GATE;
+
+beforeEach(() => {
+  delete process.env.EMAIL_VERIFICATION_GATE;
+});
+
+afterEach(() => {
+  if (original === undefined) {
+    delete process.env.EMAIL_VERIFICATION_GATE;
+  } else {
+    process.env.EMAIL_VERIFICATION_GATE = original;
+  }
+});
+
+describe('isEmailVerificationGateEnabled', () => {
+  it('is off when the variable is unset — the default that ships', () => {
+    expect(isEmailVerificationGateEnabled()).toBe(false);
+  });
+
+  it('is on for the exact string "true"', () => {
+    process.env.EMAIL_VERIFICATION_GATE = 'true';
+    expect(isEmailVerificationGateEnabled()).toBe(true);
+  });
+
+  it('is off for every other truthy-looking value', () => {
+    for (const value of ['1', 'yes', 'TRUE', 'True', 'on', '']) {
+      process.env.EMAIL_VERIFICATION_GATE = value;
+      expect(isEmailVerificationGateEnabled()).toBe(false);
+    }
+  });
+
+  it('re-reads on every call, so a test can flip it in-process', () => {
+    expect(isEmailVerificationGateEnabled()).toBe(false);
+    process.env.EMAIL_VERIFICATION_GATE = 'true';
+    expect(isEmailVerificationGateEnabled()).toBe(true);
+    process.env.EMAIL_VERIFICATION_GATE = 'false';
+    expect(isEmailVerificationGateEnabled()).toBe(false);
+  });
+});

--- a/app/utils/config/email-verification-gate.ts
+++ b/app/utils/config/email-verification-gate.ts
@@ -1,29 +1,28 @@
 /**
- * E-GATE — the cloud-portal half of the Phase B hard gate's two-switch kill.
+ * The portal half of the email-verification gate's two-switch kill (the other
+ * switch is milo's).
  *
- * OFF BY DEFAULT, and off for every value except the exact string 'true'.
- * CHATBOT_ENABLED (utils/env/env.server.ts:86-88) uses the same `=== 'true'`
- * rule; matching it exactly is deliberate.
+ * OFF BY DEFAULT, and off for every value except the exact string 'true' —
+ * the same rule CHATBOT_ENABLED uses in utils/env/env.server.ts.
  *
  * NOT in the validated env.server.ts schema, deliberately. This flag is read
- * from `resolveUserFraudRedirectPath`, and `routes/onboarding/layout.tsx:14`
- * imports that function into a ROUTE module. `utils/env/index.ts:88-92` throws
- * on any universal access to server env, so the safe precedent is the one
- * `fraud-redirect.ts:1` already follows: `features/onboarding/onboarding-dev-
- * bypass.ts` reads process.env directly for exactly this reason. The
- * `typeof process` guard makes a hypothetical client-side evaluation return
- * false instead of throwing — which is also the fail-safe answer, since every
- * gate decision this flag participates in is made server-side.
+ * from `resolveUserFraudRedirectPath`, which `routes/onboarding/layout.tsx`
+ * imports into a ROUTE module, and `utils/env/index.ts` throws on any universal
+ * access to server env. So it follows the precedent already set by
+ * `features/onboarding/onboarding-dev-bypass.ts`: read process.env directly.
+ * The `typeof process` guard makes a hypothetical client-side evaluation return
+ * false rather than throw — also the fail-safe answer, since every decision
+ * this flag feeds is made server-side.
  *
- * Read at CALL time, never cached at module scope. Infra flips this by rolling
- * the Deployment, so caching would cost nothing in production — but it would
- * make the kill switch untestable, and an untested kill switch is not one.
+ * Read at CALL time, never cached at module scope. The flag is flipped by
+ * rolling the Deployment, so caching would cost nothing in production — but it
+ * would make the kill switch untestable, and an untested kill switch is not one.
  *
- * ORDERING (spec §Rollback, roadmap §6):
+ * ORDERING:
  *   to ENABLE  — flip THIS first, then milo's gate.
  *   to DISABLE — flip milo's FIRST, then this one.
- * Getting it backwards produces an app that loads and then fails on every
- * request (enable) or admits users its API still denies (disable).
+ * Backwards produces an app that loads and then fails on every request
+ * (enable), or one that admits users its API still denies (disable).
  */
 export function isEmailVerificationGateEnabled(): boolean {
   return typeof process !== 'undefined' && process.env.EMAIL_VERIFICATION_GATE === 'true';

--- a/app/utils/config/email-verification-gate.ts
+++ b/app/utils/config/email-verification-gate.ts
@@ -1,0 +1,30 @@
+/**
+ * E-GATE — the cloud-portal half of the Phase B hard gate's two-switch kill.
+ *
+ * OFF BY DEFAULT, and off for every value except the exact string 'true'.
+ * CHATBOT_ENABLED (utils/env/env.server.ts:86-88) uses the same `=== 'true'`
+ * rule; matching it exactly is deliberate.
+ *
+ * NOT in the validated env.server.ts schema, deliberately. This flag is read
+ * from `resolveUserFraudRedirectPath`, and `routes/onboarding/layout.tsx:14`
+ * imports that function into a ROUTE module. `utils/env/index.ts:88-92` throws
+ * on any universal access to server env, so the safe precedent is the one
+ * `fraud-redirect.ts:1` already follows: `features/onboarding/onboarding-dev-
+ * bypass.ts` reads process.env directly for exactly this reason. The
+ * `typeof process` guard makes a hypothetical client-side evaluation return
+ * false instead of throwing — which is also the fail-safe answer, since every
+ * gate decision this flag participates in is made server-side.
+ *
+ * Read at CALL time, never cached at module scope. Infra flips this by rolling
+ * the Deployment, so caching would cost nothing in production — but it would
+ * make the kill switch untestable, and an untested kill switch is not one.
+ *
+ * ORDERING (spec §Rollback, roadmap §6):
+ *   to ENABLE  — flip THIS first, then milo's gate.
+ *   to DISABLE — flip milo's FIRST, then this one.
+ * Getting it backwards produces an app that loads and then fails on every
+ * request (enable) or admits users its API still denies (disable).
+ */
+export function isEmailVerificationGateEnabled(): boolean {
+  return typeof process !== 'undefined' && process.env.EMAIL_VERIFICATION_GATE === 'true';
+}

--- a/app/utils/config/paths.config.ts
+++ b/app/utils/config/paths.config.ts
@@ -19,6 +19,12 @@ export const paths = {
     verifying: '/verifying',
     accountUnderReview: '/account-under-review',
     accountSuspended: '/account-suspended',
+    // Grouped here by MECHANISM, not by meaning. Email verification is not a
+    // fraud signal, but this is the fourth page resolveUserFraudRedirectPath
+    // can send a user to, and all four must be declared outside the private
+    // layout for the same reason (see routes.ts). Keeping them together is
+    // what stops a fifth being added somewhere the layout gates it into a loop.
+    verifyEmail: '/verify-email',
     statusApi: '/api/fraud-status',
   },
   invitationAccept: '/invitation/:invitationId/accept',

--- a/app/utils/fraud/user-access.ts
+++ b/app/utils/fraud/user-access.ts
@@ -6,8 +6,7 @@ import { AuthService } from '@/utils/auth';
 import { AuthorizationError, NotFoundError } from '@/utils/errors';
 
 export type UserAccessResult =
-  | { user: User; refreshedHeaders?: Headers }
-  | { error: 'not_found' | 'forbidden' | 'other' };
+  { user: User; refreshedHeaders?: Headers } | { error: 'not_found' | 'forbidden' | 'other' };
 
 /**
  * A service-account principal (e.g. the plugin e2e suite's dev token
@@ -50,7 +49,7 @@ export async function getUserWithAccessRetry(
 
   try {
     const user = await createUserService().get(userId);
-    return { user };
+    return { user: await withSessionEmailVerified(user, cookieHeader) };
   } catch (error) {
     if (error instanceof NotFoundError) {
       if (isOnboardingDevBypassEnabled()) {
@@ -98,10 +97,24 @@ async function retryAfterTokenRefresh(
     }
 
     const user = await createUserService().get(userId);
-    return { user, refreshedHeaders: headers };
+    return {
+      user: { ...user, emailVerified: newSession.emailVerified },
+      refreshedHeaders: headers,
+    };
   } catch {
     return null;
   }
+}
+
+/**
+ * Verification lives on the id_token, not on the milo User, so it has to be
+ * overlaid after the fetch. Reading the session rather than the resource is
+ * what makes a stale claim possible — callers waiting on verification must
+ * force a refresh (`refreshBeforeRead`) rather than poll this alone.
+ */
+async function withSessionEmailVerified(user: User, cookieHeader: string | null): Promise<User> {
+  const { session } = await AuthService.getSession(cookieHeader);
+  return { ...user, emailVerified: session?.emailVerified === true };
 }
 
 export function appendSetCookieHeaders(target: Headers, source?: Headers): void {

--- a/app/utils/fraud/user-access.ts
+++ b/app/utils/fraud/user-access.ts
@@ -23,6 +23,11 @@ function buildDevStubUser(userId: string): User {
     platformAccess: 'Approved',
     state: 'Active',
     nameReviewRequired: false,
+    // Fourth gate, same reason as the three above: this principal has no User
+    // CR at all, so there is nothing for zitadel-provider to have marked
+    // verified. Without this the Phase B gate redirects the dev token-exchange
+    // session to /verify-email and the plugin e2e suite stops at the door.
+    emailVerified: true,
   };
 }
 

--- a/app/utils/fraud/user-access.ts
+++ b/app/utils/fraud/user-access.ts
@@ -24,8 +24,8 @@ function buildDevStubUser(userId: string): User {
     state: 'Active',
     nameReviewRequired: false,
     // Fourth gate, same reason as the three above: this principal has no User
-    // CR at all, so there is nothing for zitadel-provider to have marked
-    // verified. Without this the Phase B gate redirects the dev token-exchange
+    // record at all, so there is nothing for zitadel-provider to have marked
+    // verified. Without this the email gate redirects the dev token-exchange
     // session to /verify-email and the plugin e2e suite stops at the door.
     emailVerified: true,
   };

--- a/app/utils/middlewares/auth.middleware.ts
+++ b/app/utils/middlewares/auth.middleware.ts
@@ -79,6 +79,7 @@ const shouldSkipOnboardingRedirect = (pathname: string): boolean => {
   if (pathname === paths.fraud.verifying) return true;
   if (pathname === paths.fraud.accountUnderReview) return true;
   if (pathname === paths.fraud.accountSuspended) return true;
+  if (pathname === paths.fraud.verifyEmail) return true;
   if (/^\/invitation\/[^/]+\/accept$/.test(pathname)) return true;
   // Account settings are user-level and org-independent — always reachable.
   if (ACCOUNT_SETTINGS_PATHS.has(pathname)) return true;

--- a/app/utils/middlewares/auth.middleware.ts
+++ b/app/utils/middlewares/auth.middleware.ts
@@ -1,9 +1,12 @@
-import { onboardingEntryPath, resolveUserFraudRedirectPath } from './fraud-redirect';
+import {
+  denyIfEmailGateEnabled,
+  onboardingEntryPath,
+  resolveUserFraudRedirectPath,
+} from './fraud-redirect';
 import { MiddlewareContext, NextFunction } from './middleware';
 import { getRequestContext } from '@/modules/axios/request-context';
 import { createOrganizationService } from '@/resources/organizations';
 import { sessionContext } from '@/server/context';
-import { isEmailVerificationGateEnabled } from '@/utils/config/email-verification-gate';
 import { paths } from '@/utils/config/paths.config';
 import { getSession, isAuthenticated } from '@/utils/cookies';
 import { AuthenticationError } from '@/utils/errors';
@@ -100,16 +103,12 @@ async function redirectToOnboardingIfNoOrgs(
   const access = await getUserWithAccessRetry(userId, cookieHeader);
 
   if ('error' in access) {
-    // E-FC defence in depth. Not load-bearing today — private.layout.tsx runs
-    // authMiddleware BEFORE fraudStatusMiddleware, so a null here falls through
-    // to a middleware that fetches and decides for itself — but nothing
-    // enforces that ordering. Blunter than the sibling: it did not separate
-    // not_found/forbidden (propagation) from 'other' (an incident), so under
-    // the gate only the indeterminate case is denied.
-    if (isEmailVerificationGateEnabled() && access.error === 'other') {
-      return redirect(paths.fraud.verifying);
-    }
-    return null;
+    // Defence in depth, and not load-bearing today: private.layout.tsx runs
+    // authMiddleware BEFORE fraudStatusMiddleware, so returning null here falls
+    // through to a middleware that fetches and decides for itself. Nothing
+    // enforces that ordering, though, so the indeterminate case is answered
+    // here too — via the same helper, so the two cannot drift apart.
+    return denyIfEmailGateEnabled() ?? null;
   }
 
   const { user, refreshedHeaders } = access;
@@ -136,11 +135,8 @@ async function redirectToOnboardingIfNoOrgs(
     appendSetCookieHeaders(headers, refreshedHeaders);
     return redirect(onboardingEntryPath(user), { headers });
   } catch {
-    // E-FC defence in depth, same reasoning as the 'error' branch above:
-    // an org-list or resolver throw means the state is indeterminate.
-    if (isEmailVerificationGateEnabled()) {
-      return redirect(paths.fraud.verifying);
-    }
-    return null;
+    // Same reasoning as the 'error' branch above: an org-list or resolver
+    // throw means the state is indeterminate.
+    return denyIfEmailGateEnabled() ?? null;
   }
 }

--- a/app/utils/middlewares/auth.middleware.ts
+++ b/app/utils/middlewares/auth.middleware.ts
@@ -3,6 +3,7 @@ import { MiddlewareContext, NextFunction } from './middleware';
 import { getRequestContext } from '@/modules/axios/request-context';
 import { createOrganizationService } from '@/resources/organizations';
 import { sessionContext } from '@/server/context';
+import { isEmailVerificationGateEnabled } from '@/utils/config/email-verification-gate';
 import { paths } from '@/utils/config/paths.config';
 import { getSession, isAuthenticated } from '@/utils/cookies';
 import { AuthenticationError } from '@/utils/errors';
@@ -99,6 +100,15 @@ async function redirectToOnboardingIfNoOrgs(
   const access = await getUserWithAccessRetry(userId, cookieHeader);
 
   if ('error' in access) {
+    // E-FC defence in depth. Not load-bearing today — private.layout.tsx runs
+    // authMiddleware BEFORE fraudStatusMiddleware, so a null here falls through
+    // to a middleware that fetches and decides for itself — but nothing
+    // enforces that ordering. Blunter than the sibling: it did not separate
+    // not_found/forbidden (propagation) from 'other' (an incident), so under
+    // the gate only the indeterminate case is denied.
+    if (isEmailVerificationGateEnabled() && access.error === 'other') {
+      return redirect(paths.fraud.verifying);
+    }
     return null;
   }
 
@@ -126,6 +136,11 @@ async function redirectToOnboardingIfNoOrgs(
     appendSetCookieHeaders(headers, refreshedHeaders);
     return redirect(onboardingEntryPath(user), { headers });
   } catch {
+    // E-FC defence in depth, same reasoning as the 'error' branch above:
+    // an org-list or resolver throw means the state is indeterminate.
+    if (isEmailVerificationGateEnabled()) {
+      return redirect(paths.fraud.verifying);
+    }
     return null;
   }
 }

--- a/app/utils/middlewares/fraud-redirect.test.ts
+++ b/app/utils/middlewares/fraud-redirect.test.ts
@@ -1,17 +1,35 @@
 import {
+  isAwaitingEmailVerification,
   onboardingEntryPath,
   resolveFraudPollResult,
   resolveUserFraudRedirectPath,
+  resolveVerifyEmailPageRedirect,
 } from './fraud-redirect';
 import { PlatformAccess } from '@/resources/users/user.schema';
 import { paths } from '@/utils/config/paths.config';
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 const baseUser = {
   state: 'Active' as const,
   platformAccess: PlatformAccess.Approved,
   nameReviewRequired: false,
 };
+
+// The gate reads process.env at call time (see utils/config/email-verification-gate.ts),
+// so flipping it here is enough — no module reset needed. Cleared before AND
+// after every test so the pre-existing describes above keep running with the
+// gate off, which is the default they were written against.
+const enableGate = () => {
+  process.env.EMAIL_VERIFICATION_GATE = 'true';
+};
+
+beforeEach(() => {
+  delete process.env.EMAIL_VERIFICATION_GATE;
+});
+
+afterEach(() => {
+  delete process.env.EMAIL_VERIFICATION_GATE;
+});
 
 describe('resolveUserFraudRedirectPath', () => {
   it('redirects inactive users to account suspended', () => {
@@ -64,7 +82,7 @@ describe('resolveFraudPollResult', () => {
         ...baseUser,
         platformAccess: PlatformAccess.Pending,
       } as never)
-    ).toEqual({ status: 'pending' });
+    ).toEqual({ status: 'pending', reason: 'fraud-review' });
   });
 
   it('returns onboarding redirect when registration is approved', () => {
@@ -89,5 +107,164 @@ describe('onboardingEntryPath', () => {
     const user = { ...baseUser, nameReviewRequired: true } as never;
     const poll = resolveFraudPollResult(user);
     expect(poll.status === 'completed' ? poll.redirectTo : null).toBe(onboardingEntryPath(user));
+  });
+});
+
+describe('resolveUserFraudRedirectPath — email verification gate', () => {
+  // Approved + name review cleared: the strongest possible "should be let in"
+  // user, so anything that stops them is the gate and nothing else.
+  const unverified = { ...baseUser, emailVerified: false };
+  const here = paths.account.organizations.root;
+
+  it('is completely inert while the flag is off — the shipping default', () => {
+    expect(resolveUserFraudRedirectPath(unverified as never, here)).toBeNull();
+  });
+
+  it('redirects an unverified user to verify-email once the flag is on', () => {
+    enableGate();
+    expect(resolveUserFraudRedirectPath(unverified as never, here)).toBe(paths.fraud.verifyEmail);
+  });
+
+  it('reads an ABSENT emailVerified as unverified (fail-closed)', () => {
+    enableGate();
+    expect(resolveUserFraudRedirectPath(baseUser as never, here)).toBe(paths.fraud.verifyEmail);
+  });
+
+  it('never shows a verify prompt to a suspended or inactive user', () => {
+    enableGate();
+    expect(resolveUserFraudRedirectPath({ ...unverified, state: 'Inactive' } as never, here)).toBe(
+      paths.fraud.accountSuspended
+    );
+    expect(
+      resolveUserFraudRedirectPath(
+        { ...unverified, platformAccess: PlatformAccess.Suspended } as never,
+        here
+      )
+    ).toBe(paths.fraud.accountSuspended);
+  });
+
+  it('gates BEFORE approval, rejection, and the pending wait', () => {
+    enableGate();
+    for (const platformAccess of [
+      PlatformAccess.Approved,
+      PlatformAccess.Rejected,
+      PlatformAccess.Pending,
+    ]) {
+      expect(resolveUserFraudRedirectPath({ ...unverified, platformAccess } as never, here)).toBe(
+        paths.fraud.verifyEmail
+      );
+    }
+  });
+
+  it('gates before the name-review nudge', () => {
+    enableGate();
+    expect(
+      resolveUserFraudRedirectPath({ ...unverified, nameReviewRequired: true } as never, here)
+    ).toBe(paths.fraud.verifyEmail);
+  });
+
+  it('lets a verified user through unchanged', () => {
+    enableGate();
+    expect(
+      resolveUserFraudRedirectPath({ ...baseUser, emailVerified: true } as never, here)
+    ).toBeNull();
+  });
+
+  it('does not redirect the verify-email page to itself', () => {
+    enableGate();
+    expect(resolveUserFraudRedirectPath(unverified as never, paths.fraud.verifyEmail)).toBeNull();
+  });
+});
+
+describe('resolveFraudPollResult — email verification gate', () => {
+  const unverified = { ...baseUser, emailVerified: false };
+
+  it('is completely inert while the flag is off', () => {
+    expect(resolveFraudPollResult(unverified as never)).toEqual({
+      status: 'completed',
+      decision: 'ACCEPTED',
+      redirectTo: paths.onboarding.account,
+    });
+  });
+
+  it('holds an unverified user with a distinguishable pending reason', () => {
+    enableGate();
+    expect(resolveFraudPollResult(unverified as never)).toEqual({
+      status: 'pending',
+      reason: 'email-unverified',
+    });
+  });
+
+  it('still deactivates a suspended user ahead of the verify wait', () => {
+    enableGate();
+    expect(resolveFraudPollResult({ ...unverified, state: 'Inactive' } as never)).toEqual({
+      status: 'completed',
+      decision: 'DEACTIVATE',
+    });
+  });
+
+  it('releases the user the moment verification lands', () => {
+    enableGate();
+    expect(resolveFraudPollResult({ ...baseUser, emailVerified: true } as never)).toEqual({
+      status: 'completed',
+      decision: 'ACCEPTED',
+      redirectTo: paths.onboarding.account,
+    });
+  });
+
+  it('reports a verified-but-Pending user as a FRAUD wait, not an email wait', () => {
+    // This is the assertion that stops /verify-email becoming a dead end: once
+    // the address is proven the page must be able to tell that it is now
+    // waiting on staff, and move the user to /verifying.
+    enableGate();
+    expect(
+      resolveFraudPollResult({
+        ...baseUser,
+        emailVerified: true,
+        platformAccess: PlatformAccess.Pending,
+      } as never)
+    ).toEqual({ status: 'pending', reason: 'fraud-review' });
+  });
+});
+
+describe('isAwaitingEmailVerification', () => {
+  it('is true only for the email wait', () => {
+    expect(isAwaitingEmailVerification({ status: 'pending', reason: 'email-unverified' })).toBe(
+      true
+    );
+    expect(isAwaitingEmailVerification({ status: 'pending', reason: 'fraud-review' })).toBe(false);
+    expect(isAwaitingEmailVerification({ status: 'completed', decision: 'ACCEPTED' })).toBe(false);
+    expect(isAwaitingEmailVerification({ status: 'completed', decision: 'DEACTIVATE' })).toBe(
+      false
+    );
+  });
+});
+
+describe('resolveVerifyEmailPageRedirect', () => {
+  it('sends everyone home while the flag is off — the disable direction of the kill switch', () => {
+    expect(resolveVerifyEmailPageRedirect({ emailVerified: false })).toBe(paths.home);
+    expect(resolveVerifyEmailPageRedirect(null)).toBe(paths.home);
+  });
+
+  it('renders the page for an unverified user when the flag is on', () => {
+    enableGate();
+    expect(resolveVerifyEmailPageRedirect({ emailVerified: false })).toBeNull();
+  });
+
+  it('renders the page when emailVerified is absent (fail-closed)', () => {
+    enableGate();
+    expect(resolveVerifyEmailPageRedirect({})).toBeNull();
+  });
+
+  it('sends a verified user home so the page is never a dead end', () => {
+    enableGate();
+    expect(resolveVerifyEmailPageRedirect({ emailVerified: true })).toBe(paths.home);
+  });
+
+  it('renders the page when the user could not be read at all', () => {
+    // Fail-CLOSED by staying put: this page IS the block, so an upstream
+    // failure must not become a way past it.
+    enableGate();
+    expect(resolveVerifyEmailPageRedirect(null)).toBeNull();
   });
 });

--- a/app/utils/middlewares/fraud-redirect.ts
+++ b/app/utils/middlewares/fraud-redirect.ts
@@ -3,6 +3,7 @@ import type { User } from '@/resources/users';
 import { PlatformAccess } from '@/resources/users/user.schema';
 import { isEmailVerificationGateEnabled } from '@/utils/config/email-verification-gate';
 import { paths } from '@/utils/config/paths.config';
+import { redirect } from 'react-router';
 
 export type FraudPollResult =
   | {
@@ -27,20 +28,40 @@ export const onboardingEntryPath = (user: User): string =>
   user.nameReviewRequired ? paths.onboarding.profile : paths.onboarding.account;
 
 /**
- * Whether Phase B's email-verification gate should hold this user.
+ * Whether the email-verification gate should hold this user.
  *
- * Reads ABSENT as unverified. `emailVerified` is optional on the domain User
- * and no pre-Phase-B `User` CR carries it, so `!== true` is the fail-closed
- * reading the spec asks for. `toUser` (user.adapter.ts) already coerces the
- * wire value to a boolean, but this predicate does not lean on that — a User
- * built by hand (buildDevStubUser, fixtures) must not slip the gate simply by
- * omitting the key.
+ * Reads ABSENT as unverified: `emailVerified` is optional on the domain User
+ * and no User record predating the gate carries it, so `!== true` is the
+ * fail-closed reading. `toUser` already coerces the wire value to a boolean,
+ * but this does not lean on that — a User built by hand (buildDevStubUser,
+ * test fixtures) must not slip the gate by omitting the key.
  *
- * Returns false whenever the flag is off. That is the portal half of the
- * two-switch kill, and it is why every branch below can land dark.
+ * Returns false whenever the flag is off, which is what lets every branch
+ * below ship dark.
  */
 function isBlockedOnEmailVerification(user: User): boolean {
   return isEmailVerificationGateEnabled() && user.emailVerified !== true;
+}
+
+/**
+ * The redirect to issue when a caller could not DETERMINE the user's state, or
+ * undefined to let the request proceed.
+ *
+ * Admitting on "we don't know" is a fail-open, and it fails open on exactly the
+ * population this gate exists to catch. Shared by the two middlewares so the
+ * indeterminate case is answered the same way in both.
+ *
+ * Keyed on the flag deliberately: with the gate off this returns undefined and
+ * every caller behaves exactly as it did before. Denying unconditionally would
+ * turn a transient upstream failure into a portal-wide outage before the gate
+ * is even on.
+ *
+ * /verifying is safe as the destination — it sits outside the private layout
+ * (blocking-page invariant, routes.ts) so it cannot loop, and it self-heals:
+ * the page polls and releases the user once the upstream answers again.
+ */
+export function denyIfEmailGateEnabled(): Response | undefined {
+  return isEmailVerificationGateEnabled() ? redirect(paths.fraud.verifying) : undefined;
 }
 
 /**
@@ -58,14 +79,11 @@ export function isAwaitingEmailVerification(result: FraudPollResult): boolean {
  *
  * Pass `null` for `user` when the user could not be read — that renders the
  * page. Fail-CLOSED: this page is the block, so an upstream outage must not
- * become a way past it. (account-under-review.tsx calls the same behaviour
- * "fail-open"; on a blocking page the two words describe the same safe
- * outcome — keep showing it.)
+ * become a way past it.
  *
- * The flag-off branch is the DISABLE direction of the kill switch: the instant
- * infra rolls EMAIL_VERIFICATION_GATE back off, anyone parked here is released
- * on their next navigation rather than stranded on a page nothing moves them
- * past.
+ * The flag-off branch is the disable direction of the kill switch: the instant
+ * EMAIL_VERIFICATION_GATE is rolled back off, anyone parked here is released on
+ * their next navigation rather than stranded on a page nothing moves them past.
  */
 export function resolveVerifyEmailPageRedirect(
   user: Pick<User, 'emailVerified'> | null
@@ -84,11 +102,11 @@ export function resolveFraudPollResult(user: User): FraudPollResult {
     return { status: 'completed', decision: 'DEACTIVATE' };
   }
 
-  // POSITION 2 — the same rank this branch holds in resolveUserFraudRedirectPath
-  // below, and it has to be. If this returned ACCEPTED for an Approved-but-
+  // Position 2, the same rank this branch holds in resolveUserFraudRedirectPath
+  // below — and it has to be. If this returned ACCEPTED for an approved but
   // unverified user, /verify-email would poll, be told to proceed, navigate,
-  // and be bounced straight back by the redirect cascade. That is a loop, not
-  // a funnel. The two functions move together or not at all.
+  // and be bounced straight back by the cascade. That is a loop, not a funnel.
+  // The two functions move together or not at all.
   if (isBlockedOnEmailVerification(user)) {
     return { status: 'pending', reason: 'email-unverified' };
   }
@@ -123,23 +141,15 @@ export function resolveUserFraudRedirectPath(
     return paths.fraud.accountSuspended;
   }
 
-  // POSITION 2 — after suspension, before approval.
+  // Position 2 — after suspension, before approval. After suspension because a
+  // suspended user must never see a verify prompt; before approval because
+  // staff should not review an address nobody has proven they own. This is an
+  // ADDITIONAL gate, not a replacement for staff approval: the funnel is
+  // check-your-email → verify → under review → staff approves → in.
   //
-  // After suspension because a suspended user must never see a verify prompt.
-  // Before approval because staff should not review an address nobody has
-  // proven they own. This is an ADDITIONAL gate, not a replacement for staff
-  // approval: the funnel is check-your-email → verify → under review → staff
-  // approves → in.
-  //
-  // Route-level, so it blocks EVERYTHING rather than just mutations — verb-level
-  // gating is not expressible here, and a read-only pass would leave unverified
-  // users in a functional-looking app that fails on every write.
-  //
-  // The self-exclusion mirrors the name-review branch below. It is currently
-  // unreachable — /verify-email is declared outside the private layout, so
-  // none of this function's three callers ever see that pathname — but it
-  // costs one comparison and makes the cascade loop-free by construction
-  // rather than by where a route happens to be mounted.
+  // The self-exclusion mirrors the name-review branch below and relies on the
+  // blocking-page invariant (routes.ts) rather than trusting it — see
+  // routes-layout-invariant.test.ts.
   if (isBlockedOnEmailVerification(user) && pathname !== paths.fraud.verifyEmail) {
     return paths.fraud.verifyEmail;
   }

--- a/app/utils/middlewares/fraud-redirect.ts
+++ b/app/utils/middlewares/fraud-redirect.ts
@@ -1,10 +1,21 @@
 import { isOnboardingDevBypassEnabled } from '@/features/onboarding/onboarding-dev-bypass';
 import type { User } from '@/resources/users';
 import { PlatformAccess } from '@/resources/users/user.schema';
+import { isEmailVerificationGateEnabled } from '@/utils/config/email-verification-gate';
 import { paths } from '@/utils/config/paths.config';
 
 export type FraudPollResult =
-  | { status: 'pending' }
+  | {
+      status: 'pending';
+      /**
+       * WHICH wait this is. Required, not optional: /verify-email polls this
+       * endpoint to decide whether to stay put, and an optional field would
+       * let a future pending branch omit it — at which point the page reads
+       * `undefined`, concludes "not an email wait", and navigates a still-
+       * unverified user away from the page that exists to hold them.
+       */
+      reason: 'fraud-review' | 'email-unverified';
+    }
   | {
       status: 'completed';
       decision: 'ACCEPTED' | 'REVIEW' | 'DEACTIVATE';
@@ -15,9 +26,71 @@ export type FraudPollResult =
 export const onboardingEntryPath = (user: User): string =>
   user.nameReviewRequired ? paths.onboarding.profile : paths.onboarding.account;
 
+/**
+ * Whether Phase B's email-verification gate should hold this user.
+ *
+ * Reads ABSENT as unverified. `emailVerified` is optional on the domain User
+ * and no pre-Phase-B `User` CR carries it, so `!== true` is the fail-closed
+ * reading the spec asks for. `toUser` (user.adapter.ts) already coerces the
+ * wire value to a boolean, but this predicate does not lean on that — a User
+ * built by hand (buildDevStubUser, fixtures) must not slip the gate simply by
+ * omitting the key.
+ *
+ * Returns false whenever the flag is off. That is the portal half of the
+ * two-switch kill, and it is why every branch below can land dark.
+ */
+function isBlockedOnEmailVerification(user: User): boolean {
+  return isEmailVerificationGateEnabled() && user.emailVerified !== true;
+}
+
+/**
+ * True while /verify-email must keep waiting. Anything else — a completed
+ * decision, or a pending FRAUD review — means the address is proven and the
+ * cascade has moved on, so the page hands control back to the server.
+ */
+export function isAwaitingEmailVerification(result: FraudPollResult): boolean {
+  return result.status === 'pending' && result.reason === 'email-unverified';
+}
+
+/**
+ * Where /verify-email should send the user instead of rendering, or null to
+ * render the blocking page.
+ *
+ * Pass `null` for `user` when the user could not be read — that renders the
+ * page. Fail-CLOSED: this page is the block, so an upstream outage must not
+ * become a way past it. (account-under-review.tsx calls the same behaviour
+ * "fail-open"; on a blocking page the two words describe the same safe
+ * outcome — keep showing it.)
+ *
+ * The flag-off branch is the DISABLE direction of the kill switch: the instant
+ * infra rolls EMAIL_VERIFICATION_GATE back off, anyone parked here is released
+ * on their next navigation rather than stranded on a page nothing moves them
+ * past.
+ */
+export function resolveVerifyEmailPageRedirect(
+  user: Pick<User, 'emailVerified'> | null
+): string | null {
+  if (!isEmailVerificationGateEnabled()) {
+    return paths.home;
+  }
+  if (user?.emailVerified === true) {
+    return paths.home;
+  }
+  return null;
+}
+
 export function resolveFraudPollResult(user: User): FraudPollResult {
   if (user.platformAccess === PlatformAccess.Suspended || user.state === 'Inactive') {
     return { status: 'completed', decision: 'DEACTIVATE' };
+  }
+
+  // POSITION 2 — the same rank this branch holds in resolveUserFraudRedirectPath
+  // below, and it has to be. If this returned ACCEPTED for an Approved-but-
+  // unverified user, /verify-email would poll, be told to proceed, navigate,
+  // and be bounced straight back by the redirect cascade. That is a loop, not
+  // a funnel. The two functions move together or not at all.
+  if (isBlockedOnEmailVerification(user)) {
+    return { status: 'pending', reason: 'email-unverified' };
   }
 
   if (user.platformAccess === PlatformAccess.Approved) {
@@ -32,7 +105,7 @@ export function resolveFraudPollResult(user: User): FraudPollResult {
     return { status: 'completed', decision: 'REVIEW' };
   }
 
-  return { status: 'pending' };
+  return { status: 'pending', reason: 'fraud-review' };
 }
 
 /**
@@ -48,6 +121,27 @@ export function resolveUserFraudRedirectPath(
 
   if (user.platformAccess === PlatformAccess.Suspended || user.state === 'Inactive') {
     return paths.fraud.accountSuspended;
+  }
+
+  // POSITION 2 — after suspension, before approval.
+  //
+  // After suspension because a suspended user must never see a verify prompt.
+  // Before approval because staff should not review an address nobody has
+  // proven they own. This is an ADDITIONAL gate, not a replacement for staff
+  // approval: the funnel is check-your-email → verify → under review → staff
+  // approves → in.
+  //
+  // Route-level, so it blocks EVERYTHING rather than just mutations — verb-level
+  // gating is not expressible here, and a read-only pass would leave unverified
+  // users in a functional-looking app that fails on every write.
+  //
+  // The self-exclusion mirrors the name-review branch below. It is currently
+  // unreachable — /verify-email is declared outside the private layout, so
+  // none of this function's three callers ever see that pathname — but it
+  // costs one comparison and makes the cascade loop-free by construction
+  // rather than by where a route happens to be mounted.
+  if (isBlockedOnEmailVerification(user) && pathname !== paths.fraud.verifyEmail) {
+    return paths.fraud.verifyEmail;
   }
 
   if (user.platformAccess === PlatformAccess.Approved) {

--- a/app/utils/middlewares/fraud-status.middleware.test.ts
+++ b/app/utils/middlewares/fraud-status.middleware.test.ts
@@ -1,0 +1,115 @@
+import { fraudStatusMiddleware } from './fraud-status.middleware';
+import type { MiddlewareContext } from './middleware';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// getUserWithAccessRetry is the seam: every W0-3 site is reachable by
+// controlling what it returns or throws. getSession controls the no-session
+// keeper. Mutable per-test behaviour, following legacy-setup.middleware.test.ts.
+type Access = { error: 'not_found' | 'forbidden' | 'other' } | { user: Record<string, unknown> };
+
+let access: Access | (() => never) = { error: 'other' };
+let session: { sub?: string } | null = { sub: 'u1' };
+
+const getUserWithAccessRetry = mock(async () => {
+  if (typeof access === 'function') return access();
+  return access;
+});
+
+mock.module('@/utils/fraud/user-access', () => ({
+  getUserWithAccessRetry,
+  appendSetCookieHeaders: () => {},
+}));
+
+mock.module('@/utils/cookies', () => ({
+  getSession: async () => ({ session }),
+}));
+
+mock.module('@/modules/axios/request-context', () => ({
+  getRequestContext: () => undefined,
+}));
+
+const gateOn = () => {
+  process.env.EMAIL_VERIFICATION_GATE = 'true';
+};
+const gateOff = () => {
+  delete process.env.EMAIL_VERIFICATION_GATE;
+};
+
+const approvedVerifiedUser = () => ({
+  sub: 'u1',
+  state: 'Active',
+  platformAccess: 'Approved',
+  nameReviewRequired: false,
+  emailVerified: true,
+});
+
+function ctxFor(path: string): MiddlewareContext {
+  return { request: new Request(`http://localhost${path}`), context: {} as never };
+}
+
+beforeEach(() => {
+  access = { error: 'other' };
+  session = { sub: 'u1' };
+  getUserWithAccessRetry.mockClear();
+});
+
+afterEach(() => {
+  gateOff();
+});
+
+describe('fraudStatusMiddleware — W0-3 indeterminate exits', () => {
+  it("gate OFF: an 'other' error still passes through (today's behaviour, byte-identical)", async () => {
+    gateOff();
+    const next = mock(async () => new Response('ok'));
+    const res = await fraudStatusMiddleware(ctxFor('/dashboard'), next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).toBe(200);
+  });
+
+  it("gate ON: an 'other' error redirects to /verifying instead of admitting", async () => {
+    gateOn();
+    const next = mock(async () => new Response('ok'));
+    const res = await fraudStatusMiddleware(ctxFor('/dashboard'), next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe('/verifying');
+  });
+
+  it('gate ON: a thrown error redirects rather than falling through the catch', async () => {
+    gateOn();
+    access = () => {
+      throw new Error('boom');
+    };
+    const next = mock(async () => new Response('ok'));
+    const res = await fraudStatusMiddleware(ctxFor('/dashboard'), next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.headers.get('Location')).toBe('/verifying');
+  });
+
+  // The keepers. These are the assertions that fail if someone "flips them all".
+  it('gate ON: the logout route still passes through — the escape hatch survives', async () => {
+    gateOn();
+    access = () => {
+      throw new Error('boom');
+    };
+    const next = mock(async () => new Response('ok'));
+    await fraudStatusMiddleware(ctxFor('/logout'), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('gate ON: no session still passes through to authMiddleware', async () => {
+    gateOn();
+    session = null;
+    const next = mock(async () => new Response('ok'));
+    await fraudStatusMiddleware(ctxFor('/dashboard'), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('gate ON: a resolved, permitted user still passes through', async () => {
+    gateOn();
+    access = { user: approvedVerifiedUser() };
+    const next = mock(async () => new Response('ok'));
+    await fraudStatusMiddleware(ctxFor('/dashboard'), next);
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/app/utils/middlewares/fraud-status.middleware.test.ts
+++ b/app/utils/middlewares/fraud-status.middleware.test.ts
@@ -2,9 +2,10 @@ import { fraudStatusMiddleware } from './fraud-status.middleware';
 import type { MiddlewareContext } from './middleware';
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
-// getUserWithAccessRetry is the seam: every W0-3 site is reachable by
-// controlling what it returns or throws. getSession controls the no-session
-// keeper. Mutable per-test behaviour, following legacy-setup.middleware.test.ts.
+// getUserWithAccessRetry is the seam: every indeterminate-state exit is
+// reachable by controlling what it returns or throws. getSession controls the
+// no-session keeper. Mutable per-test behaviour, following
+// legacy-setup.middleware.test.ts.
 type Access = { error: 'not_found' | 'forbidden' | 'other' } | { user: Record<string, unknown> };
 
 let access: Access | (() => never) = { error: 'other' };
@@ -57,7 +58,7 @@ afterEach(() => {
   gateOff();
 });
 
-describe('fraudStatusMiddleware — W0-3 indeterminate exits', () => {
+describe('fraudStatusMiddleware — indeterminate-state exits', () => {
   it("gate OFF: an 'other' error still passes through (today's behaviour, byte-identical)", async () => {
     gateOff();
     const next = mock(async () => new Response('ok'));

--- a/app/utils/middlewares/fraud-status.middleware.ts
+++ b/app/utils/middlewares/fraud-status.middleware.ts
@@ -1,10 +1,30 @@
 import { resolveUserFraudRedirectPath } from './fraud-redirect';
 import { type MiddlewareContext, type NextFunction } from './middleware';
 import { getRequestContext } from '@/modules/axios/request-context';
+import { isEmailVerificationGateEnabled } from '@/utils/config/email-verification-gate';
 import { paths } from '@/utils/config/paths.config';
 import { getSession } from '@/utils/cookies';
 import { appendSetCookieHeaders, getUserWithAccessRetry } from '@/utils/fraud/user-access';
 import { redirect } from 'react-router';
+
+/**
+ * E-FC (W0-3). Three of this middleware's six `next()` exits are reached when
+ * the user's state could not be DETERMINED — not when it was determined to be
+ * fine. Admitting on "we don't know" is a fail-open, and it fails open on
+ * exactly the population the Phase B gate exists to catch.
+ *
+ * Keyed on the gate flag on purpose: with the gate off this returns undefined
+ * and every caller behaves byte-identically to pre-Phase-B. Flipping it
+ * unconditionally would turn a milo blip into a portal-wide outage before the
+ * gate is even on (spec risk #2).
+ *
+ * /verifying is safe as a destination: routes.ts places it OUTSIDE the
+ * private layout, which is this middleware's only registration
+ * (private.layout.tsx:96-97), so it cannot loop. It also self-heals — the page
+ * polls and releases the user once milo answers again.
+ */
+const denyIfGated = (): Response | undefined =>
+  isEmailVerificationGateEnabled() ? redirect(paths.fraud.verifying) : undefined;
 
 /**
  * Fraud status middleware that gates access based on user.status fields set by
@@ -13,7 +33,7 @@ import { redirect } from 'react-router';
  *
  * Algorithm:
  * 1. Read session; if no sub, call next() (let authMiddleware handle)
- * 2. Fetch user (or reuse auth middleware cache); if NotFoundError or AuthorizationError → /verifying (not yet provisioned or permissions not yet propagated); other errors → fail-open
+ * 2. Fetch user (or reuse auth middleware cache); if NotFoundError or AuthorizationError → /verifying (not yet provisioned or permissions not yet propagated); other errors → fail-open with the email gate off, /verifying with it on (E-FC)
  * 3. Cache user in reqCtx to avoid a second upstream call in the layout loader
  * 4. state === 'Inactive' || platformAccess === 'Suspended' → /account-suspended
  * 5. platformAccess === 'Approved'         → if nameReviewRequired and not on onboarding profile → redirect there; else next()
@@ -48,7 +68,10 @@ export async function fraudStatusMiddleware(
         if (access.error === 'not_found' || access.error === 'forbidden') {
           return redirect(paths.fraud.verifying);
         }
-        return next();
+        // 'other' = milo 5xx, timeout, reset, decode error — the state could
+        // not be determined. The widest W0-3 fail-open, and the one that fires
+        // in a real incident.
+        return denyIfGated() ?? next();
       }
 
       user = access.user;
@@ -56,7 +79,9 @@ export async function fraudStatusMiddleware(
     }
 
     if (!user) {
-      return next();
+      // Unreachable on current types; the guard exists because its author did
+      // not trust that, and an unknown user must not pass a security gate.
+      return denyIfGated() ?? next();
     }
 
     const reqCtx = getRequestContext();
@@ -74,7 +99,10 @@ export async function fraudStatusMiddleware(
 
     return next();
   } catch {
-    // Fail-open on unexpected errors
-    return next();
+    // Unexpected throw (getSession, the resolver, header handling): fail-open
+    // with the email gate off — byte-identical to pre-Phase-B — and /verifying
+    // with it on (E-FC). The logout short-circuit above runs before this try,
+    // so the escape hatch survives either way.
+    return denyIfGated() ?? next();
   }
 }

--- a/app/utils/middlewares/fraud-status.middleware.ts
+++ b/app/utils/middlewares/fraud-status.middleware.ts
@@ -1,30 +1,10 @@
-import { resolveUserFraudRedirectPath } from './fraud-redirect';
+import { denyIfEmailGateEnabled, resolveUserFraudRedirectPath } from './fraud-redirect';
 import { type MiddlewareContext, type NextFunction } from './middleware';
 import { getRequestContext } from '@/modules/axios/request-context';
-import { isEmailVerificationGateEnabled } from '@/utils/config/email-verification-gate';
 import { paths } from '@/utils/config/paths.config';
 import { getSession } from '@/utils/cookies';
 import { appendSetCookieHeaders, getUserWithAccessRetry } from '@/utils/fraud/user-access';
 import { redirect } from 'react-router';
-
-/**
- * E-FC (W0-3). Three of this middleware's six `next()` exits are reached when
- * the user's state could not be DETERMINED — not when it was determined to be
- * fine. Admitting on "we don't know" is a fail-open, and it fails open on
- * exactly the population the Phase B gate exists to catch.
- *
- * Keyed on the gate flag on purpose: with the gate off this returns undefined
- * and every caller behaves byte-identically to pre-Phase-B. Flipping it
- * unconditionally would turn a milo blip into a portal-wide outage before the
- * gate is even on (spec risk #2).
- *
- * /verifying is safe as a destination: routes.ts places it OUTSIDE the
- * private layout, which is this middleware's only registration
- * (private.layout.tsx:96-97), so it cannot loop. It also self-heals — the page
- * polls and releases the user once milo answers again.
- */
-const denyIfGated = (): Response | undefined =>
-  isEmailVerificationGateEnabled() ? redirect(paths.fraud.verifying) : undefined;
 
 /**
  * Fraud status middleware that gates access based on user.status fields set by
@@ -33,7 +13,7 @@ const denyIfGated = (): Response | undefined =>
  *
  * Algorithm:
  * 1. Read session; if no sub, call next() (let authMiddleware handle)
- * 2. Fetch user (or reuse auth middleware cache); if NotFoundError or AuthorizationError → /verifying (not yet provisioned or permissions not yet propagated); other errors → fail-open with the email gate off, /verifying with it on (E-FC)
+ * 2. Fetch user (or reuse auth middleware cache); if NotFoundError or AuthorizationError → /verifying (not yet provisioned or permissions not yet propagated); other errors → fail-open with the email gate off, /verifying with it on
  * 3. Cache user in reqCtx to avoid a second upstream call in the layout loader
  * 4. state === 'Inactive' || platformAccess === 'Suspended' → /account-suspended
  * 5. platformAccess === 'Approved'         → if nameReviewRequired and not on onboarding profile → redirect there; else next()
@@ -69,9 +49,9 @@ export async function fraudStatusMiddleware(
           return redirect(paths.fraud.verifying);
         }
         // 'other' = milo 5xx, timeout, reset, decode error — the state could
-        // not be determined. The widest W0-3 fail-open, and the one that fires
-        // in a real incident.
-        return denyIfGated() ?? next();
+        // not be determined. The widest of the three indeterminate exits, and
+        // the one that fires during a real incident.
+        return denyIfEmailGateEnabled() ?? next();
       }
 
       user = access.user;
@@ -79,9 +59,9 @@ export async function fraudStatusMiddleware(
     }
 
     if (!user) {
-      // Unreachable on current types; the guard exists because its author did
-      // not trust that, and an unknown user must not pass a security gate.
-      return denyIfGated() ?? next();
+      // Unreachable on current types. Kept because an unknown user must not
+      // pass a security gate on the strength of a type annotation.
+      return denyIfEmailGateEnabled() ?? next();
     }
 
     const reqCtx = getRequestContext();
@@ -100,9 +80,9 @@ export async function fraudStatusMiddleware(
     return next();
   } catch {
     // Unexpected throw (getSession, the resolver, header handling): fail-open
-    // with the email gate off — byte-identical to pre-Phase-B — and /verifying
-    // with it on (E-FC). The logout short-circuit above runs before this try,
-    // so the escape hatch survives either way.
-    return denyIfGated() ?? next();
+    // with the email gate off — identical to the behaviour that shipped before
+    // it existed — and /verifying with it on. The logout short-circuit above
+    // runs before this try, so the escape hatch survives either way.
+    return denyIfEmailGateEnabled() ?? next();
   }
 }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -55,6 +55,11 @@ export default defineConfig({
     APP_URL: process.env.CYPRESS_BASE_URL,
     ACCESS_TOKEN: process.env.ACCESS_TOKEN,
     SUB: process.env.SUB,
+    // Forwarded so a spec can tell which position the server under test is in.
+    // Cypress only auto-imports CYPRESS_-prefixed variables, but the server
+    // reads the unprefixed name — without this line the two disagree and the
+    // spec asserts off-position behaviour against an on-position server.
+    EMAIL_VERIFICATION_GATE: process.env.EMAIL_VERIFICATION_GATE,
   },
   e2e: {
     // Required to type into Stripe PaymentElement / AddressElement iframes (js.stripe.com).

--- a/cypress/e2e/regression/email-verification-gate.cy.ts
+++ b/cypress/e2e/regression/email-verification-gate.cy.ts
@@ -1,19 +1,23 @@
 import { paths } from '@/utils/config/paths.config';
 
 /**
- * Email Verification Gate — Phase B (E-GATE / E-B3b)
+ * Email verification gate — both positions of one switch, one spec.
  *
- * Two positions of the same switch, one spec. Run it twice:
- *   bun run test:e2e                                  → gate off (default)
- *   EMAIL_VERIFICATION_GATE=true bun run test:e2e     → gate on
- * The server-side flag is what changes; the spec reads the same variable so it
- * knows which behaviour to assert. A spec that only ever runs in one position
- * is not a kill-switch test.
+ *   bun run test:e2e                                → gate off (default, and
+ *                                                     what CI runs)
+ *   EMAIL_VERIFICATION_GATE=true bun run test:e2e   → gate on
  *
- * NOTE on the on-position: whether the signed-in fixture user reads verified
- * or unverified depends on the environment's milo User CR. Before the A-BF
- * backfill has run anywhere, EVERY user reads unverified, so gate-on holds the
- * fixture at /verify-email — which is exactly the assertion below.
+ * The variable reaches BOTH processes: the server reads it from its own
+ * environment, and cypress.config.ts forwards it into `Cypress.env` so the spec
+ * knows which behaviour to assert. Cypress only auto-imports CYPRESS_-prefixed
+ * variables, so that forwarding is what keeps the two in agreement — without it
+ * the spec asserts the off-position against an on-position server. A spec that
+ * only ever runs in one position is not a kill-switch test.
+ *
+ * NOTE on the on-position: whether the signed-in fixture user reads verified or
+ * unverified depends on the environment's milo User record. Before the backfill
+ * has run anywhere, EVERY user reads unverified, so gate-on holds the fixture
+ * at /verify-email — which is exactly the assertion below.
  */
 const gateOn = Cypress.env('EMAIL_VERIFICATION_GATE') === 'true';
 
@@ -44,12 +48,22 @@ describe('email verification gate', () => {
 
   it('always lets the user log out', () => {
     // The one escape hatch every blocking page keeps (verifying.tsx,
-    // account-under-review.tsx). If the gate ever swallows this, a
-    // mis-flip becomes unrecoverable without an infra roll.
+    // account-under-review.tsx). If the gate ever swallows this, a mis-flip
+    // becomes unrecoverable without an infra roll.
     cy.login();
-    cy.visit(paths.fraud.verifyEmail, { failOnStatusCode: false });
+
     if (gateOn) {
+      cy.visit(paths.fraud.verifyEmail, { failOnStatusCode: false });
       cy.contains('Log out').should('be.visible');
+    } else {
+      // Gate off, so /verify-email is not where the user lands. Assert the
+      // escape hatch still answers on the page they DO get, rather than
+      // asserting nothing at all in the position CI actually runs.
+      cy.visit(paths.account.organizations.root, { failOnStatusCode: false });
+      cy.location('pathname').should('not.eq', paths.fraud.verifyEmail);
+      cy.request({ url: paths.auth.logOut, followRedirect: false })
+        .its('status')
+        .should('be.oneOf', [200, 302]);
     }
   });
 });

--- a/cypress/e2e/regression/email-verification-gate.cy.ts
+++ b/cypress/e2e/regression/email-verification-gate.cy.ts
@@ -1,0 +1,55 @@
+import { paths } from '@/utils/config/paths.config';
+
+/**
+ * Email Verification Gate — Phase B (E-GATE / E-B3b)
+ *
+ * Two positions of the same switch, one spec. Run it twice:
+ *   bun run test:e2e                                  → gate off (default)
+ *   EMAIL_VERIFICATION_GATE=true bun run test:e2e     → gate on
+ * The server-side flag is what changes; the spec reads the same variable so it
+ * knows which behaviour to assert. A spec that only ever runs in one position
+ * is not a kill-switch test.
+ *
+ * NOTE on the on-position: whether the signed-in fixture user reads verified
+ * or unverified depends on the environment's milo User CR. Before the A-BF
+ * backfill has run anywhere, EVERY user reads unverified, so gate-on holds the
+ * fixture at /verify-email — which is exactly the assertion below.
+ */
+const gateOn = Cypress.env('EMAIL_VERIFICATION_GATE') === 'true';
+
+describe('email verification gate', () => {
+  it(`${gateOn ? 'holds' : 'ignores'} a signed-in user at /verify-email`, () => {
+    cy.login();
+    cy.visit(paths.fraud.verifyEmail, { failOnStatusCode: false });
+
+    if (gateOn) {
+      cy.location('pathname').should('eq', paths.fraud.verifyEmail);
+      cy.contains('Check your email').should('be.visible');
+    } else {
+      // Flag off: the page redirects home and the gate is invisible.
+      cy.location('pathname').should('not.eq', paths.fraud.verifyEmail);
+    }
+  });
+
+  it(`${gateOn ? 'redirects' : 'does not redirect'} a protected route`, () => {
+    cy.login();
+    cy.visit(paths.account.organizations.root, { failOnStatusCode: false });
+
+    if (gateOn) {
+      cy.location('pathname').should('eq', paths.fraud.verifyEmail);
+    } else {
+      cy.location('pathname').should('not.eq', paths.fraud.verifyEmail);
+    }
+  });
+
+  it('always lets the user log out', () => {
+    // The one escape hatch every blocking page keeps (verifying.tsx,
+    // account-under-review.tsx). If the gate ever swallows this, a
+    // mis-flip becomes unrecoverable without an infra roll.
+    cy.login();
+    cy.visit(paths.fraud.verifyEmail, { failOnStatusCode: false });
+    if (gateOn) {
+      cy.contains('Log out').should('be.visible');
+    }
+  });
+});


### PR DESCRIPTION
## What's the problem?

**Nothing checks whether you've confirmed your email before you can use the platform.** Verified or not, you're in — you can create orgs, projects, everything.

There's a second, quieter problem. When the portal *can't tell* what state your account is in — milo returns a 500, times out, the connection resets — it currently lets you through. That's a fail-open, and it fails open on exactly the accounts a security gate exists to catch. It's also the case that fires during an incident, when you'd least want it.

## How are we fixing it?

- **An email check in the redirect cascade,** placed right after "is this account suspended?" and before "is it approved?" — a suspended user should never see a verify prompt, and staff shouldn't review an address nobody has proven they own.
- **A `/verify-email` page** that blocks everything else and polls in the background, moving the user forward the moment they click the link — no refresh needed.
- **A guard on the three API routes that spend our own credentials** — `/assistant` (Anthropic), `/cloudvalid`, `/usage` (Amberflo). The page-level gate covers navigation, not the Hono API surface. Every other route there forwards the caller's own token, so milo is the enforcement point; these three authenticate with a key we hold, and nothing downstream can tell an unverified signup apart.
- **Fail closed when the state is unknown.** The places that admitted users on "we couldn't determine this" now send them to `/verifying` instead, through one shared helper so the two middlewares can't drift apart. Logout still always works, so nobody can get stuck.
- **All of it behind `EMAIL_VERIFICATION_GATE`, off by default.** With the flag off, behaviour is byte-identical to today — the whole existing test suite passes unchanged.

## Why are we solving it?

Part of the passkey and account-security work — [enhancements#738](https://github.com/datum-cloud/enhancements/issues/738), tracked in [auth-ui#111](https://github.com/datum-cloud/auth-ui/issues/111). An unverified account shouldn't be able to act on the platform; this is the portal half of that gate, with milo enforcing the API half.

## ⚠️ Before anyone turns this on

**No existing user has the verified flag yet, and this code reads "missing" as "not verified".** Turning the flag on before the backfill job has run and its count has been reviewed locks out the entire existing user base — while looking perfectly healthy.

Order matters when flipping it:
- **Enabling:** portal first, then milo. (The reverse denies API calls to users the portal still lets in — an app that loads, then fails on everything.)
- **Disabling:** milo first, then portal.

## Notes for reviewers

- `EMAIL_VERIFICATION_GATE` is a plain env var on the Deployment — deliberately *not* an OpenFeature flag, since those are org-scoped and this has to work for users who don't have an org yet.
- Worth an eye from whoever owns the milo User API: we read `status.emailVerified` off the milo User. If it lands at a different path, this silently reads "unverified" for everyone.
- The e2e spec runs in both positions: `bun run test:e2e` for off (what CI runs), `EMAIL_VERIFICATION_GATE=true bun run test:e2e` for on. `cypress.config.ts` forwards the variable into `Cypress.env` so the spec and the server agree on which position they're in.
- `/verify-email` polls with `?refresh=0` and backs off 4s → 15s → 60s. The endpoint's proactive token refresh is for `/verifying`, which waits seconds; this page waits on a human finding an email, where a refresh grant per tick is pure cost.
- `routes-layout-invariant.test.ts` asserts the blocking pages stay outside the private layout. Three guards in the cascade defend that invariant and all three are unreachable by construction, so nothing else would tell us when one goes stale.
