### PR TITLE
fix(ci): make PR Test Summary wait for e2e-regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,9 +344,16 @@ jobs:
   # ─── PR Comment ─────────────────────────────────────────────
   pr-comment:
     name: PR Test Summary
-    needs: [bun-tests, unit-tests, e2e-smoke]
+    # Must depend on EVERY test job it reports on — otherwise it fires as soon
+    # as the fast jobs finish and snapshots the slow ones (the e2e-regression
+    # shards) while they're still running, so they show up as "pending" and a
+    # real failure would be masked as "pending" too.
+    needs: [bun-tests, unit-tests, e2e-smoke, e2e-regression]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # `always()` so the summary still posts when a test job fails — that's when
+    # the artifact links matter most. Without it, a failed dependency would
+    # skip this job and leave the PR with no comment at all.
+    if: always() && github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: write
@@ -371,35 +378,45 @@ jobs:
               j.name === 'Bun Unit Tests' || j.name === 'Unit Tests' || j.name.startsWith('E2E')
             );
 
+            // A job that hasn't finished has a null `conclusion` (distinct from
+            // "skipped"). With this job now depending on every test job it
+            // reports on, null should not occur — but label it honestly if it
+            // ever does, rather than collapsing it into the "skipped" emoji.
             const statusEmoji = (conclusion) => {
-              if (!conclusion || conclusion === 'skipped') return '⏭️';
               if (conclusion === 'success') return '✅';
               if (conclusion === 'failure') return '❌';
               if (conclusion === 'cancelled') return '🚫';
+              if (conclusion === 'skipped') return '⏭️';
+              if (!conclusion) return '⏳';
               return '❓';
             };
 
             let table = '| Job | Status |\n|-----|--------|\n';
             for (const job of testJobs.sort((a, b) => a.name.localeCompare(b.name))) {
-              table += `| ${job.name} | ${statusEmoji(job.conclusion)} ${job.conclusion || 'pending'} |\n`;
+              table += `| ${job.name} | ${statusEmoji(job.conclusion)} ${job.conclusion || 'in progress'} |\n`;
             }
-
-            const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: runId,
-            });
 
             let body = `## 🧪 Test Summary\n\n${table}\n\n`;
             body += `[View workflow run](${runUrl})`;
-            body += `\n\n### 📎 Artifacts\n\n`;
-            if (artifacts.artifacts.length > 0) {
-              body += `Videos and screenshots from failed E2E tests:\n\n`;
-              for (const a of artifacts.artifacts) {
-                body += `- **${a.name}** – [Download](${runUrl})\n`;
+
+            // Only surface debugging artifacts when a test actually failed. On a
+            // green run the coverage/build artifacts still exist, so listing
+            // them here would wrongly imply a failure. E2E failure artifacts are
+            // named `e2e-*` (see the upload steps); coverage/build are not.
+            const anyFailed = testJobs.some(j => j.conclusion === 'failure');
+            if (anyFailed) {
+              const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              });
+              const e2eArtifacts = artifacts.artifacts.filter(a => a.name.startsWith('e2e-'));
+              if (e2eArtifacts.length > 0) {
+                body += `\n\n### 📎 Failure artifacts\n\nVideos and screenshots from failed E2E tests:\n\n`;
+                for (const a of e2eArtifacts) {
+                  body += `- **${a.name}** – [Download](${runUrl})\n`;
+                }
               }
-            } else {
-              body += `No artifacts (all tests passed).\n`;
             }
 
             fs.writeFileSync('pr-summary.md', body);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,17 @@ jobs:
                 repo: context.repo.repo,
                 run_id: runId,
               });
-              const e2eArtifacts = artifacts.artifacts.filter(a => a.name.startsWith('e2e-'));
+              // Dedupe by name: re-running a failed shard uploads its artifact
+              // again under the same name (the name carries run_id but not the
+              // run attempt), so the API returns two records for one shard.
+              // Keep one row per shard rather than listing the re-run twice.
+              const e2eArtifacts = [
+                ...new Map(
+                  artifacts.artifacts
+                    .filter(a => a.name.startsWith('e2e-'))
+                    .map(a => [a.name, a])
+                ).values(),
+              ];
               if (e2eArtifacts.length > 0) {
                 body += `\n\n### 📎 Failure artifacts\n\nVideos and screenshots from failed E2E tests:\n\n`;
                 for (const a of e2eArtifacts) {


### PR DESCRIPTION
## Problem

The **PR Test Summary** comment reports the E2E Regression shards as `⏭️ pending` even when they pass (e.g. [#1429](https://github.com/datum-cloud/cloud-portal/pull/1429#issuecomment-5235989767) — all four shards were `success` on the run, but the comment shows pending).

The `pr-comment` job only depended on `[bun-tests, unit-tests, e2e-smoke]`, so it fired as soon as those finished and read every job's `conclusion` via the API **while the regression shards were still running**. An unfinished job has a `null` conclusion, which the script rendered as "pending". Because it snapshots at a fixed moment, the same race would also **mask a genuine regression failure as "pending"** — a misleading green-ish signal. (The `status-check` merge gate already waits for regression, so merge protection was never affected — only the comment was wrong.)

Two smaller issues in the same job:
- No `if: always()`, so a **failed** test dependency skipped the comment entirely — no summary exactly when the failure artifacts are most useful.
- The artifacts block printed *"Videos and screenshots from failed E2E tests"* on green runs too, listing `bun-coverage`/`build-*` artifacts that always exist.

## Fix

- Add `e2e-regression` to `needs` so conclusions are final when read.
- Add `always()` so the summary still posts on failure.
- Split the overloaded `⏭️` emoji: `⏳ in progress` (unfinished) vs `⏭️ skipped`.
- Only list failure artifacts when a test actually failed, filtered to the `e2e-*` artifacts.

All changes are commented inline. YAML + embedded `github-script` both validated (`node --check`).

## Trade-off

The comment now appears after the slowest shard (~20 min) instead of early. That's intended for a *summary* — a late-but-correct comment beats an early wrong one.

## Note (out of scope)

While reviewing the flow I noticed `publish-container-image` / `publish-kustomize-bundles` have no event guard and **do run on every green `pull_request`** (confirmed on run 31356162089), publishing images with `secrets: inherit`. Flagging separately in case that's unintended — not touched here.