### PR TITLE
feat: Add staging AI assistant usage charges

### DIFF
--- a/config/components/service-catalog-staging/kustomization.yaml
+++ b/config/components/service-catalog-staging/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: service-configuration-charges.yaml
+    target:
+      group: services.miloapis.com
+      version: v1alpha1
+      kind: ServiceConfiguration
+      name: assistant-miloapis-com

--- a/config/components/service-catalog-staging/service-configuration-charges.yaml
+++ b/config/components/service-catalog-staging/service-configuration-charges.yaml
@@ -1,0 +1,54 @@
+# Staging pass-through for the portal assistant. Rates are Anthropic's
+# published list prices for claude-sonnet-4-6, the model staging runs:
+# $3 / $15 per million input / output tokens, cache reads at $0.30,
+# 5-minute cache writes at $3.75. The assistant uses ephemeral prompt
+# cache (5 minute TTL). Match on model so a later model switch does not
+# silently bill at these rates. Do not add an unmatched catch-all;
+# Amberflo cannot represent that beside matched rates. Messages stay
+# unpriced; Anthropic does not bill per message.
+apiVersion: services.miloapis.com/v1alpha1
+kind: ServiceConfiguration
+metadata:
+  name: assistant-miloapis-com
+spec:
+  charges:
+    - name: assistant.miloapis.com/conversation/input-tokens
+      chargeType: Usage
+      currency: USD
+      displayName: Input tokens
+      usage:
+        metricRef: assistant.miloapis.com/conversation/input-tokens
+        pricingUnit: token
+        rates:
+          - match: { dimension: model, value: claude-sonnet-4-6 }
+            flat: "0.000003"
+    - name: assistant.miloapis.com/conversation/output-tokens
+      chargeType: Usage
+      currency: USD
+      displayName: Output tokens
+      usage:
+        metricRef: assistant.miloapis.com/conversation/output-tokens
+        pricingUnit: token
+        rates:
+          - match: { dimension: model, value: claude-sonnet-4-6 }
+            flat: "0.000015"
+    - name: assistant.miloapis.com/conversation/cache-read-tokens
+      chargeType: Usage
+      currency: USD
+      displayName: Cached prompt tokens
+      usage:
+        metricRef: assistant.miloapis.com/conversation/cache-read-tokens
+        pricingUnit: token
+        rates:
+          - match: { dimension: model, value: claude-sonnet-4-6 }
+            flat: "0.0000003"
+    - name: assistant.miloapis.com/conversation/cache-write-tokens
+      chargeType: Usage
+      currency: USD
+      displayName: Prompt cache storage
+      usage:
+        metricRef: assistant.miloapis.com/conversation/cache-write-tokens
+        pricingUnit: token
+        rates:
+          - match: { dimension: model, value: claude-sonnet-4-6 }
+            flat: "0.00000375"


### PR DESCRIPTION
## Summary

Staging already meters portal assistant usage, but those meters have no rates, so nothing shows up as a priced product item. This adds a staging-only kustomize component that patches Anthropic's published `claude-sonnet-4-6` list prices onto the four token charges. That is the model the portal runs when `ANTHROPIC_MODEL` is unset.

Per-token rates:

- Input: `0.000003` ($3 / million)
- Output: `0.000015` ($15 / million)
- Cache read: `0.0000003` ($0.30 / million)
- 5-minute cache write: `0.00000375` ($3.75 / million), matching ephemeral prompt cache

Each rate matches `model=claude-sonnet-4-6`. There is no unmatched catch-all, because Amberflo cannot represent that beside matched rates. Messages stay unpriced; Anthropic does not bill per message.

Production bundles are unchanged. Infra still has to attach this component to the staging `cloud-portal-milo-services` Flux Kustomization.

`payg-v1` is already GA, so these ServicePricings will not join that Offer on their own. After ChargeFanOut runs, include them on a new Offer (or a draft that migrates from `payg-v1`).

## Test plan

- [ ] `kustomize build` of `config/services` plus this component shows the four charges
- [ ] After infra wires the component, staging `ServiceConfiguration/assistant-miloapis-com` has `spec.charges`
- [ ] ChargeFanOut creates the four `ServicePricing` objects
- [ ] Production assistant ServiceConfiguration still has no charges