### PR TITLE
fix: clarify hostnames vs TLS hostname on ALB dialog

### DIFF
--- a/app/features/edge/proxy/form/hostnames-field.tsx
+++ b/app/features/edge/proxy/form/hostnames-field.tsx
@@ -23,7 +23,12 @@ export const ProxyHostnamesField = forwardRef<HTMLDivElement, ProxyHostnamesFiel
 
     return (
       <div ref={ref} className="flex flex-col gap-2">
-        <span className="text-xs font-semibold">Hostnames</span>
+        <div className="flex flex-col gap-0.5">
+          <span className="text-xs font-semibold">Hostnames</span>
+          <span className="text-muted-foreground text-xs">
+            The domains that should point to this Application Load Balancer.
+          </span>
+        </div>
 
         <Form.FieldArray name="hostnames">
           {({ fields, append, remove }) => (

--- a/app/features/edge/proxy/form/tls-field.tsx
+++ b/app/features/edge/proxy/form/tls-field.tsx
@@ -8,12 +8,12 @@ export const ProxyTlsField = ({ required = false }: ProxyTlsFieldProps) => {
   return (
     <Form.Field
       name="tlsHostname"
-      label="TLS Hostname"
+      label="TLS Hostname (advanced)"
       required={required}
       description={
         required
-          ? 'The hostname to use for TLS certificate validation with your IP-based endpoint (required for SNI and certificate hostname matching)'
-          : 'The hostname to use for TLS certificate validation (SNI and certificate hostname matching). Leave empty to use the hostname from the endpoint URL.'
+          ? 'For certificate matching only — this does not add a hostname. Required for SNI and certificate hostname matching with your IP-based endpoint. Add your domain under Hostnames above.'
+          : 'For certificate matching only — this does not add a hostname. Used for SNI and certificate hostname matching. Leave empty to use the hostname from the endpoint URL. Add your domain under Hostnames above.'
       }>
       <Form.Input
         placeholder="e.g. secure.example.com"

--- a/app/features/edge/proxy/proxy-hostnames-dialog.tsx
+++ b/app/features/edge/proxy/proxy-hostnames-dialog.tsx
@@ -53,7 +53,7 @@ export const ProxyHostnamesConfigDialog = forwardRef<
     setProxy(proxyData);
     setProxyName(proxyData.name);
     setDefaultValues({
-      hostnames: proxyData.hostnames,
+      hostnames: proxyData.hostnames && proxyData.hostnames.length > 0 ? proxyData.hostnames : [''],
       tlsHostname: proxyData.tlsHostname,
     });
     setOpen(true);


### PR DESCRIPTION
## Summary

Quick pass at making the Hostnames/TLS dialog clearer.

- Pre-populate one hostname row when the ALB has no hostnames configured, instead of an empty state with only an "Add hostname" button.
- Add a short description to the Hostnames section.
- Relabel TLS Hostname as advanced and note it doesn't add a hostname.

Fixes #1434

Before:
<img width="1605" height="951" alt="Screenshot From 2026-08-18 10-31-42" src="https://github.com/user-attachments/assets/39db70e0-4037-483a-b455-c45bcbebc5fa" />

After:

<img width="822" height="562" alt="image" src="https://github.com/user-attachments/assets/44b20a35-a91d-4581-9af1-0546714dcdd8" />


## Test plan

- [ ] Open an ALB with no custom hostnames and confirm the dialog opens with one editable row.
- [ ] Open an ALB with existing hostnames and confirm they still load correctly.
- [ ] Confirm TLS Hostname field still validates and saves as before.