### PR TITLE
feat(plugins): Let portal.nav/project declare Coming Soon

### DIFF
--- a/app/modules/plugins/client/plugin-nav.test.ts
+++ b/app/modules/plugins/client/plugin-nav.test.ts
@@ -1,0 +1,91 @@
+import { buildPluginNavItems } from './plugin-nav';
+import type { NavProjectProperties, PublicPlugin } from '@/modules/plugins/types';
+import { describe, expect, test } from 'bun:test';
+
+function pluginWithNav(slug: string, navProps: NavProjectProperties[]): PublicPlugin {
+  return {
+    slug,
+    displayName: slug,
+    devMode: true,
+    deprecated: false,
+    source: 'static',
+    manifest: {
+      name: `${slug}.example.com`,
+      version: '1.0.0',
+      remoteEntry: 'remoteEntry.js',
+      exposedModules: {},
+      extensions: navProps.map((properties) => ({
+        type: 'portal.nav/project' as const,
+        properties,
+      })),
+    },
+  };
+}
+
+describe('buildPluginNavItems', () => {
+  test('builds live plugin mount links', () => {
+    const items = buildPluginNavItems(
+      [
+        pluginWithNav('sample', [
+          { id: 'home', title: 'Sample', icon: 'puzzle', path: 'home', order: 10 },
+        ]),
+      ],
+      'proj-1'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      title: 'Sample',
+      type: 'link',
+      order: 10,
+    });
+    expect(items[0].href).toContain('/project/proj-1/services/sample/home');
+  });
+
+  test('builds Coming Soon items as external roadmap links', () => {
+    const roadmap = 'https://github.com/datum-cloud/enhancements/issues/1';
+    const items = buildPluginNavItems(
+      [
+        pluginWithNav('volumes', [
+          {
+            id: 'volumes',
+            title: 'Volumes',
+            icon: 'hard-drive',
+            path: '',
+            comingSoon: true,
+            roadmapUrl: roadmap,
+            order: 40,
+          },
+        ]),
+      ],
+      'proj-1'
+    );
+    expect(items).toEqual([
+      expect.objectContaining({
+        title: 'Volumes',
+        href: roadmap,
+        type: 'externalLink',
+        order: 40,
+      }),
+    ]);
+  });
+
+  test('ignores comingSoon without roadmapUrl (treats as live path)', () => {
+    const items = buildPluginNavItems(
+      [
+        pluginWithNav('sample', [
+          {
+            id: 'home',
+            title: 'Sample',
+            icon: 'puzzle',
+            path: 'home',
+            comingSoon: true,
+            order: 10,
+          },
+        ]),
+      ],
+      'proj-1'
+    );
+    expect(items[0].type).toBe('link');
+    expect(items[0].href).toContain('/services/sample/home');
+  });
+});

--- a/app/modules/plugins/client/plugin-nav.ts
+++ b/app/modules/plugins/client/plugin-nav.ts
@@ -6,9 +6,9 @@
  * after every built-in item.
  *
  * Icons resolve from a name (never plugin code), so the sidebar renders even if
- * a plugin's bundle is broken. Hrefs point at the plugin mount
- * (`/project/:projectId/services/<slug>/<navPath>`); navigating there loads the
- * plugin lazily under the catch-all route.
+ * a plugin's bundle is broken. Live hrefs point at the plugin mount
+ * (`/project/:projectId/services/<slug>/<navPath>`). Coming Soon items open
+ * `roadmapUrl` externally instead.
  */
 import { resolvePluginIcon } from './icon-map';
 import { getNavExtensions } from './match-extension';
