### PR TITLE
fix: Stop silent TXT record truncation

### DIFF
--- a/app/features/edge/dns-zone/form/types/txt-record-field.tsx
+++ b/app/features/edge/dns-zone/form/types/txt-record-field.tsx
@@ -2,9 +2,9 @@ import { Form } from '@datum-cloud/datum-ui/form';
 
 export const TXTRecordField = () => (
   <Form.Field name="txt.content" label="Text Content" required className="col-span-full">
-    <Form.Input
+    <Form.Textarea
       placeholder="e.g., v=spf1 include:_spf.example.com ~all"
-      maxLength={255}
+      rows={3}
       autoCapitalize="none"
       autoCorrect="off"
       spellCheck={false}

--- a/app/resources/dns-records/dns-record.schema.test.ts
+++ b/app/resources/dns-records/dns-record.schema.test.ts
@@ -1,0 +1,45 @@
+import {
+  TXT_CONTENT_MAX_LENGTH,
+  createDnsRecordSchema,
+  txtRecordDataSchema,
+} from './dns-record.schema';
+import { describe, expect, it } from 'bun:test';
+
+describe('txtRecordDataSchema', () => {
+  it('accepts DKIM-length content beyond a single 255-octet TXT string', () => {
+    const content = `v=DKIM1; k=rsa; p=${'A'.repeat(392)}`;
+    expect(content.length).toBeGreaterThan(255);
+    expect(content.length).toBeLessThanOrEqual(TXT_CONTENT_MAX_LENGTH);
+
+    const result = txtRecordDataSchema.parse({ content });
+    expect(result.content).toBe(content);
+  });
+
+  it('rejects content longer than the per-record maximum', () => {
+    const result = txtRecordDataSchema.safeParse({
+      content: 'a'.repeat(TXT_CONTENT_MAX_LENGTH + 1),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('strips line breaks from wrapped pastes', () => {
+    const result = txtRecordDataSchema.parse({
+      content: 'v=DKIM1; k=rsa;\np=ABC\r\nDEF',
+    });
+    expect(result.content).toBe('v=DKIM1; k=rsa;p=ABCDEF');
+  });
+});
+
+describe('createDnsRecordSchema TXT', () => {
+  it('accepts a long TXT record in the form schema', () => {
+    const parsed = createDnsRecordSchema.parse({
+      recordType: 'TXT',
+      name: 'google._domainkey',
+      ttl: 3600,
+      txt: { content: `v=DKIM1; k=rsa; p=${'A'.repeat(392)}` },
+    });
+    expect(parsed.recordType).toBe('TXT');
+    if (parsed.recordType !== 'TXT') return;
+    expect(parsed.txt.content.length).toBeGreaterThan(255);
+  });
+});

--- a/app/resources/dns-records/dns-record.schema.ts
+++ b/app/resources/dns-records/dns-record.schema.ts
@@ -128,13 +128,26 @@ export const aliasRecordDataSchema = z.object({
 });
 
 // TXT Record - Text content
-// Cloudflare: max 2,048 chars per record, max 8,192 total for same name
-// Google Cloud: Standard TXT record limits
+// A single DNS TXT string is limited to 255 octets (RFC 1035), but a record
+// may contain multiple concatenated strings. Providers typically allow ~2,048
+// characters per record (Cloudflare: 2,048 per record, 8,192 total per name).
+export const TXT_CONTENT_MAX_LENGTH = 2048;
+
 export const txtRecordDataSchema = z.object({
   content: z
     .string({ error: 'Text content is required.' })
-    .min(1, 'Text content cannot be empty.')
-    .max(2048, 'Text content cannot exceed 2,048 characters per record'),
+    // Line breaks are not meaningful in TXT values and appear when users paste
+    // wrapped DKIM/SPF keys from docs. Strip them so paste is not stored as-is.
+    .transform((val) => val.replace(/[\r\n]/g, ''))
+    .pipe(
+      z
+        .string()
+        .min(1, 'Text content cannot be empty.')
+        .max(
+          TXT_CONTENT_MAX_LENGTH,
+          `Text content cannot exceed ${TXT_CONTENT_MAX_LENGTH.toLocaleString()} characters per record`
+        )
+    ),
 });
 
 // MX Record - Mail exchange

--- a/app/resources/dns-records/index.ts
+++ b/app/resources/dns-records/index.ts
@@ -28,6 +28,7 @@ export {
   aliasRecordDataSchema,
   cnameRecordDataSchema,
   txtRecordDataSchema,
+  TXT_CONTENT_MAX_LENGTH,
   mxRecordDataSchema,
   srvRecordDataSchema,
   caaRecordDataSchema,

--- a/app/routes/test/dns-record/components/default-test-scenarios.ts
+++ b/app/routes/test/dns-record/components/default-test-scenarios.ts
@@ -1,4 +1,8 @@
-import { CreateDnsRecordSchema, DNSRecordType } from '@/resources/dns-records';
+import {
+  CreateDnsRecordSchema,
+  DNSRecordType,
+  TXT_CONTENT_MAX_LENGTH,
+} from '@/resources/dns-records';
 
 export interface TestScenario {
   id: string;
@@ -195,6 +199,21 @@ export const DEFAULT_TEST_SCENARIOS: Record<DNSRecordType, TestScenario[]> = {
       isDefault: true,
     },
     {
+      id: 'txt-dkim',
+      name: 'DKIM Key',
+      recordType: 'TXT',
+      data: {
+        recordType: 'TXT',
+        name: 'google._domainkey',
+        ttl: 3600,
+        // 2048-bit RSA DKIM keys are ~400 chars; well over a single 255-octet TXT string
+        txt: {
+          content: `v=DKIM1; k=rsa; p=${'A'.repeat(392)}`,
+        },
+      },
+      isDefault: true,
+    },
+    {
       id: 'txt-too-long',
       name: 'Invalid Too Long',
       recordType: 'TXT',
@@ -202,7 +221,7 @@ export const DEFAULT_TEST_SCENARIOS: Record<DNSRecordType, TestScenario[]> = {
         recordType: 'TXT',
         name: 'test',
         ttl: null,
-        txt: { content: 'a'.repeat(2049) }, // Exceeds 2048 char limit
+        txt: { content: 'a'.repeat(TXT_CONTENT_MAX_LENGTH + 1) },
       },
       isDefault: true,
     },


### PR DESCRIPTION
## Summary

Pasting a long TXT value, like a Google DKIM key, was getting cut at 255 characters with no warning. The field had HTML `maxLength={255}`, so the browser truncated the paste before validation ran.

255 is one TXT string on the wire, not the record. A 2048-bit DKIM key is usually around 400 characters. The field is now a textarea with no HTML cap. Values over 2,048 characters still fail validation with an error. Wrapped pastes from docs have their line breaks stripped so the stored value is a single string.