### PR TITLE
Make project renames actually stick

### DIFF
--- a/app/resources/projects/project.adapter.test.ts
+++ b/app/resources/projects/project.adapter.test.ts
@@ -41,6 +41,39 @@ describe('toProject', () => {
     expect(toProject(raw as never).description).toBeUndefined();
   });
 
+  it('prefers the display-name annotation over description for displayName', () => {
+    const raw = {
+      metadata: rawMetadata({
+        name: 'proj-abc',
+        annotations: {
+          'kubernetes.io/display-name': 'Renamed Project',
+          'kubernetes.io/description': 'Original Name',
+        },
+      }),
+      spec: { ownerRef: { name: 'acme' } },
+    };
+    const project = toProject(raw as never);
+
+    expect(project.displayName).toBe('Renamed Project');
+    // description stays its own field even when display-name wins the label.
+    expect(project.description).toBe('Original Name');
+  });
+
+  it('falls through an empty display-name annotation instead of blanking the label', () => {
+    const raw = {
+      metadata: rawMetadata({
+        name: 'proj-abc',
+        annotations: {
+          'kubernetes.io/display-name': '',
+          'kubernetes.io/description': 'Web project',
+        },
+      }),
+      spec: { ownerRef: { name: 'acme' } },
+    };
+
+    expect(toProject(raw as never).displayName).toBe('Web project');
+  });
+
   it('maps deletionTimestamp from metadata', () => {
     const raw = {
       metadata: rawMetadata({
@@ -145,6 +178,16 @@ describe('toCreatePayload', () => {
     expect(payload.metadata?.annotations?.['kubernetes.io/description']).toBe('desc');
     expect(payload.spec?.ownerRef).toEqual({ kind: 'Organization', name: 'acme' });
   });
+
+  it('stamps display-name alongside description so the name is renameable later', () => {
+    const payload = toCreatePayload({
+      organizationId: 'acme',
+      description: 'My Project',
+    } as never);
+
+    expect(payload.metadata?.annotations?.['kubernetes.io/display-name']).toBe('My Project');
+    expect(payload.metadata?.annotations?.['kubernetes.io/description']).toBe('My Project');
+  });
 });
 
 describe('toUpdatePayload', () => {
@@ -155,13 +198,51 @@ describe('toUpdatePayload', () => {
     } as never);
 
     expect(payload.metadata?.annotations).toEqual({
+      'kubernetes.io/display-name': 'new desc',
       'kubernetes.io/description': 'new desc',
       'custom/flag': 'on',
     });
   });
 
-  it('omits the description annotation when no description is provided', () => {
+  it('omits the name annotations when no description is provided', () => {
     const payload = toUpdatePayload({ annotations: { a: 'b' } } as never);
     expect(payload.metadata?.annotations).toEqual({ a: 'b' });
+  });
+
+  it('writes an explicitly empty name instead of silently dropping it', () => {
+    const payload = toUpdatePayload({ description: '' } as never);
+
+    expect(payload.metadata?.annotations).toEqual({
+      'kubernetes.io/display-name': '',
+      'kubernetes.io/description': '',
+    });
+  });
+});
+
+// Regression guard for #1440: renaming wrote kubernetes.io/description while
+// toProject read kubernetes.io/display-name first, so any project already
+// carrying display-name silently reverted to its old name after a save.
+describe('rename round-trip', () => {
+  it('resolves to the new name for a project already carrying display-name', () => {
+    const existing = rawMetadata({
+      name: 'proj-abc',
+      annotations: {
+        'kubernetes.io/display-name': 'Old Name',
+        'kubernetes.io/description': 'Old Name',
+      },
+    });
+
+    const patch = toUpdatePayload({ description: 'New Name' } as never);
+
+    // metadata.annotations is a map, so merge-patch merges keys onto the object.
+    const merged = {
+      metadata: {
+        ...existing,
+        annotations: { ...existing.annotations, ...patch.metadata?.annotations },
+      },
+      spec: { ownerRef: { name: 'acme' } },
+    };
+
+    expect(toProject(merged as never).displayName).toBe('New Name');
   });
 });

--- a/app/resources/projects/project.adapter.ts
+++ b/app/resources/projects/project.adapter.ts
@@ -20,9 +20,9 @@ export function toProject(raw: ComMiloapisResourcemanagerV1Alpha1Project): Proje
     name: raw.metadata?.name ?? '',
     namespace: raw.metadata?.namespace ?? '',
     displayName:
-      annotations?.['kubernetes.io/display-name'] ??
-      annotations?.['kubernetes.io/description'] ??
-      raw.metadata?.name ??
+      annotations?.['kubernetes.io/display-name'] ||
+      annotations?.['kubernetes.io/description'] ||
+      raw.metadata?.name ||
       '',
     description: annotations?.['kubernetes.io/description'],
     resourceVersion: raw.metadata?.resourceVersion ?? '',
@@ -73,7 +73,11 @@ export function toCreatePayload(
     kind: 'Project',
     metadata: {
       generateName: 'project-',
+      // Both annotations carry the name: display-name is what the read path
+      // above (and graphql-gateway's Project.displayName) prefers, while
+      // description stays populated for consumers still reading it.
       annotations: {
+        'kubernetes.io/display-name': input.description ?? '',
         'kubernetes.io/description': input.description ?? '',
       },
     },
@@ -94,7 +98,13 @@ export function toUpdatePayload(
     kind: 'Project',
     metadata: {
       annotations: {
-        ...(input.description && { 'kubernetes.io/description': input.description }),
+        // Kept in sync with toCreatePayload — writing only description would
+        // leave a stale display-name winning the read chain, so the rename
+        // would appear to succeed and then revert (#1440).
+        ...(input.description !== undefined && {
+          'kubernetes.io/display-name': input.description,
+          'kubernetes.io/description': input.description,
+        }),
         ...input.annotations,
       },
     },

--- a/app/resources/projects/project.schema.test.ts
+++ b/app/resources/projects/project.schema.test.ts
@@ -1,0 +1,16 @@
+import { updateProjectSchema } from './project.schema';
+import { describe, expect, it } from 'bun:test';
+
+describe('updateProjectSchema', () => {
+  it('rejects an empty project name so Save cannot silently no-op', () => {
+    expect(updateProjectSchema.safeParse({ description: '' }).success).toBe(false);
+  });
+
+  it('accepts a non-empty project name', () => {
+    expect(updateProjectSchema.safeParse({ description: 'My Project' }).success).toBe(true);
+  });
+
+  it('still allows updates that touch only annotations', () => {
+    expect(updateProjectSchema.safeParse({ annotations: { a: 'b' } }).success).toBe(true);
+  });
+});

--- a/app/resources/projects/project.schema.ts
+++ b/app/resources/projects/project.schema.ts
@@ -52,7 +52,10 @@ export type CreateProjectInput = z.infer<typeof createProjectSchema>;
 
 export const updateProjectSchema = z.object({
   name: z.string().min(1).max(100).optional(),
-  description: z.string().max(500).optional(),
+  // min(1): the settings form binds this to "Project name". Form.Field's
+  // `required` prop only renders an asterisk, so without this an empty name
+  // validated fine and produced a no-op PATCH behind a success toast.
+  description: z.string().min(1, 'Project name is required.').max(500).optional(),
   annotations: z.record(z.string(), z.string()).optional(),
 });
 


### PR DESCRIPTION
**Problem**
The project name shown in the portal is resolved from the `kubernetes.io/display-name` annotation, falling back to `kubernetes.io/description`. Nothing ever wrote `display-name` — Project Settings > General only ever patched `description`. Any project already carrying a `display-name` annotation showed a success toast on rename and then immediately reverted to its old name. Separately, clearing the name field passed validation and produced an empty patch, so that save silently did nothing too.

**Solution**
Create and update now write `display-name` alongside `description`, kept in sync, matching how Organizations and billing accounts already behave and matching graphql-gateway's documented `Project.displayName` chain. The read chain uses `||` rather than `??` so a blank annotation falls through instead of surfacing as an empty name, and `updateProjectSchema` now requires a non-empty name — `Form.Field`'s `required` prop only renders an asterisk, it does not validate.

Worth knowing for review: nothing in milo, datumctl, the gateway, or this repo currently stamps `display-name` on a Project, so renames work today for portal-created projects. This closes the gap before something does, and covers the `display-name` branch of `toProject`, which previously had no assertions.

Refs #1440