@@ -32,13 +32,29 @@ function pluginHref(projectId: string, slug: string, navPath: string): string {
 /** Nav items contributed by a single plugin, carrying each extension's `order`
  * (missing `order` sorts last, alongside `getNavExtensions`' own default). */
 function navItemsForPlugin(plugin: PublicPlugin, projectId: string): OrderedNavItem[] {
-  return getNavExtensions(plugin.manifest).map((nav) => ({
-    title: nav.properties.title,
-    href: pluginHref(projectId, plugin.slug, nav.properties.path),
-    type: 'link',
-    icon: resolvePluginIcon(nav.properties.icon),
-    order: nav.properties.order ?? Number.MAX_SAFE_INTEGER,
-  }));
+  return getNavExtensions(plugin.manifest).map((nav) => {
+    const comingSoon = nav.properties.comingSoon === true && !!nav.properties.roadmapUrl;
+    const order = nav.properties.order ?? Number.MAX_SAFE_INTEGER;
+    const icon = resolvePluginIcon(nav.properties.icon);
+
+    if (comingSoon) {
+      return {
+        title: nav.properties.title,
+        href: nav.properties.roadmapUrl!,
+        type: 'externalLink' as const,
+        icon,
+        order,
+      };
+    }
+
+    return {
+      title: nav.properties.title,
+      href: pluginHref(projectId, plugin.slug, nav.properties.path),
+      type: 'link' as const,
+      icon,
+      order,
+    };
+  });
 }
 
 /** Flatten every ready plugin's nav extensions into a single ordered list, for

--- a/app/modules/plugins/manifest.schema.test.ts
+++ b/app/modules/plugins/manifest.schema.test.ts
@@ -121,6 +121,67 @@ describe('validateManifest', () => {
     expect(result.valid).toBe(false);
   });
 
+  test('accepts comingSoon nav with roadmapUrl and empty path', () => {
+    const result = validateManifest(
+      baseManifest({
+        extensions: [
+          {
+            type: 'portal.nav/project',
+            properties: {
+              id: 'volumes',
+              title: 'Volumes',
+              icon: 'hard-drive',
+              path: '',
+              comingSoon: true,
+              roadmapUrl: 'https://github.com/datum-cloud/enhancements/issues/1',
+              order: 40,
+            },
+          },
+        ],
+      })
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  test('rejects comingSoon nav without roadmapUrl', () => {
+    const result = validateManifest(
+      baseManifest({
+        extensions: [
+          {
+            type: 'portal.nav/project',
+            properties: {
+              id: 'volumes',
+              title: 'Volumes',
+              icon: 'hard-drive',
+              path: '',
+              comingSoon: true,
+            },
+          },
+        ],
+      })
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects live nav with empty path', () => {
+    const result = validateManifest(
+      baseManifest({
+        extensions: [
+          {
+            type: 'portal.nav/project',
+            properties: {
+              id: 'volumes',
+              title: 'Volumes',
+              icon: 'hard-drive',
+              path: '   ',
+            },
+          },
+        ],
+      })
+    );
+    expect(result.valid).toBe(false);
+  });
+
   test('rejects a non-object input', () => {
     expect(validateManifest(null).valid).toBe(false);
     expect(validateManifest('nope').valid).toBe(false);

--- a/app/modules/plugins/manifest.schema.ts
+++ b/app/modules/plugins/manifest.schema.ts
@@ -36,13 +36,35 @@ const codeRefSchema = z.object({
 
 const navProjectExtensionSchema = z.object({
   type: z.literal(EXTENSION_NAV_PROJECT),
-  properties: z.object({
-    id: z.string().min(1),
-    title: z.string().min(1),
-    icon: z.string().min(1),
-    path: z.string(),
-    order: z.number().optional(),
-  }),
+  properties: z
+    .object({
+      id: z.string().min(1),
+      title: z.string().min(1),
+      icon: z.string().min(1),
+      path: z.string(),
+      order: z.number().optional(),
+      comingSoon: z.boolean().optional(),
+      roadmapUrl: z.string().url().optional(),
+    })
+    .superRefine((props, ctx) => {
+      if (props.comingSoon) {
+        if (!props.roadmapUrl) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'roadmapUrl is required when comingSoon is true',
+            path: ['roadmapUrl'],
+          });
+        }
+        return;
+      }
+      if (!props.path.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'path is required when comingSoon is not true',
+          path: ['path'],
+        });
+      }
+    }),
   requirements: requirementsSchema,
 });
 

--- a/app/modules/plugins/types.ts
+++ b/app/modules/plugins/types.ts
@@ -134,9 +134,24 @@ export interface NavProjectProperties {
   title: string;
   /** A lucide icon name, resolved by the host. Never plugin code. */
   icon: string;
-  /** Path relative to the plugin's mount point. */
+  /**
+   * Path relative to the plugin's mount point. Required for live links;
+   * ignored (and may be empty) while `comingSoon` is true.
+   */
   path: string;
   order?: number;
+  /**
+   * When true, render a Coming Soon placeholder (external roadmap link)
+   * instead of a live plugin route. Lets a service register a PortalPlugin
+   * early and own its sidebar placeholder; go live by updating the manifest
+   * alone (drop comingSoon / roadmapUrl and set a real path).
+   */
+  comingSoon?: boolean;
+  /**
+   * External roadmap / enhancement URL used when `comingSoon` is true.
+   * Required whenever `comingSoon` is true.
+   */
+  roadmapUrl?: string;
 }
 
 export interface NavProjectExtension {
@@ -183,7 +198,9 @@ export interface UnknownExtension {
 }
 
 export type KnownPluginExtension =
-  NavProjectExtension | PageProjectExtension | CardProjectHomeExtension;
+  | NavProjectExtension
+  | PageProjectExtension
+  | CardProjectHomeExtension;
 
 export type PluginExtension = KnownPluginExtension | UnknownExtension;
 

--- a/app/modules/plugins/types.ts
+++ b/app/modules/plugins/types.ts
@@ -198,9 +198,7 @@ export interface UnknownExtension {
 }
 
 export type KnownPluginExtension =
-  | NavProjectExtension
-  | PageProjectExtension
-  | CardProjectHomeExtension;
+  NavProjectExtension | PageProjectExtension | CardProjectHomeExtension;
 
 export type PluginExtension = KnownPluginExtension | UnknownExtension;
 

--- a/docs/enhancements/portal-plugin-system.md
+++ b/docs/enhancements/portal-plugin-system.md
@@ -231,14 +231,15 @@ Contract rules:
 
 - **`$codeRef`** is a lazy reference into `exposedModules` (`"ModuleName"` or `"ModuleName.exportName"`); no plugin code loads until an extension actually renders.
 - **`icon` is a name, never code** — a lucide icon name resolved by the host. Navigation must render without executing plugin code, so a broken plugin can never take down the sidebar.
-- **`path` is relative to the plugin's mount point.** Plugins cannot address URL space outside `/project/:projectId/services/<slug>/`.
+- **`path` is relative to the plugin's mount point.** Plugins cannot address URL space outside `/project/:projectId/services/<slug>/`. Required for live nav; may be empty while `comingSoon` is true.
+- **`comingSoon` + `roadmapUrl`** — optional. When `comingSoon` is true, the host renders an external roadmap link instead of a plugin mount href. `roadmapUrl` is required in that case. Going live is a manifest-only change: drop `comingSoon` / `roadmapUrl` and set a real `path` (and matching `portal.page/project`).
 - **`requirements.permissions`** are `SelfSubjectAccessReview` checks against the current project's scoped control plane — the same fail-closed gate the portal's built-in pages use. All listed permissions must pass for the extension to appear.
 
 ### Extension points
 
-| Type                                | Status | Renders                                                          | Key properties                                              |
-| ----------------------------------- | ------ | ---------------------------------------------------------------- | ----------------------------------------------------------- |
-| `portal.nav/project`                | **v1** | Item in the project sidebar, grouped under a per-service section | `id`, `title`, `icon` (lucide name), `path`, `order`        |
+| Type                                | Status | Renders                                                          | Key properties                                                                                      |
+| ----------------------------------- | ------ | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `portal.nav/project`                | **v1** | Item in the project sidebar, grouped under a per-service section | `id`, `title`, `icon` (lucide name), `path`, `order`, optional `comingSoon` + `roadmapUrl`        |
 | `portal.page/project`               | **v1** | Routed page under `/project/:projectId/services/<slug>/<path>`   | `path` (supports params and nesting), `component: $codeRef` |
 | `portal.card/project-home`          | **v1** | Card on the project home page                                    | `title`, `component: $codeRef`, `order`                     |
 | `portal.nav/org`, `portal.page/org` | v1.x   | Org-scoped nav and pages                                         | same shapes, org-scoped RBAC                                |

--- a/examples/sample-plugin/README.md
+++ b/examples/sample-plugin/README.md
@@ -9,8 +9,10 @@ fixture for the portal repo.
 
 **Nav + pages:**
 
-- `portal.nav/project` — two sidebar items: **Platform data** (icon `globe`,
-  RBAC-gated) and **Sample Plugin** (icon `puzzle`, the minimal demo).
+- `portal.nav/project` — three sidebar items: **Platform data** (icon `globe`,
+  RBAC-gated), **Sample Plugin** (icon `puzzle`, the minimal demo), and
+  **Volumes** as a Coming Soon external roadmap link (`comingSoon` +
+  `roadmapUrl`, empty `path`).
 - `portal.page/project`:
   - `platform` — read-only **DNS zones** for the current project, read from the
     **Milo control plane** through `/api/proxy`. Carries

--- a/examples/sample-plugin/public/plugin-manifest.json
+++ b/examples/sample-plugin/public/plugin-manifest.json
@@ -39,6 +39,18 @@
       }
     },
     {
+      "type": "portal.nav/project",
+      "properties": {
+        "id": "sample-volumes-soon",
+        "title": "Volumes",
+        "icon": "hard-drive",
+        "path": "",
+        "order": 60,
+        "comingSoon": true,
+        "roadmapUrl": "https://github.com/datum-cloud/enhancements/issues/849"
+      }
+    },
+    {
       "type": "portal.page/project",
       "properties": {
         "path": "platform",


### PR DESCRIPTION
## Summary

Service teams should be able to put a Coming Soon item in the project sidebar without a portal host PR, then go live by updating the plugin manifest alone.

This extends `portal.nav/project` with optional `comingSoon` + `roadmapUrl`. When Coming Soon, the host renders an external roadmap link instead of a plugin mount href. Schema requires `roadmapUrl` when Coming Soon, and a non-empty `path` for live nav.

Key behaviors:

- Coming Soon nav opens `roadmapUrl` as `externalLink`
- Live nav still mounts under `/project/:id/services/<slug>/…`
- Sample plugin includes a Volumes Coming Soon example

Out of scope: category IA / nested menus (stays on `feat/nav-nested-menus`).

## Test plan

- [x] `bun test app/modules/plugins/manifest.schema.test.ts app/modules/plugins/client/plugin-nav.test.ts`
- [ ] Load sample plugin locally and confirm Volumes opens the roadmap URL
- [ ] Confirm live Sample Plugin / Platform data links still mount correctly