### PR TITLE
Retry Stripe config fetch on new-user permission race

### DIFF
--- a/app/resources/stripe-provider-configs/stripe-provider-config.service.ts
+++ b/app/resources/stripe-provider-configs/stripe-provider-config.service.ts
@@ -1,7 +1,7 @@
 import type { StripeProviderConfig } from '@/features/billing/types';
 import { listStripeBillingMiloapisComV1Alpha1StripeProviderConfig } from '@/modules/control-plane/stripe';
 import { logger } from '@/modules/logger';
-import { getUserScopedBase } from '@/resources/base/utils';
+import { getUserScopedBase, retryOnTransientAuthError } from '@/resources/base/utils';
 import { mapApiError } from '@/utils/errors/error-mapper';
 
 /**
@@ -29,10 +29,27 @@ export function createStripeProviderConfigService() {
     async list(): Promise<StripeProviderConfig[]> {
       const startTime = Date.now();
       try {
-        const resp = await listStripeBillingMiloapisComV1Alpha1StripeProviderConfig({
-          baseURL: getUserScopedBase(),
-        });
-        const items = resp.data?.items ?? [];
+        // A fresh signup's StripeProviderConfig grant travels an async
+        // pipeline (User → org membership → PolicyBinding → OpenFGA
+        // tuple sync) before it's effective, so a list fired in that
+        // window returns 401/403. Retry with backoff so the first page
+        // load after onboarding doesn't surface it as a hard error;
+        // callers that degrade gracefully still get their fallback if
+        // the grant never lands.
+        const items = await retryOnTransientAuthError(
+          async () => {
+            try {
+              const resp = await listStripeBillingMiloapisComV1Alpha1StripeProviderConfig({
+                baseURL: getUserScopedBase(),
+              });
+              return resp.data?.items ?? [];
+            } catch (error) {
+              // Map first so the retry loop can read the HTTP status.
+              throw mapApiError(error);
+            }
+          },
+          { operation: `${SERVICE_NAME}.list` }
+        );
         logger.service(SERVICE_NAME, 'list', { duration: Date.now() - startTime });
         return items;
       } catch (error) {


### PR DESCRIPTION
**Problem**
A new user who lands on the billing page right after signing up can hit `cannot list resource "stripeproviderconfigs" at cluster scope`. The grant for the StripeProviderConfig list travels an async pipeline (user → org membership → PolicyBinding → OpenFGA tuple sync) and isn't effective for the first few seconds, so the list returns 403.

**Solution**
Retry the list with backoff on transient 401/403, matching the existing `retryOnTransientAuthError` pattern used for post-onboarding grants. Non-auth errors still fail fast, and callers keep their graceful "not ready" fallback if the grant never lands.