### PR TITLE
fix(usage): hide gateway breakdown tabs on usage meters

### DIFF
--- a/app/modules/billing/usage.server.ts
+++ b/app/modules/billing/usage.server.ts
@@ -84,6 +84,8 @@ const MAX_BREAKDOWN_DIMENSIONS = 3;
 
 /** Platform dimension injected by the billing pipeline (not on MeterDefinition). */
 const PROJECT_BREAKDOWN_DIMENSION = 'project_name';
+/** Internal Gateway labels — not useful as consumer-facing usage breakdown tabs. */
+const HIDDEN_BREAKDOWN_DIMENSIONS = new Set(['gateway', 'gateway_namespace']);
 
 export async function listMeterDefinitions(): Promise<MeterDefinition[]> {
   try {
@@ -312,7 +314,9 @@ export async function fetchUsageForCustomerIds({
       };
 
       try {
-        const dims = (def.dimensions ?? []).slice(0, MAX_BREAKDOWN_DIMENSIONS);
+        const dims = (def.dimensions ?? [])
+          .filter((dimension) => !HIDDEN_BREAKDOWN_DIMENSIONS.has(dimension))
+          .slice(0, MAX_BREAKDOWN_DIMENSIONS);
         const [values, meterBreakdowns, projectBreakdown] = await Promise.all([
           fetchAggregateSeries(queryArgs),
           Promise.all(


### PR DESCRIPTION
## Summary
- Hide `gateway` and `gateway_namespace` breakdown tabs on usage meter cards — these internal labels are not useful for consumers

## Test plan
- [ ] Open org usage dashboard for an org with ALB/network usage
- [ ] Confirm Gateway and Gateway Namespace tabs are no longer shown on meter cards
- [ ] Confirm Region and Project Name breakdowns still work where present